### PR TITLE
All settings

### DIFF
--- a/MeshhessenClient/MainWindow.xaml
+++ b/MeshhessenClient/MainWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="MeshhessenClient.MainWindow"
+﻿<Window x:Class="MeshhessenClient.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="http://schemas.modernwpf.com/2019"
@@ -1000,6 +1000,122 @@
                 </Grid>
             </TabItem>
 
+            <!-- Karte Tab -->
+            <TabItem Header="{DynamicResource StrTabMap}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Grid Grid.Row="0" Margin="10,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal">
+                            <Button Content="+" Width="32" Height="32" Margin="0,0,4,0"
+                                    Click="MapZoomIn_Click" ToolTip="Zoom In"/>
+                            <Button Content="-" Width="32" Height="32" Margin="0,0,10,0"
+                                    Click="MapZoomOut_Click" ToolTip="Zoom Out"/>
+                            <Button Content="{DynamicResource StrLoadTraceroute}" Height="28" Margin="0,0,6,0"
+                                    Padding="8,2"
+                                    Click="MapLoadTraceroute_Click"
+                                    ToolTip="{DynamicResource StrLoadTracerouteTooltip}"/>
+                            <ComboBox x:Name="TracerouteAgeFilterCombo" Height="28" Width="70"
+                                      Margin="0,0,4,0" ToolTip="{DynamicResource StrTracerouteDbTimeTooltip}">
+                                <ComboBoxItem Content="3d"  Tag="3"   />
+                                <ComboBoxItem Content="7d"  Tag="7"   IsSelected="True"/>
+                                <ComboBoxItem Content="14d" Tag="14"  />
+                                <ComboBoxItem Content="30d" Tag="30"  />
+                                <ComboBoxItem Content="90d" Tag="90"  />
+                                <ComboBoxItem Content="{DynamicResource StrAllTimeRange}" Tag="0"  />
+                            </ComboBox>
+                            <Button Content="{DynamicResource StrLoadFromDb}" Height="28" Padding="8,2" Margin="0,0,6,0"
+                                    Click="MapLoadTracerouteFromDb_Click"
+                                    ToolTip="{DynamicResource StrLoadFromDbTooltip}"/>
+                            <CheckBox x:Name="TracerouteDedupeCheckBox" VerticalAlignment="Center"
+                                      IsChecked="True" Margin="0,0,6,0"
+                                      ToolTip="{DynamicResource StrDedupeTooltip}">
+                                <TextBlock Text="Dedupe" FontSize="11"/>
+                            </CheckBox>
+                            <Button Content="{DynamicResource StrRemoveAllTraceroutes}" Height="28" Padding="8,2" Margin="0,0,0,0"
+                                    Click="ClearAllTraceroutes_Click"
+                                    ToolTip="{DynamicResource StrRemoveAllTooltip}"/>
+                        </StackPanel>
+                        <TextBlock x:Name="MapStatusText" Grid.Column="1" VerticalAlignment="Center" Foreground="Gray" FontStyle="Italic"/>
+                    </Grid>
+                    <Grid Grid.Row="1">
+                        <mapsui:MapControl x:Name="MapControl"/>
+
+                        <!-- Traceroute Legend (top-left overlay) -->
+                        <Border x:Name="TracerouteLegend"
+                                HorizontalAlignment="Left" VerticalAlignment="Top"
+                                Margin="8,8,0,0"
+                                Background="#CC1E1E1E"
+                                BorderBrush="#44FFFFFF"
+                                BorderThickness="1"
+                                CornerRadius="5"
+                                Padding="8,6"
+                                Visibility="Collapsed">
+                            <StackPanel>
+                                <TextBlock Text="📡 Traceroutes" FontSize="11" FontWeight="SemiBold"
+                                           Foreground="#BBDDDDDD" Margin="0,0,0,4"/>
+                                <ItemsControl x:Name="TracerouteLegendItems"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Map Line Types Legend (top-right overlay) -->
+                    <Border x:Name="MapLegendBorder" HorizontalAlignment="Right" VerticalAlignment="Top"
+                            Margin="0,8,8,0" Padding="8,6" CornerRadius="6"
+                            Background="#CC000000" BorderBrush="#44FFFFFF" BorderThickness="1"
+                            Panel.ZIndex="10">
+                        <StackPanel>
+                            <DockPanel>
+                                <Button DockPanel.Dock="Right" Content="✕" Width="18" Height="18"
+                                        Padding="0" FontSize="10" Margin="6,0,0,0"
+                                        Click="MapLegendClose_Click"/>
+                                <TextBlock Text="{DynamicResource StrLegendTitle}"
+                                           FontWeight="Bold" Foreground="White" FontSize="11"/>
+                            </DockPanel>
+                            <!-- Normal hop line: solid gray -->
+                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                <Line X1="0" Y1="5" X2="30" Y2="5" Stroke="Gray" StrokeThickness="2" Width="30" Height="10"/>
+                                <TextBlock Text="{DynamicResource StrLegendNormalHop}" Foreground="White" FontSize="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- MQTT dashed: yellow -->
+                            <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                <Line X1="0" Y1="5" X2="30" Y2="5" Stroke="Yellow" StrokeThickness="2"
+                                      StrokeDashArray="3,2" Width="30" Height="10"/>
+                                <TextBlock Text="{DynamicResource StrLegendMqttHop}" Foreground="White" FontSize="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Unknown dashed: dashed gray -->
+                            <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                <Line X1="0" Y1="5" X2="30" Y2="5" Stroke="Gray" StrokeThickness="2"
+                                      StrokeDashArray="4,3" Width="30" Height="10"/>
+                                <TextBlock Text="{DynamicResource StrLegendUnknownHop}" Foreground="White" FontSize="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- SNR click hint -->
+                            <TextBlock Text="{DynamicResource StrLegendSnrHint}" Foreground="#AAAAAA" FontSize="9"
+                                       Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="160"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Copyright Hinweis rechts unten -->
+                        <TextBlock x:Name="MapCopyrightText"
+                                   HorizontalAlignment="Right"
+                                   VerticalAlignment="Bottom"
+                                   Margin="0,0,8,4"
+                                   FontSize="10"
+                                   Foreground="Gray"
+                                   Background="#99FFFFFF"
+                                   Padding="4,2"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="400"
+                                   Text="© OpenStreetMap contributors"/>
+                    </Grid>
+                </Grid>
+            </TabItem>
+
             <!-- Settings Tab -->
             <TabItem Header="{DynamicResource StrTabSettings}">
                 <Grid>
@@ -1353,122 +1469,6 @@
                             </StackPanel>
                         </ScrollViewer>
                     </Border>
-                </Grid>
-            </TabItem>
-
-            <!-- Karte Tab -->
-            <TabItem Header="{DynamicResource StrTabMap}">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <Grid Grid.Row="0" Margin="10,5">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <StackPanel Grid.Column="0" Orientation="Horizontal">
-                            <Button Content="+" Width="32" Height="32" Margin="0,0,4,0"
-                                    Click="MapZoomIn_Click" ToolTip="Zoom In"/>
-                            <Button Content="-" Width="32" Height="32" Margin="0,0,10,0"
-                                    Click="MapZoomOut_Click" ToolTip="Zoom Out"/>
-                            <Button Content="{DynamicResource StrLoadTraceroute}" Height="28" Margin="0,0,6,0"
-                                    Padding="8,2"
-                                    Click="MapLoadTraceroute_Click"
-                                    ToolTip="{DynamicResource StrLoadTracerouteTooltip}"/>
-                            <ComboBox x:Name="TracerouteAgeFilterCombo" Height="28" Width="70"
-                                      Margin="0,0,4,0" ToolTip="{DynamicResource StrTracerouteDbTimeTooltip}">
-                                <ComboBoxItem Content="3d"  Tag="3"   />
-                                <ComboBoxItem Content="7d"  Tag="7"   IsSelected="True"/>
-                                <ComboBoxItem Content="14d" Tag="14"  />
-                                <ComboBoxItem Content="30d" Tag="30"  />
-                                <ComboBoxItem Content="90d" Tag="90"  />
-                                <ComboBoxItem Content="{DynamicResource StrAllTimeRange}" Tag="0"  />
-                            </ComboBox>
-                            <Button Content="{DynamicResource StrLoadFromDb}" Height="28" Padding="8,2" Margin="0,0,6,0"
-                                    Click="MapLoadTracerouteFromDb_Click"
-                                    ToolTip="{DynamicResource StrLoadFromDbTooltip}"/>
-                            <CheckBox x:Name="TracerouteDedupeCheckBox" VerticalAlignment="Center"
-                                      IsChecked="True" Margin="0,0,6,0"
-                                      ToolTip="{DynamicResource StrDedupeTooltip}">
-                                <TextBlock Text="Dedupe" FontSize="11"/>
-                            </CheckBox>
-                            <Button Content="{DynamicResource StrRemoveAllTraceroutes}" Height="28" Padding="8,2" Margin="0,0,0,0"
-                                    Click="ClearAllTraceroutes_Click"
-                                    ToolTip="{DynamicResource StrRemoveAllTooltip}"/>
-                        </StackPanel>
-                        <TextBlock x:Name="MapStatusText" Grid.Column="1" VerticalAlignment="Center" Foreground="Gray" FontStyle="Italic"/>
-                    </Grid>
-                    <Grid Grid.Row="1">
-                        <mapsui:MapControl x:Name="MapControl"/>
-
-                        <!-- Traceroute Legend (top-left overlay) -->
-                        <Border x:Name="TracerouteLegend"
-                                HorizontalAlignment="Left" VerticalAlignment="Top"
-                                Margin="8,8,0,0"
-                                Background="#CC1E1E1E"
-                                BorderBrush="#44FFFFFF"
-                                BorderThickness="1"
-                                CornerRadius="5"
-                                Padding="8,6"
-                                Visibility="Collapsed">
-                            <StackPanel>
-                                <TextBlock Text="📡 Traceroutes" FontSize="11" FontWeight="SemiBold"
-                                           Foreground="#BBDDDDDD" Margin="0,0,0,4"/>
-                                <ItemsControl x:Name="TracerouteLegendItems"/>
-                            </StackPanel>
-                        </Border>
-
-                        <!-- Map Line Types Legend (top-right overlay) -->
-                    <Border x:Name="MapLegendBorder" HorizontalAlignment="Right" VerticalAlignment="Top"
-                            Margin="0,8,8,0" Padding="8,6" CornerRadius="6"
-                            Background="#CC000000" BorderBrush="#44FFFFFF" BorderThickness="1"
-                            Panel.ZIndex="10">
-                        <StackPanel>
-                            <DockPanel>
-                                <Button DockPanel.Dock="Right" Content="✕" Width="18" Height="18"
-                                        Padding="0" FontSize="10" Margin="6,0,0,0"
-                                        Click="MapLegendClose_Click"/>
-                                <TextBlock Text="{DynamicResource StrLegendTitle}"
-                                           FontWeight="Bold" Foreground="White" FontSize="11"/>
-                            </DockPanel>
-                            <!-- Normal hop line: solid gray -->
-                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                                <Line X1="0" Y1="5" X2="30" Y2="5" Stroke="Gray" StrokeThickness="2" Width="30" Height="10"/>
-                                <TextBlock Text="{DynamicResource StrLegendNormalHop}" Foreground="White" FontSize="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                            </StackPanel>
-                            <!-- MQTT dashed: yellow -->
-                            <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                <Line X1="0" Y1="5" X2="30" Y2="5" Stroke="Yellow" StrokeThickness="2"
-                                      StrokeDashArray="3,2" Width="30" Height="10"/>
-                                <TextBlock Text="{DynamicResource StrLegendMqttHop}" Foreground="White" FontSize="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                            </StackPanel>
-                            <!-- Unknown dashed: dashed gray -->
-                            <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                                <Line X1="0" Y1="5" X2="30" Y2="5" Stroke="Gray" StrokeThickness="2"
-                                      StrokeDashArray="4,3" Width="30" Height="10"/>
-                                <TextBlock Text="{DynamicResource StrLegendUnknownHop}" Foreground="White" FontSize="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
-                            </StackPanel>
-                            <!-- SNR click hint -->
-                            <TextBlock Text="{DynamicResource StrLegendSnrHint}" Foreground="#AAAAAA" FontSize="9"
-                                       Margin="0,4,0,0" TextWrapping="Wrap" MaxWidth="160"/>
-                        </StackPanel>
-                    </Border>
-
-                    <!-- Copyright Hinweis rechts unten -->
-                        <TextBlock x:Name="MapCopyrightText"
-                                   HorizontalAlignment="Right"
-                                   VerticalAlignment="Bottom"
-                                   Margin="0,0,8,4"
-                                   FontSize="10"
-                                   Foreground="Gray"
-                                   Background="#99FFFFFF"
-                                   Padding="4,2"
-                                   TextWrapping="Wrap"
-                                   MaxWidth="400"
-                                   Text="© OpenStreetMap contributors"/>
-                    </Grid>
                 </Grid>
             </TabItem>
 

--- a/MeshhessenClient/MainWindow.xaml
+++ b/MeshhessenClient/MainWindow.xaml
@@ -351,7 +351,8 @@
                                  SelectionChanged="MessageChannelFilter_Changed"
                                  DisplayMemberPath="Name"/>
                         <Image x:Name="mh_logo_wide_top" Grid.Column="2" Height="56" Width="286"
-                               Source="/logo_mh_wide.jpg" HorizontalAlignment="Right"/>
+                               Source="/logo_mh_wide.jpg" HorizontalAlignment="Right"
+                               Cursor="Arrow" MouseLeftButtonUp="Logo_Click"/>
                     </Grid>
 
                     <!-- Message List – Chat Bubble Layout -->

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -1978,7 +1978,10 @@ public partial class MainWindow : Window
 
     private int FindFirstFreeChannelIndex()
     {
-        var usedIndices = _channels.Select(c => c.Index).ToHashSet();
+        var usedIndices = _channels
+            .Where(c => !c.Role.Equals("DISABLED", StringComparison.OrdinalIgnoreCase))
+            .Select(c => c.Index)
+            .ToHashSet();
         for (int i = 1; i < 8; i++)
         {
             if (!usedIndices.Contains(i))
@@ -2515,9 +2518,12 @@ public partial class MainWindow : Window
             {
                 var existing = _channels.FirstOrDefault(c => c.Index == channel.Index);
                 if (existing != null)
-                {
                     _channels.Remove(existing);
-                }
+
+                // Disabled-Kanäle nicht in die Liste aufnehmen
+                if (channel.Role.Equals("DISABLED", StringComparison.OrdinalIgnoreCase))
+                    return;
+
                 // Sortiert einfügen nach Channel-Index
                 int insertAt = 0;
                 for (int i = 0; i < _channels.Count; i++)
@@ -3900,7 +3906,7 @@ public partial class MainWindow : Window
     {
         try
         {
-            var win = new NodeConfigWindow(_protocolService) { Owner = this };
+            var win = new NodeConfigWindow(_protocolService, GetMapCenter) { Owner = this };
             win.Show();
         }
         catch (Exception ex)
@@ -3908,6 +3914,18 @@ public partial class MainWindow : Window
             Services.Logger.WriteLine($"ERROR opening NodeConfigWindow: {ex.Message}");
             MessageBox.Show($"Fehler beim Öffnen der Node-Konfiguration: {ex.Message}", "Fehler", MessageBoxButton.OK, MessageBoxImage.Error);
         }
+    }
+
+    private (double lat, double lon)? GetMapCenter()
+    {
+        try
+        {
+            if (MapControl?.Map == null) return null;
+            var vp = MapControl.Map.Navigator.Viewport;
+            var (lon, lat) = Mapsui.Projections.SphericalMercator.ToLonLat(vp.CenterX, vp.CenterY);
+            return (lat, lon);
+        }
+        catch { return null; }
     }
 
     // ========== Node Pinning ==========

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -782,6 +782,15 @@ public partial class MainWindow : Window
                         OpenTracerouteForNode(_mapContextMenuNode);
                 };
                 menu.Items.Add(traceItem);
+
+                // Telemetry
+                var telItem = new MenuItem { Header = Loc("StrTelemetry") };
+                telItem.Click += (s, ev) =>
+                {
+                    if (_mapContextMenuNode != null)
+                        OpenTelemetryForNode(_mapContextMenuNode);
+                };
+                menu.Items.Add(telItem);
             }
             else if (hitWaypoint != null)
             {
@@ -1198,32 +1207,7 @@ public partial class MainWindow : Window
         e.Handled = true;
     }
 
-    private class LocalFileTileProvider : ITileProvider
-    {
-        private readonly string _baseDir;
-        private readonly string _sourceFolder;
-
-        public LocalFileTileProvider(string baseDir, string sourceFolder)
-        {
-            _baseDir = baseDir;
-            _sourceFolder = sourceFolder;
-        }
-
-        public Task<byte[]?> GetTileAsync(TileInfo tileInfo)
-        {
-            var z = tileInfo.Index.Level;
-            var x = tileInfo.Index.Col;
-            // BruTile TMS hat Row 0 im Süden, OSM-Dateien haben Y=0 im Norden → konvertieren
-            var yOsm = (1 << z) - 1 - tileInfo.Index.Row;
-            // Neuer Pfad: maptiles/{source}/{z}/{x}/{y}.png
-            var path = Path.Combine(_baseDir, _sourceFolder, z.ToString(), x.ToString(), $"{yOsm}.png");
-            if (File.Exists(path))
-            {
-                try { return Task.FromResult<byte[]?>(File.ReadAllBytes(path)); } catch { }
-            }
-            return Task.FromResult<byte[]?>(null);
-        }
-    }
+    // LocalFileTileProvider moved to Services/LocalFileTileProvider.cs
 
     #endregion
 
@@ -3914,7 +3898,7 @@ public partial class MainWindow : Window
     {
         try
         {
-            var win = new NodeConfigWindow(_protocolService, GetMapCenter) { Owner = this };
+            var win = new NodeConfigWindow(_protocolService, GetMapCenter, GetMyPosition, BuildTileLayer) { Owner = this };
             win.Show();
         }
         catch (Exception ex)
@@ -3934,6 +3918,29 @@ public partial class MainWindow : Window
             return (lat, lon);
         }
         catch { return null; }
+    }
+
+    private (double lat, double lon)? GetMyPosition()
+    {
+        if (_currentSettings.MyLatitude != 0 || _currentSettings.MyLongitude != 0)
+            return (_currentSettings.MyLatitude, _currentSettings.MyLongitude);
+        return null;
+    }
+
+    private Mapsui.Tiling.Layers.TileLayer BuildTileLayer()
+    {
+        var tileDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "maptiles");
+        var sourceFolder = _currentSettings.MapSource;
+        var schema = new BruTile.Predefined.GlobalSphericalMercator(BruTile.YAxis.TMS, 0, 18, "OSM");
+        BruTile.ITileProvider tileProvider = _currentSettings.MapMode switch
+        {
+            "online-osm" => new Services.CachingHttpTileProvider(tileDir, "osm_online",
+                "https://tile.openstreetmap.org/{z}/{x}/{y}.png", useHttpCacheHeaders: true),
+            "online-own" => new Services.CachingHttpTileProvider(tileDir, sourceFolder,
+                GetUrlForSource(sourceFolder), useHttpCacheHeaders: false),
+            _ => new Services.LocalFileTileProvider(tileDir, sourceFolder)
+        };
+        return new Mapsui.Tiling.Layers.TileLayer(new BruTile.TileSource(tileProvider, schema)) { Name = "OSM" };
     }
 
     // ========== Node Pinning ==========
@@ -5165,10 +5172,9 @@ public partial class MainWindow : Window
         ToolTipService.SetToolTip(led, tooltip);
     }
 
-    private void NodeContextMenu_Telemetry_Click(object sender, RoutedEventArgs e)
+    private void OpenTelemetryForNode(NodeInfo node)
     {
-        if (NodesListView.SelectedItem is not NodeInfo node || _db == null) return;
-
+        if (_db == null) return;
         var nodeNames = _allNodes.ToDictionary(n => n.NodeId, n => n.Name);
         var win = new TelemetryWindow(node, _db, nodeNames, _currentSettings.MyLatitude, _currentSettings.MyLongitude,
             _currentSettings.SignalWeatherWindowHours, _currentSettings.SignalAntennaWindowDays)
@@ -5176,6 +5182,12 @@ public partial class MainWindow : Window
             Owner = this
         };
         win.Show();
+    }
+
+    private void NodeContextMenu_Telemetry_Click(object sender, RoutedEventArgs e)
+    {
+        if (NodesListView.SelectedItem is not NodeInfo node) return;
+        OpenTelemetryForNode(node);
     }
 
     // Context menu handlers for traceroute
@@ -5457,11 +5469,11 @@ public partial class MainWindow : Window
     private static void BeepMorse(string text)
     {
         const int Freq      = 700;
-        const int Dot       = 80;
-        const int Dash      = 240;
-        const int ElemGap   = 80;
-        const int LetterGap = 240;
-        const int WordGap   = 560;
+        const int Dot       = 50;
+        const int Dash      = 150;
+        const int ElemGap   = 50;
+        const int LetterGap = 150;
+        const int WordGap   = 350;
 
         var table = new Dictionary<char, string>
         {

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using BruTile.Predefined;
 using NetTopologySuite.Geometries;
 using Mapsui.Nts;
 using LoRaConfig = Meshtastic.Protobufs.LoRaConfig;
+using MQTTConfig = Meshtastic.Protobufs.MQTTConfig;
 
 namespace MeshhessenClient;
 
@@ -152,6 +153,9 @@ public partial class MainWindow : Window
     // Node Public Key CSV
     private NodeKeyService? _nodeKeyService;
 
+    // MQTT Proxy
+    private MqttProxyService? _mqttProxyService;
+
     // Reconnect state
     private ConnectionParameters? _lastConnectionParams;
     private Services.ConnectionType _lastConnectionType;
@@ -194,6 +198,10 @@ public partial class MainWindow : Window
         _protocolService.TimeDriftDetected += OnTimeDriftDetected;
         _protocolService.WaypointReceived  += OnWaypointReceived;
         _protocolService.WaypointDeleted   += (s, id) => Dispatcher.Invoke(() => OnWaypointDeleted(id));
+        _protocolService.MqttConfigReceived += OnMqttConfigReceived;
+
+        _mqttProxyService = new MqttProxyService(_protocolService);
+        _mqttProxyService.StatusChanged += (s, msg) => Dispatcher.Invoke(() => UpdateStatusBar(msg));
 
         // LoadRegions / LoadModemPresets removed — now displayed as read-only TextBlocks in Settings right column
 
@@ -1528,10 +1536,16 @@ public partial class MainWindow : Window
                 _protocolService.TracerouteReceived += OnTracerouteReceived;
                 _protocolService.ReactionReceived += OnReactionReceived;
                 _protocolService.DeviceTelemetryReceived += OnDeviceTelemetryReceived;
+                _protocolService.MqttConfigReceived += OnMqttConfigReceived;
                 if (_db != null) _protocolService.SetDatabase(_db);
                 if (_nodeKeyService != null) _protocolService.SetNodeKeyService(_nodeKeyService);
                 _protocolService.SetPskMismatchAction(_currentSettings.NodeKeyMismatchAction);
                 _dmWindow?.UpdateProtocolService(_protocolService);
+
+                // Recreate proxy with new protocol service
+                _mqttProxyService?.Dispose();
+                _mqttProxyService = new MqttProxyService(_protocolService);
+                _mqttProxyService.StatusChanged += (s, msg) => Dispatcher.Invoke(() => UpdateStatusBar(msg));
 
                 // Wire up connection state changed
                 _connectionService.ConnectionStateChanged += OnConnectionStateChanged;
@@ -2093,6 +2107,10 @@ public partial class MainWindow : Window
                 // Only handle disconnection here - connection status is managed by Connect_Click
                 if (!isConnected)
                 {
+                    // Stop MQTT proxy on disconnect
+                    if (_mqttProxyService != null)
+                        _ = _mqttProxyService.StopAsync();
+
                     // Stop analysis timer on disconnect
                     _analysisTimer?.Dispose();
                     _analysisTimer = null;
@@ -2183,9 +2201,16 @@ public partial class MainWindow : Window
                 _protocolService.TracerouteReceived += OnTracerouteReceived;
                 _protocolService.ReactionReceived += OnReactionReceived;
                 _protocolService.DeviceTelemetryReceived += OnDeviceTelemetryReceived;
+                _protocolService.MqttConfigReceived += OnMqttConfigReceived;
                 if (_db != null) _protocolService.SetDatabase(_db);
                 if (_nodeKeyService != null) _protocolService.SetNodeKeyService(_nodeKeyService);
                 _protocolService.SetPskMismatchAction(_currentSettings.NodeKeyMismatchAction);
+
+                // Recreate proxy with new protocol service
+                _mqttProxyService?.Dispose();
+                _mqttProxyService = new MqttProxyService(_protocolService);
+                _mqttProxyService.StatusChanged += (s, msg) => Dispatcher.Invoke(() => UpdateStatusBar(msg));
+
                 _connectionService.ConnectionStateChanged += OnConnectionStateChanged;
 
                 await _connectionService.ConnectAsync(_lastConnectionParams!);
@@ -2617,6 +2642,15 @@ public partial class MainWindow : Window
                 Services.Logger.WriteLine($"ERROR updating LoRa config in UI: {ex.Message}");
             }
         });
+    }
+
+    private void OnMqttConfigReceived(object? sender, MQTTConfig mqttConfig)
+    {
+        if (_mqttProxyService == null) return;
+        if (!mqttConfig.Enabled || !mqttConfig.ProxyToClientEnabled) return;
+
+        Services.Logger.WriteLine($"OnMqttConfigReceived: proxy={mqttConfig.ProxyToClientEnabled}, broker={mqttConfig.Address}");
+        _ = _mqttProxyService.StartAsync(mqttConfig, _myNodeId);
     }
 
     private void OnPacketCountChanged(object? sender, int count)

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -162,6 +162,12 @@ public partial class MainWindow : Window
     private bool _intentionalDisconnect = false;
     private bool _isReconnecting = false;
 
+    // Easter Eggs
+    private System.Threading.Timer? _midnightTimer;
+    private bool _midnightFiredToday = false;
+    private int _logoClickCount = 0;
+    private DateTime _lastLogoClick = DateTime.MinValue;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -174,6 +180,8 @@ public partial class MainWindow : Window
         FooterVersionText.Text = versionStr;
 
         Loaded += (_, _) => _ = CheckForUpdateAsync();
+        _midnightTimer = new System.Threading.Timer(_ => CheckMidnight(), null,
+            TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
 
         // Initialize with Serial connection (default)
         _connectionService = new SerialConnectionService();
@@ -5374,5 +5382,153 @@ public partial class MainWindow : Window
     {
         _replyToMessage = null;
         ReplyIndicatorPanel.Visibility = Visibility.Collapsed;
+    }
+
+    // ═══════════════════════════════════════════
+    // Easter Eggs
+    // ═══════════════════════════════════════════
+
+    private void CheckMidnight()
+    {
+        var now = DateTime.Now;
+        if (now.Hour == 0 && now.Minute == 0 && !_midnightFiredToday)
+        {
+            _midnightFiredToday = true;
+            Dispatcher.BeginInvoke(ShowMidnightMesh);
+        }
+        else if (now.Hour != 0)
+        {
+            _midnightFiredToday = false;
+        }
+    }
+
+    private void ShowMidnightMesh()
+    {
+        var myShortName = _allNodes.FirstOrDefault(n => n.NodeId == _myNodeId)?.ShortName
+                          ?? "MH";
+
+        var lines = new[]
+        {
+            "- - - - - - - - - - - - - - - - - - - -",
+            $"SENDESTELLE {myShortName.ToUpper()}",
+            "SENDELEISTUNG WIRD JETZT REDUZIERT",
+            "NACHT-BETRIEB AKTIV — 73 DE MH",
+            "- - - - - - - - - - - - - - - - - - - -"
+        };
+        var msg = new MessageItem
+        {
+            Time        = "00:00",
+            From        = "⚡ SENDESTELLE",
+            Message     = string.Join("\n", lines),
+            ChannelName = "SYSTEM",
+            IsOwnMessage = false
+        };
+        _allMessages.Add(msg);
+        _messages.Add(msg);
+
+        // Scroll to bottom
+        if (MessageListView.Items.Count > 0)
+            MessageListView.ScrollIntoView(MessageListView.Items[^1]);
+    }
+
+    private void Logo_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
+    {
+        var now = DateTime.Now;
+        if ((now - _lastLogoClick).TotalSeconds > 3)
+            _logoClickCount = 0;
+        _lastLogoClick = now;
+        _logoClickCount++;
+
+        if (_logoClickCount >= 5)
+        {
+            _logoClickCount = 0;
+            ShowLogoEasterEgg();
+        }
+    }
+
+    private void ShowLogoEasterEgg()
+    {
+        var myShortName = _allNodes.FirstOrDefault(n => n.NodeId == _myNodeId)?.ShortName ?? "MH";
+        // Classic ham radio CQ call: CQ CQ CQ DE [CALLSIGN] MESHHESSEN QTH HESSEN 73 SK
+        var cwText = $"CQ DE {myShortName.ToUpper()} MESHHESSEN 73 SK";
+        Task.Run(() => BeepMorse(cwText));
+    }
+
+    private static void BeepMorse(string text)
+    {
+        const int Freq      = 700;
+        const int Dot       = 80;
+        const int Dash      = 240;
+        const int ElemGap   = 80;
+        const int LetterGap = 240;
+        const int WordGap   = 560;
+
+        var table = new Dictionary<char, string>
+        {
+            {'A',".-"},  {'B',"-..."}, {'C',"-.-."}, {'D',"-.."}, {'E',"."},
+            {'F',"..-."}, {'G',"--."}, {'H',"...."}, {'I',".."}, {'J',".---"},
+            {'K',"-.-"}, {'L',".-.."}, {'M',"--"},  {'N',"-."},  {'O',"---"},
+            {'P',".--."}, {'Q',"--.-"}, {'R',".-."}, {'S',"..."}, {'T',"-"},
+            {'U',"..-"}, {'V',"...-"}, {'W',".--"}, {'X',"-..-"}, {'Y',"-.--"},
+            {'Z',"--.."},
+            {'0',"-----"}, {'1',".----"}, {'2',"..---"}, {'3',"...--"},
+            {'4',"....-"}, {'5',"....."}, {'6',"-...."}, {'7',"--..."},
+            {'8',"---.."}, {'9',"----."}
+        };
+
+        bool firstLetter = true;
+        foreach (char c in text)
+        {
+            if (c == ' ') { System.Threading.Thread.Sleep(WordGap); firstLetter = true; continue; }
+            if (!table.TryGetValue(c, out var code)) continue;
+
+            if (!firstLetter) System.Threading.Thread.Sleep(LetterGap);
+            firstLetter = false;
+
+            bool firstElem = true;
+            foreach (char sym in code)
+            {
+                if (!firstElem) System.Threading.Thread.Sleep(ElemGap);
+                firstElem = false;
+                PlaySineTone(Freq, sym == '.' ? Dot : Dash);
+            }
+        }
+    }
+
+    private static void PlaySineTone(int freqHz, int durationMs)
+    {
+        const int SampleRate = 44100;
+        const int FadeMs     = 8; // Fade-in/out in ms — eliminiert Knackgeräusche
+        int totalSamples = SampleRate * durationMs / 1000;
+        int fadeSamples  = SampleRate * FadeMs / 1000;
+
+        using var ms = new System.IO.MemoryStream();
+        using var bw = new System.IO.BinaryWriter(ms);
+
+        // WAV-Header (PCM, Mono, 16-bit)
+        bw.Write(System.Text.Encoding.ASCII.GetBytes("RIFF"));
+        bw.Write(36 + totalSamples * 2);
+        bw.Write(System.Text.Encoding.ASCII.GetBytes("WAVE"));
+        bw.Write(System.Text.Encoding.ASCII.GetBytes("fmt "));
+        bw.Write(16); bw.Write((short)1); bw.Write((short)1);
+        bw.Write(SampleRate); bw.Write(SampleRate * 2);
+        bw.Write((short)2); bw.Write((short)16);
+        bw.Write(System.Text.Encoding.ASCII.GetBytes("data"));
+        bw.Write(totalSamples * 2);
+
+        for (int i = 0; i < totalSamples; i++)
+        {
+            // Lineare Hüllkurve: sanftes Ein- und Ausblenden
+            double env = 1.0;
+            if (i < fadeSamples)                        env = (double)i / fadeSamples;
+            else if (i >= totalSamples - fadeSamples)   env = (double)(totalSamples - i) / fadeSamples;
+
+            double sample = Math.Sin(2 * Math.PI * freqHz * i / SampleRate) * env * 0.75;
+            bw.Write((short)(sample * 32767));
+        }
+
+        ms.Position = 0;
+        using var player = new System.Media.SoundPlayer(ms);
+        player.PlaySync();
     }
 }

--- a/MeshhessenClient/MapPickerWindow.xaml
+++ b/MeshhessenClient/MapPickerWindow.xaml
@@ -1,0 +1,35 @@
+<Window x:Class="MeshhessenClient.MapPickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:wpf="clr-namespace:Mapsui.UI.Wpf;assembly=Mapsui.UI.Wpf"
+        Title="{DynamicResource StrMapPickerTitle}"
+        Width="700" Height="520"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <wpf:MapControl x:Name="MapControl" Grid.Row="0"/>
+
+        <Border Grid.Row="1" Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}" Padding="12,8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="CoordHintText" Grid.Column="0" VerticalAlignment="Center"
+                           Text="{DynamicResource StrMapPickerHint}" FontSize="11" Foreground="Gray"/>
+                <Button x:Name="AcceptButton" Grid.Column="1" Click="Accept_Click"
+                        Content="{DynamicResource StrMapPickerAccept}"
+                        Padding="14,6" Margin="0,0,8,0" IsEnabled="False"/>
+                <Button Grid.Column="2" Click="Cancel_Click"
+                        Content="{DynamicResource StrMapPickerCancel}"
+                        Padding="14,6"/>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/MeshhessenClient/MapPickerWindow.xaml.cs
+++ b/MeshhessenClient/MapPickerWindow.xaml.cs
@@ -1,0 +1,100 @@
+using System.Windows;
+using System.Windows.Input;
+using Mapsui;
+using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Projections;
+using Mapsui.Styles;
+using Mapsui.Tiling;
+using Mapsui.Tiling.Layers;
+
+namespace MeshhessenClient;
+
+public partial class MapPickerWindow : Window
+{
+    public (double lat, double lon)? SelectedPosition { get; private set; }
+
+    private Mapsui.Map? _map;
+    private MemoryLayer? _markerLayer;
+    private readonly List<IFeature> _markerFeatures = new();
+    private readonly Func<TileLayer>? _tileLayerFactory;
+
+    public MapPickerWindow(double initialLat, double initialLon, Func<TileLayer>? tileLayerFactory = null)
+    {
+        InitializeComponent();
+        _tileLayerFactory = tileLayerFactory;
+        Loaded += (_, _) => InitMap(initialLat, initialLon);
+    }
+
+    private void InitMap(double initialLat, double initialLon)
+    {
+        try
+        {
+            _map = new Mapsui.Map();
+
+            // Use the same tile layer as the main map; fall back to online OSM if no factory provided
+            var tileLayer = _tileLayerFactory?.Invoke() ?? OpenStreetMap.CreateTileLayer("MeshhessenClient/MapPicker");
+            _map.Layers.Add(tileLayer);
+
+            _markerLayer = new MemoryLayer("Marker") { Features = _markerFeatures, Style = null };
+            _map.Layers.Add(_markerLayer);
+
+            MapControl.Map = _map;
+            MapControl.MouseLeftButtonUp += MapControl_Click;
+
+            var center = SphericalMercator.FromLonLat(initialLon, initialLat);
+            _map.Home = n => n.CenterOnAndZoomTo(new MPoint(center.x, center.y), 153.0); // ~zoom 12
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.WriteLine($"ERROR MapPickerWindow InitMap: {ex.Message}");
+        }
+    }
+
+    private void MapControl_Click(object sender, MouseButtonEventArgs e)
+    {
+        if (_map == null) return;
+        try
+        {
+            var screenPos = e.GetPosition(MapControl);
+            var viewport = _map.Navigator.Viewport;
+            var worldPos = viewport.ScreenToWorld(screenPos.X, screenPos.Y);
+            var lonLat = SphericalMercator.ToLonLat(worldPos.X, worldPos.Y);
+
+            SelectedPosition = (lonLat.lat, lonLat.lon);
+            AcceptButton.IsEnabled = true;
+
+            CoordHintText.Text = $"{lonLat.lat:F6}, {lonLat.lon:F6}";
+
+            // Update marker
+            _markerFeatures.Clear();
+            var feature = new PointFeature(worldPos.X, worldPos.Y);
+            feature.Styles.Add(new SymbolStyle
+            {
+                SymbolScale = 0.7,
+                Fill = new Brush(Mapsui.Styles.Color.FromArgb(200, 220, 60, 60)),
+                Outline = new Pen(Mapsui.Styles.Color.White, 2),
+                SymbolType = SymbolType.Ellipse
+            });
+            _markerFeatures.Add(feature);
+            _markerLayer?.DataHasChanged();
+            MapControl.Refresh();
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.WriteLine($"ERROR MapPickerWindow click: {ex.Message}");
+        }
+    }
+
+    private void Accept_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+        Close();
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/MeshhessenClient/MeshhessenClient.csproj
+++ b/MeshhessenClient/MeshhessenClient.csproj
@@ -47,6 +47,9 @@
     <!-- Crypto: X25519 ECDH + AES-CTR for PKI packet decryption -->
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
 
+    <!-- MQTT Proxy-to-Client -->
+    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
+
     <!-- Offline Map -->
     <PackageReference Include="Mapsui" Version="4.1.7" />
     <PackageReference Include="Mapsui.Wpf" Version="4.1.7" />

--- a/MeshhessenClient/MeshhessenClient.csproj
+++ b/MeshhessenClient/MeshhessenClient.csproj
@@ -18,9 +18,9 @@
     <PublishDir>..\public\</PublishDir>
 
     <AssemblyName>MeshhessenClient</AssemblyName>
-    <Version>1.5.8</Version>
-    <AssemblyVersion>1.5.8.0</AssemblyVersion>
-    <FileVersion>1.5.8.0</FileVersion>
+    <Version>1.5.9</Version>
+    <AssemblyVersion>1.5.9.0</AssemblyVersion>
+    <FileVersion>1.5.9.0</FileVersion>
     <Company>Meshtastic Community</Company>
     <Product>Meshhessen Client</Product>
     <Description>Offline-fähiger Windows Client für Meshtastic Geräte</Description>

--- a/MeshhessenClient/Models/ChannelInfo.cs
+++ b/MeshhessenClient/Models/ChannelInfo.cs
@@ -8,4 +8,5 @@ public class ChannelInfo
     public string Role { get; set; } = string.Empty;
     public bool Downlink { get; set; }
     public bool Uplink { get; set; }
+    public uint PositionPrecision { get; set; }
 }

--- a/MeshhessenClient/NodeConfigWindow.xaml
+++ b/MeshhessenClient/NodeConfigWindow.xaml
@@ -183,6 +183,25 @@
                             <TextBlock Text="{DynamicResource StrNcNavSerial}" VerticalAlignment="Center"/>
                         </DockPanel>
                     </ListBoxItem>
+
+                    <!-- SECURITY + CHANNELS section -->
+                    <ListBoxItem Style="{StaticResource NavHeaderStyle}" Margin="0,8,0,2">
+                        <TextBlock Text="DEVICE"
+                                   Foreground="#F57C00"
+                                   FontSize="10" FontWeight="Bold" Padding="10,0,0,0"/>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Security">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="#F57C00" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavSecurity}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Channels">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="#F57C00" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavChannels}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
                 </ListBox>
             </Border>
 
@@ -202,6 +221,10 @@
                             <TextBlock Text="{DynamicResource StrNcShortName}" Margin="0,12,0,2"/>
                             <TextBox x:Name="ShortNameTextBox" MaxLength="4" Width="100" HorizontalAlignment="Left"/>
                             <TextBlock Text="{DynamicResource StrNcDescShortName}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="IsLicensedCheckBox" Content="{DynamicResource StrNcIsLicensed}" Margin="0,12,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescIsLicensed}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="IsUnmessagableCheckBox" Content="{DynamicResource StrNcIsUnmessagable}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescIsUnmessagable}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -253,6 +276,14 @@
                             <CheckBox x:Name="LedHeartbeatCheckBox" Content="{DynamicResource StrNcLedHeartbeat}" Margin="0,12,0,0"/>
                             <CheckBox x:Name="DoubleTapCheckBox" Content="{DynamicResource StrNcDoubleTap}" Margin="0,8,0,0"/>
                             <TextBlock Text="{DynamicResource StrNcDescDoubleTap}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="DisableTripleClickCheckBox" Content="{DynamicResource StrNcDisableTripleClick}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescDisableTripleClick}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcButtonGpio}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="ButtonGpioTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescButtonGpio}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcBuzzerGpio}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="BuzzerGpioTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescBuzzerGpio}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -313,6 +344,13 @@
                             <TextBlock Text="{DynamicResource StrNcDescDutyCycle}" Style="{StaticResource DescStyle}" Foreground="Orange"/>
                             <CheckBox x:Name="LoraSx126xRxBoostedCheckBox" Content="SX126x RX Boosted Gain" Margin="0,8,0,0"/>
                             <TextBlock Text="{DynamicResource StrNcDescSx126x}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="LoraIgnoreMqttCheckBox" Content="{DynamicResource StrNcIgnoreMqtt}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescIgnoreMqtt}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="LoraOkToMqttCheckBox" Content="{DynamicResource StrNcOkToMqtt}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescOkToMqtt}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcOverrideFreq}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="LoraOverrideFreqTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescOverrideFreq}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -331,6 +369,8 @@
                                 <ComboBoxItem Content="{DynamicResource StrNcGpsNotPresent}" Tag="2"/>
                             </ComboBox>
                             <TextBlock Text="{DynamicResource StrNcDescGpsMode}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="FixedPositionCheckBox" Content="{DynamicResource StrNcFixedPosition}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescFixedPosition}" Style="{StaticResource DescStyle}"/>
                             <TextBlock Text="{DynamicResource StrNcPosBroadcast}" Margin="0,12,0,2"/>
                             <TextBox x:Name="PosBroadcastSecsTextBox" Width="160" HorizontalAlignment="Left"/>
                             <TextBlock Text="{DynamicResource StrNcDescPosBroadcast}" Style="{StaticResource DescStyle}"/>
@@ -339,12 +379,21 @@
                             <TextBlock Text="{DynamicResource StrNcMinDistance}" Margin="0,8,0,2"/>
                             <TextBox x:Name="MinDistanceTextBox" Width="120" HorizontalAlignment="Left"/>
                             <TextBlock Text="{DynamicResource StrNcDescMinDistance}" Style="{StaticResource DescStyle}"/>
-                            <TextBlock Text="{DynamicResource StrNcMinSpeed}" Margin="0,8,0,2"/>
-                            <TextBox x:Name="MinSpeedTextBox" Width="120" HorizontalAlignment="Left"/>
-                            <TextBlock Text="{DynamicResource StrNcDescMinSpeed}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcMinIntervalSecs}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="MinIntervalSecsTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMinIntervalSecs}" Style="{StaticResource DescStyle}"/>
                             <TextBlock Text="{DynamicResource StrNcGpsUpdateInterval}" Margin="0,12,0,2"/>
                             <TextBox x:Name="GpsUpdateIntervalTextBox" Width="120" HorizontalAlignment="Left"/>
                             <TextBlock Text="{DynamicResource StrNcDescGpsInterval}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcRxGpio}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="GpsRxGpioTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescRxGpio}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcTxGpioPos}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="GpsTxGpioTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescTxGpioPos}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcGpsEnGpio}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="GpsEnGpioTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescGpsEnGpio}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -373,6 +422,12 @@
                             <TextBlock Text="{DynamicResource StrNcMinWakeSecs}" Margin="0,10,0,2"/>
                             <TextBox x:Name="MinWakeSecsTextBox" Width="160" HorizontalAlignment="Left"/>
                             <TextBlock Text="{DynamicResource StrNcDescMinWake}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcAdcMult}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="AdcMultTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescAdcMult}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcBatteryInaAddr}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="BatteryInaAddrTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescBatteryInaAddr}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -390,7 +445,7 @@
                             <TextBox x:Name="WifiSsidTextBox" MaxLength="32"/>
                             <TextBlock Text="{DynamicResource StrNcDescWifiSsid}" Style="{StaticResource DescStyle}"/>
                             <TextBlock Text="{DynamicResource StrNcWifiPsk}" Margin="0,10,0,2"/>
-                            <Grid Height="30">
+                            <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
@@ -413,6 +468,17 @@
                             <TextBlock Text="{DynamicResource StrNcNtpServer}" Margin="0,10,0,2"/>
                             <TextBox x:Name="NtpServerTextBox" MaxLength="64"/>
                             <TextBlock Text="{DynamicResource StrNcDescNtpServer}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="EthEnabledCheckBox" Content="{DynamicResource StrNcEthEnabled}" Margin="0,12,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescEthEnabled}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcAddressMode}" Margin="0,10,0,2"/>
+                            <ComboBox x:Name="AddressModeComboBox" Width="160" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="DHCP" Tag="0"/>
+                                <ComboBoxItem Content="STATIC" Tag="1"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescAddressMode}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcRsyslogServer}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="RsyslogServerTextBox" MaxLength="64"/>
+                            <TextBlock Text="{DynamicResource StrNcDescRsyslogServer}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -434,6 +500,47 @@
                             <TextBlock Text="{DynamicResource StrNcDescCompassNorth}" Style="{StaticResource DescStyle}"/>
                             <CheckBox x:Name="FlipScreenCheckBox" Content="{DynamicResource StrNcFlipScreen}" Margin="0,8,0,0"/>
                             <TextBlock Text="{DynamicResource StrNcDescFlipScreen}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="HeadingBoldCheckBox" Content="{DynamicResource StrNcHeadingBold}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescHeadingBold}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="WakeOnTapCheckBox" Content="{DynamicResource StrNcWakeOnTap}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescWakeOnTap}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="Use12hClockCheckBox" Content="{DynamicResource StrNcUse12hClock}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescUse12hClock}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcDisplayUnits}" Margin="0,12,0,2"/>
+                            <ComboBox x:Name="DisplayUnitsComboBox" Width="160" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="{DynamicResource StrNcMetric}" Tag="0"/>
+                                <ComboBoxItem Content="{DynamicResource StrNcImperial}" Tag="1"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescDisplayUnits}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcDisplayMode}" Margin="0,10,0,2"/>
+                            <ComboBox x:Name="DisplayModeComboBox" Width="180" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="DEFAULT" Tag="0"/>
+                                <ComboBoxItem Content="TWOCOLOR" Tag="1"/>
+                                <ComboBoxItem Content="INVERTED" Tag="2"/>
+                                <ComboBoxItem Content="COLOR" Tag="3"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescDisplayMode}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcOledType}" Margin="0,10,0,2"/>
+                            <ComboBox x:Name="OledTypeComboBox" Width="180" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="AUTO" Tag="0"/>
+                                <ComboBoxItem Content="SSD1306" Tag="1"/>
+                                <ComboBoxItem Content="SH1106" Tag="2"/>
+                                <ComboBoxItem Content="SH1107 (128×64)" Tag="3"/>
+                                <ComboBoxItem Content="SH1107 (128×128)" Tag="4"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescOledType}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcCompassOrientation}" Margin="0,10,0,2"/>
+                            <ComboBox x:Name="CompassOrientationComboBox" Width="200" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="0°" Tag="0"/>
+                                <ComboBoxItem Content="90°" Tag="1"/>
+                                <ComboBoxItem Content="180°" Tag="2"/>
+                                <ComboBoxItem Content="270°" Tag="3"/>
+                                <ComboBoxItem Content="0° (Inverted)" Tag="4"/>
+                                <ComboBoxItem Content="90° (Inverted)" Tag="5"/>
+                                <ComboBoxItem Content="180° (Inverted)" Tag="6"/>
+                                <ComboBoxItem Content="270° (Inverted)" Tag="7"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescCompassOrientation}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -478,7 +585,7 @@
                             <TextBlock Text="{DynamicResource StrNcMqttUsername}" Margin="0,8,0,2"/>
                             <TextBox x:Name="MqttUsernameTextBox"/>
                             <TextBlock Text="{DynamicResource StrNcMqttPassword}" Margin="0,8,0,2"/>
-                            <PasswordBox x:Name="MqttPasswordBox" Height="30"/>
+                            <TextBox x:Name="MqttPasswordBox" Height="30" MaxLength="63"/>
                             <CheckBox x:Name="MqttEncryptionCheckBox" Content="{DynamicResource StrNcMqttEncryption}" Margin="0,10,0,0"/>
                             <TextBlock Text="{DynamicResource StrNcDescMqttEncryption}" Style="{StaticResource DescStyle}"/>
                             <CheckBox x:Name="MqttJsonCheckBox" Content="{DynamicResource StrNcMqttJson}" Margin="0,6,0,0"/>
@@ -672,6 +779,184 @@
                                 <ComboBoxItem Content="CALTOPO — CalTopo/SARTopo" Tag="5"/>
                             </ComboBox>
                             <TextBlock Text="{DynamicResource StrNcDescSerMode}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ SECURITY ═══════════════ -->
+                <ScrollViewer x:Name="PanelSecurity" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="#FFF3E0" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavSecurity}" FontWeight="SemiBold" FontSize="13" Foreground="#F57C00"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="{DynamicResource StrNcSecPublicKey}" Margin="0,0,0,2"/>
+                            <TextBox x:Name="SecPublicKeyTextBox" IsReadOnly="True" FontFamily="Consolas" FontSize="11" Height="28"
+                                     Background="#F5F5F5" Foreground="Gray"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSecPublicKey}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSecAdminKey}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="SecAdminKeyTextBox" Height="70" AcceptsReturn="True" TextWrapping="NoWrap"
+                                     FontFamily="Consolas" FontSize="11" VerticalScrollBarVisibility="Auto"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSecAdminKey}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="SecSerialEnabledCheckBox" Content="{DynamicResource StrNcSecSerialEnabled}" Margin="0,12,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSecSerialEnabled}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="SecDebugLogCheckBox" Content="{DynamicResource StrNcSecDebugLog}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSecDebugLog}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="SecIsManagedCheckBox" Content="{DynamicResource StrNcSecIsManaged}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSecIsManaged}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="SecAdminChannelCheckBox" Content="{DynamicResource StrNcSecAdminChannel}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSecAdminChannel}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ CHANNELS ═══════════════ -->
+                <ScrollViewer x:Name="PanelChannels" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="#FFF3E0" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavChannels}" FontWeight="SemiBold" FontSize="13" Foreground="#F57C00"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <!-- Column headers -->
+                            <Grid Margin="0,0,0,6">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="#" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
+                                <TextBlock Grid.Column="1" Text="Role" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
+                                <TextBlock Grid.Column="2" Text="Name" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
+                                <TextBlock Grid.Column="3" Text="{DynamicResource StrNcChannelUplink}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
+                                <TextBlock Grid.Column="4" Text="{DynamicResource StrNcChannelDownlink}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
+                            </Grid>
+                            <Rectangle Height="1" Fill="#E0E0E0" Margin="0,0,0,6"/>
+                            <!-- Channel 0 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="0" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch0Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch0Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch0Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch0Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Channel 1 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="1" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch1Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch1Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch1Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch1Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Channel 2 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="2" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch2Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch2Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch2Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch2Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Channel 3 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="3" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch3Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch3Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch3Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch3Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Channel 4 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="4" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch4Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch4Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch4Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch4Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Channel 5 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="5" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch5Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch5Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch5Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch5Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Channel 6 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="6" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch6Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch6Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch6Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch6Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <!-- Channel 7 -->
+                            <Grid Margin="0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="60"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="80"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="7" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                                <TextBlock x:Name="Ch7Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch7Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
+                                <CheckBox x:Name="Ch7Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch7Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                            <TextBlock Margin="0,12,0,0" TextWrapping="Wrap" Foreground="Gray" FontSize="11"
+                                       Text="{DynamicResource StrNcDescChannelUplink}"/>
+                            <TextBlock Margin="0,4,0,0" TextWrapping="Wrap" Foreground="Gray" FontSize="11"
+                                       Text="{DynamicResource StrNcDescChannelDownlink}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>

--- a/MeshhessenClient/NodeConfigWindow.xaml
+++ b/MeshhessenClient/NodeConfigWindow.xaml
@@ -369,8 +369,45 @@
                                 <ComboBoxItem Content="{DynamicResource StrNcGpsNotPresent}" Tag="2"/>
                             </ComboBox>
                             <TextBlock Text="{DynamicResource StrNcDescGpsMode}" Style="{StaticResource DescStyle}"/>
-                            <CheckBox x:Name="FixedPositionCheckBox" Content="{DynamicResource StrNcFixedPosition}" Margin="0,10,0,0"/>
+                            <CheckBox x:Name="FixedPositionCheckBox" Content="{DynamicResource StrNcFixedPosition}" Margin="0,10,0,0"
+                                      Checked="FixedPositionCheckBox_Changed" Unchecked="FixedPositionCheckBox_Changed"/>
                             <TextBlock Text="{DynamicResource StrNcDescFixedPosition}" Style="{StaticResource DescStyle}"/>
+
+                            <!-- Fixed position coordinate panel (nur sichtbar wenn aktiviert) -->
+                            <Border x:Name="FixedPositionPanel" Visibility="Collapsed"
+                                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                                    BorderThickness="0,0,0,0" Background="{StaticResource BgConfig}"
+                                    Padding="12,10" Margin="0,8,16,0" CornerRadius="4">
+                                <StackPanel>
+                                    <TextBlock Text="{DynamicResource StrNcFixedPosGroupHeader}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="12"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="12"/>
+                                            <ColumnDefinition Width="100"/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0">
+                                            <TextBlock Text="{DynamicResource StrNcFixedLat}" Margin="0,0,0,2" FontSize="11"/>
+                                            <TextBox x:Name="FixedLatTextBox" Height="26" FontSize="12"/>
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Text="{DynamicResource StrNcFixedLon}" Margin="0,0,0,2" FontSize="11"/>
+                                            <TextBox x:Name="FixedLonTextBox" Height="26" FontSize="12"/>
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="4">
+                                            <TextBlock Text="{DynamicResource StrNcFixedAlt}" Margin="0,0,0,2" FontSize="11"/>
+                                            <TextBox x:Name="FixedAltTextBox" Height="26" FontSize="12" Text="0"/>
+                                        </StackPanel>
+                                    </Grid>
+                                    <TextBlock Text="{DynamicResource StrNcDescFixedCoords}" Style="{StaticResource DescStyle}" Margin="0,6,0,6"/>
+                                    <Button x:Name="PickFromMapButton" Click="PickFromMap_Click"
+                                            Content="{DynamicResource StrNcPickFromMap}"
+                                            ToolTip="{DynamicResource StrNcPickFromMapTip}"
+                                            HorizontalAlignment="Left" Padding="10,4"/>
+                                </StackPanel>
+                            </Border>
                             <TextBlock Text="{DynamicResource StrNcPosBroadcast}" Margin="0,12,0,2"/>
                             <TextBox x:Name="PosBroadcastSecsTextBox" Width="160" HorizontalAlignment="Left"/>
                             <TextBlock Text="{DynamicResource StrNcDescPosBroadcast}" Style="{StaticResource DescStyle}"/>
@@ -790,14 +827,43 @@
                             <TextBlock Text="{DynamicResource StrNcNavSecurity}" FontWeight="SemiBold" FontSize="13" Foreground="#F57C00"/>
                         </Border>
                         <StackPanel Margin="16,0,0,0">
+                            <!-- Public Key (read-only) -->
                             <TextBlock Text="{DynamicResource StrNcSecPublicKey}" Margin="0,0,0,2"/>
                             <TextBox x:Name="SecPublicKeyTextBox" IsReadOnly="True" FontFamily="Consolas" FontSize="11" Height="28"
                                      Background="#F5F5F5" Foreground="Gray"/>
                             <TextBlock Text="{DynamicResource StrNcDescSecPublicKey}" Style="{StaticResource DescStyle}"/>
-                            <TextBlock Text="{DynamicResource StrNcSecAdminKey}" Margin="0,12,0,2"/>
-                            <TextBox x:Name="SecAdminKeyTextBox" Height="70" AcceptsReturn="True" TextWrapping="NoWrap"
-                                     FontFamily="Consolas" FontSize="11" VerticalScrollBarVisibility="Auto"/>
-                            <TextBlock Text="{DynamicResource StrNcDescSecAdminKey}" Style="{StaticResource DescStyle}"/>
+
+                            <!-- Private Key (show/hide) -->
+                            <TextBlock Text="{DynamicResource StrNcSecPrivateKey}" Margin="0,12,0,2"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox x:Name="SecPrivKeyBox" Grid.Column="0" Height="28"
+                                         FontFamily="Consolas" FontSize="11" Visibility="Collapsed"/>
+                                <TextBox x:Name="SecPrivKeyMaskBox" Grid.Column="0" Height="28"
+                                         FontFamily="Consolas" FontSize="11" IsReadOnly="True"
+                                         Background="#F5F5F5" Foreground="Gray"
+                                         Text="••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••"/>
+                                <ToggleButton x:Name="SecPrivKeyToggle" Grid.Column="1"
+                                              Width="34" Height="28" Margin="4,0,0,0"
+                                              Checked="SecPrivKeyToggle_Checked"
+                                              Unchecked="SecPrivKeyToggle_Unchecked"
+                                              ToolTip="{DynamicResource StrNcShowPassword}"
+                                              Content="👁"/>
+                            </Grid>
+                            <TextBlock Text="{DynamicResource StrNcDescSecPrivateKey}" Style="{StaticResource DescStyle}"/>
+
+                            <!-- Admin Keys (separate fields) -->
+                            <TextBlock Text="{DynamicResource StrNcSecAdminKey1}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="SecAdminKey1TextBox" FontFamily="Consolas" FontSize="11" Height="28"/>
+                            <TextBlock Text="{DynamicResource StrNcSecAdminKey2}" Margin="0,6,0,2"/>
+                            <TextBox x:Name="SecAdminKey2TextBox" FontFamily="Consolas" FontSize="11" Height="28"/>
+                            <TextBlock Text="{DynamicResource StrNcSecAdminKey3}" Margin="0,6,0,2"/>
+                            <TextBox x:Name="SecAdminKey3TextBox" FontFamily="Consolas" FontSize="11" Height="28"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSecAdminKeys}" Style="{StaticResource DescStyle}"/>
+
                             <CheckBox x:Name="SecSerialEnabledCheckBox" Content="{DynamicResource StrNcSecSerialEnabled}" Margin="0,12,0,0"/>
                             <TextBlock Text="{DynamicResource StrNcDescSecSerialEnabled}" Style="{StaticResource DescStyle}"/>
                             <CheckBox x:Name="SecDebugLogCheckBox" Content="{DynamicResource StrNcSecDebugLog}" Margin="0,8,0,0"/>
@@ -817,141 +883,161 @@
                             <TextBlock Text="{DynamicResource StrNcNavChannels}" FontWeight="SemiBold" FontSize="13" Foreground="#F57C00"/>
                         </Border>
                         <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="{DynamicResource StrNcDescChannelPosPrecision}" Style="{StaticResource DescStyle}" Margin="0,0,0,8"/>
                             <!-- Column headers -->
-                            <Grid Margin="0,0,0,6">
+                            <Grid Margin="0,0,0,4">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="#" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
                                 <TextBlock Grid.Column="1" Text="Role" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
-                                <TextBlock Grid.Column="2" Text="Name" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
+                                <TextBlock Grid.Column="2" Text="Name" FontWeight="SemiBold" FontSize="11" Foreground="Gray" Margin="4,0"/>
                                 <TextBlock Grid.Column="3" Text="{DynamicResource StrNcChannelUplink}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
                                 <TextBlock Grid.Column="4" Text="{DynamicResource StrNcChannelDownlink}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
+                                <TextBlock Grid.Column="5" Text="{DynamicResource StrNcChannelPosPrecision}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
                             </Grid>
-                            <Rectangle Height="1" Fill="#E0E0E0" Margin="0,0,0,6"/>
+                            <Rectangle Height="1" Fill="#E0E0E0" Margin="0,0,0,4"/>
+
                             <!-- Channel 0 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow0" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="0" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch0Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch0Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch0Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch0Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch0Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch0Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch0Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch0Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <!-- Channel 1 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow1" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="1" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch1Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch1Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch1Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch1Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch1Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch1Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch1Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch1Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <!-- Channel 2 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow2" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="2" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch2Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch2Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch2Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch2Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch2Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch2Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch2Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch2Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <!-- Channel 3 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow3" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="3" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch3Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch3Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch3Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch3Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch3Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch3Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch3Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch3Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <!-- Channel 4 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow4" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="4" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch4Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch4Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch4Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch4Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch4Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch4Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch4Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch4Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <!-- Channel 5 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow5" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="5" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch5Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch5Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch5Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch5Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch5Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch5Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch5Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch5Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <!-- Channel 6 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow6" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="6" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch6Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch6Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch6Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch6Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch6Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch6Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch6Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch6Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <!-- Channel 7 -->
-                            <Grid Margin="0,2">
+                            <Grid x:Name="ChRow7" Margin="0,2">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="20"/>
                                     <ColumnDefinition Width="60"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="70"/>
-                                    <ColumnDefinition Width="80"/>
+                                    <ColumnDefinition Width="58"/>
+                                    <ColumnDefinition Width="68"/>
+                                    <ColumnDefinition Width="96"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="7" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
-                                <TextBlock x:Name="Ch7Role" Grid.Column="1" VerticalAlignment="Center" FontSize="11"/>
+                                <TextBlock x:Name="Ch7Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
                                 <TextBlock x:Name="Ch7Name" Grid.Column="2" VerticalAlignment="Center" Margin="4,0"/>
-                                <CheckBox x:Name="Ch7Uplink" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                <CheckBox x:Name="Ch7Downlink" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <CheckBox x:Name="Ch7Uplink"   Grid.Column="3" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <CheckBox x:Name="Ch7Downlink" Grid.Column="4" Width="22" Height="22" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{x:Null}"/>
+                                <ComboBox x:Name="Ch7Precision" Grid.Column="5" FontSize="11" Height="24"/>
                             </Grid>
                             <TextBlock Margin="0,12,0,0" TextWrapping="Wrap" Foreground="Gray" FontSize="11"
                                        Text="{DynamicResource StrNcDescChannelUplink}"/>

--- a/MeshhessenClient/NodeConfigWindow.xaml
+++ b/MeshhessenClient/NodeConfigWindow.xaml
@@ -4,208 +4,683 @@
         xmlns:ui="http://schemas.modernwpf.com/2019"
         ui:WindowHelper.UseModernWindowStyle="True"
         Title="{DynamicResource StrNcWindowTitle}"
-        Width="520"
-        Height="560"
+        Width="760"
+        Height="620"
+        MinWidth="620"
+        MinHeight="500"
         WindowStartupLocation="CenterOwner">
 
-    <Grid Margin="12">
+    <Window.Resources>
+        <!-- Category colors -->
+        <SolidColorBrush x:Key="ColorNode"   Color="#00897B"/>
+        <SolidColorBrush x:Key="ColorConfig" Color="#1976D2"/>
+        <SolidColorBrush x:Key="ColorModule" Color="#388E3C"/>
+        <SolidColorBrush x:Key="BgNode"      Color="#E0F2F1"/>
+        <SolidColorBrush x:Key="BgConfig"    Color="#E3F2FD"/>
+        <SolidColorBrush x:Key="BgModule"    Color="#E8F5E9"/>
+
+        <!-- Non-selectable section header -->
+        <Style x:Key="NavHeaderStyle" TargetType="ListBoxItem">
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="IsHitTestVisible" Value="False"/>
+            <Setter Property="Padding" Value="10,8,8,2"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBoxItem">
+                        <ContentPresenter/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Shared description TextBlock style -->
+        <Style x:Key="DescStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground" Value="Gray"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="Margin" Value="0,2,0,0"/>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0" x:Name="StatusText" Text="{DynamicResource StrLoadingConfig}" Margin="0,0,0,8" Foreground="Gray" FontStyle="Italic"/>
+        <!-- Status bar -->
+        <Border Grid.Row="0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" Padding="12,6">
+            <TextBlock x:Name="StatusText" Text="{DynamicResource StrLoadingConfig}" Foreground="Gray" FontStyle="Italic"/>
+        </Border>
 
-        <TabControl Grid.Row="1" x:Name="ConfigTabs">
+        <!-- Two-panel layout -->
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="190"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-            <!-- Tab: Benutzer -->
-            <TabItem Header="{DynamicResource StrNcTabUser}">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="10">
-                        <TextBlock Text="{DynamicResource StrNcLongName}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="LongNameTextBox" MaxLength="39"/>
-                        <TextBlock Text="{DynamicResource StrNcShortName}" Margin="0,10,0,2"/>
-                        <TextBox x:Name="ShortNameTextBox" MaxLength="4"/>
+            <!-- Left nav -->
+            <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" BorderThickness="0,0,1,0">
+                <ListBox x:Name="NavList" SelectionChanged="NavList_SelectionChanged"
+                         Background="Transparent" BorderThickness="0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+
+                    <!-- NODE section -->
+                    <ListBoxItem Style="{StaticResource NavHeaderStyle}" Margin="0,6,0,2">
+                        <TextBlock Text="{DynamicResource StrNcSectionNode}"
+                                   Foreground="{StaticResource ColorNode}"
+                                   FontSize="10" FontWeight="Bold" Padding="10,0,0,0"/>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="User">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorNode}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavUser}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+
+                    <!-- CONFIG section -->
+                    <ListBoxItem Style="{StaticResource NavHeaderStyle}" Margin="0,8,0,2">
+                        <TextBlock Text="{DynamicResource StrNcSectionConfig}"
+                                   Foreground="{StaticResource ColorConfig}"
+                                   FontSize="10" FontWeight="Bold" Padding="10,0,0,0"/>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Device">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorConfig}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavDevice}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Lora">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorConfig}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavLora}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Position">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorConfig}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavPosition}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Power">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorConfig}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavPower}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Network">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorConfig}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavNetwork}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Display">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorConfig}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavDisplay}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Bluetooth">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorConfig}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavBluetooth}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+
+                    <!-- MODULES section -->
+                    <ListBoxItem Style="{StaticResource NavHeaderStyle}" Margin="0,8,0,2">
+                        <TextBlock Text="{DynamicResource StrNcSectionModules}"
+                                   Foreground="{StaticResource ColorModule}"
+                                   FontSize="10" FontWeight="Bold" Padding="10,0,0,0"/>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Mqtt">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavMqtt}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Telemetry">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavTelemetry}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="NeighborInfo">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavNeighborInfo}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="StoreForward">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavStoreForward}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="ExtNotif">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavExtNotif}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="CannedMsg">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavCannedMsg}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="RangeTest">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavRangeTest}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                    <ListBoxItem Tag="Serial">
+                        <DockPanel>
+                            <Rectangle DockPanel.Dock="Left" Width="3" Fill="{StaticResource ColorModule}" Margin="0,3,8,3" RadiusX="1" RadiusY="1"/>
+                            <TextBlock Text="{DynamicResource StrNcNavSerial}" VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </ListBoxItem>
+                </ListBox>
+            </Border>
+
+            <!-- Right content area — only one panel visible at a time -->
+            <Grid Grid.Column="1">
+
+                <!-- ═══════════════ USER ═══════════════ -->
+                <ScrollViewer x:Name="PanelUser" Visibility="Visible" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgNode}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavUser}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorNode}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="{DynamicResource StrNcLongName}" Margin="0,0,0,2"/>
+                            <TextBox x:Name="LongNameTextBox" MaxLength="39"/>
+                            <TextBlock Text="{DynamicResource StrNcDescLongName}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcShortName}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="ShortNameTextBox" MaxLength="4" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescShortName}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
 
-            <!-- Tab: Gerät -->
-            <TabItem Header="{DynamicResource StrNcTabDevice}">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="10">
-                        <TextBlock Text="{DynamicResource StrNcRole}" Margin="0,8,0,2"/>
-                        <ComboBox x:Name="RoleComboBox" Width="200" HorizontalAlignment="Left">
-                            <ComboBoxItem Content="CLIENT" Tag="0"/>
-                            <ComboBoxItem Content="CLIENT_MUTE" Tag="1"/>
-                            <ComboBoxItem Content="ROUTER" Tag="2"/>
-                            <ComboBoxItem Content="ROUTER_CLIENT" Tag="3"/>
-                            <ComboBoxItem Content="REPEATER" Tag="4"/>
-                            <ComboBoxItem Content="TRACKER" Tag="5"/>
-                            <ComboBoxItem Content="SENSOR" Tag="6"/>
-                            <ComboBoxItem Content="TAK" Tag="7"/>
-                            <ComboBoxItem Content="CLIENT_HIDDEN" Tag="8"/>
-                        </ComboBox>
-                        <TextBlock Text="{DynamicResource StrNcRebroadcast}" Margin="0,10,0,2"/>
-                        <ComboBox x:Name="RebroadcastComboBox" Width="200" HorizontalAlignment="Left">
-                            <ComboBoxItem Content="ALL" Tag="0"/>
-                            <ComboBoxItem Content="ALL_SKIP_DECODING" Tag="1"/>
-                            <ComboBoxItem Content="LOCAL_ONLY" Tag="2"/>
-                            <ComboBoxItem Content="KNOWN_ONLY" Tag="3"/>
-                            <ComboBoxItem Content="NONE" Tag="4"/>
-                            <ComboBoxItem Content="CORE_PORTNUMS_ONLY" Tag="5"/>
-                        </ComboBox>
-                        <TextBlock Text="{DynamicResource StrNcNodeInfoInterval}" Margin="0,10,0,2"/>
-                        <TextBox x:Name="NodeInfoIntervalTextBox" Width="150" HorizontalAlignment="Left"/>
-                        <TextBlock Text="{DynamicResource StrNcTimezone}" Margin="0,10,0,2"/>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox x:Name="TzdefTextBox" Grid.Column="0" Margin="0,0,6,0"/>
-                            <Button Grid.Column="1" Content="{DynamicResource StrNcFromWindows}" ToolTip="{DynamicResource StrNcFromWindowsTip}" Click="TzFromWindows_Click" Padding="8,4"/>
-                        </Grid>
-                        <CheckBox x:Name="LedHeartbeatCheckBox" Content="{DynamicResource StrNcLedHeartbeat}" Margin="0,12,0,0"/>
+                <!-- ═══════════════ DEVICE ═══════════════ -->
+                <ScrollViewer x:Name="PanelDevice" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgConfig}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavDevice}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorConfig}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="{DynamicResource StrNcRole}" Margin="0,0,0,2"/>
+                            <ComboBox x:Name="RoleComboBox" Width="220" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="CLIENT" Tag="0"/>
+                                <ComboBoxItem Content="CLIENT_MUTE" Tag="1"/>
+                                <ComboBoxItem Content="ROUTER" Tag="2"/>
+                                <ComboBoxItem Content="ROUTER_CLIENT" Tag="3"/>
+                                <ComboBoxItem Content="REPEATER" Tag="4"/>
+                                <ComboBoxItem Content="TRACKER" Tag="5"/>
+                                <ComboBoxItem Content="SENSOR" Tag="6"/>
+                                <ComboBoxItem Content="TAK" Tag="7"/>
+                                <ComboBoxItem Content="CLIENT_HIDDEN" Tag="8"/>
+                                <ComboBoxItem Content="LOST_AND_FOUND" Tag="9"/>
+                                <ComboBoxItem Content="TAK_TRACKER" Tag="10"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcRebroadcast}" Margin="0,12,0,2"/>
+                            <ComboBox x:Name="RebroadcastComboBox" Width="220" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="ALL" Tag="0"/>
+                                <ComboBoxItem Content="ALL_SKIP_DECODING" Tag="1"/>
+                                <ComboBoxItem Content="LOCAL_ONLY" Tag="2"/>
+                                <ComboBoxItem Content="KNOWN_ONLY" Tag="3"/>
+                                <ComboBoxItem Content="NONE" Tag="4"/>
+                                <ComboBoxItem Content="CORE_PORTNUMS_ONLY" Tag="5"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescRebroadcast}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcNodeInfoInterval}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="NodeInfoIntervalTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescNodeInfo}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcTimezone}" Margin="0,12,0,2"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox x:Name="TzdefTextBox" Grid.Column="0" Margin="0,0,6,0"/>
+                                <Button Grid.Column="1" Content="{DynamicResource StrNcFromWindows}" ToolTip="{DynamicResource StrNcFromWindowsTip}" Click="TzFromWindows_Click" Padding="8,4"/>
+                            </Grid>
+                            <TextBlock Text="{DynamicResource StrNcDescTimezone}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="LedHeartbeatCheckBox" Content="{DynamicResource StrNcLedHeartbeat}" Margin="0,12,0,0"/>
+                            <CheckBox x:Name="DoubleTapCheckBox" Content="{DynamicResource StrNcDoubleTap}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescDoubleTap}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
 
-            <!-- Tab: LoRa -->
-            <TabItem Header="LoRa">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="10">
-                        <TextBlock Text="Region" Margin="0,8,0,2"/>
-                        <ComboBox x:Name="LoraRegionComboBox" Width="150" HorizontalAlignment="Left">
-                            <ComboBoxItem Content="Unset" Tag="0"/>
-                            <ComboBoxItem Content="US" Tag="1"/>
-                            <ComboBoxItem Content="EU_433" Tag="2"/>
-                            <ComboBoxItem Content="EU_868" Tag="3"/>
-                            <ComboBoxItem Content="CN" Tag="4"/>
-                            <ComboBoxItem Content="JP" Tag="5"/>
-                            <ComboBoxItem Content="ANZ" Tag="6"/>
-                            <ComboBoxItem Content="KR" Tag="7"/>
-                            <ComboBoxItem Content="TW" Tag="8"/>
-                            <ComboBoxItem Content="RU" Tag="9"/>
-                            <ComboBoxItem Content="IN" Tag="10"/>
-                            <ComboBoxItem Content="NZ_865" Tag="11"/>
-                            <ComboBoxItem Content="TH" Tag="12"/>
-                            <ComboBoxItem Content="LORA_24" Tag="13"/>
-                            <ComboBoxItem Content="UA_868" Tag="14"/>
-                            <ComboBoxItem Content="MY_919" Tag="15"/>
-                            <ComboBoxItem Content="MY_433" Tag="16"/>
-                            <ComboBoxItem Content="SG_923" Tag="17"/>
-                            <ComboBoxItem Content="WLAN" Tag="18"/>
-                        </ComboBox>
-                        <CheckBox x:Name="LoraUsePresetCheckBox" Content="{DynamicResource StrNcUsePreset}" Margin="0,10,0,0" Checked="LoraUsePresetCheckBox_Changed" Unchecked="LoraUsePresetCheckBox_Changed"/>
-                        <TextBlock Text="{DynamicResource StrNcModemPreset}" Margin="0,8,0,2"/>
-                        <ComboBox x:Name="LoraPresetComboBox" Width="180" HorizontalAlignment="Left" IsEnabled="False">
-                            <ComboBoxItem Content="LONG_FAST" Tag="0"/>
-                            <ComboBoxItem Content="LONG_SLOW" Tag="1"/>
-                            <ComboBoxItem Content="VERY_LONG_SLOW" Tag="2"/>
-                            <ComboBoxItem Content="MEDIUM_SLOW" Tag="3"/>
-                            <ComboBoxItem Content="MEDIUM_FAST" Tag="4"/>
-                            <ComboBoxItem Content="SHORT_SLOW" Tag="5"/>
-                            <ComboBoxItem Content="SHORT_FAST" Tag="6"/>
-                            <ComboBoxItem Content="LONG_MODERATE" Tag="7"/>
-                        </ComboBox>
-                        <TextBlock Text="{DynamicResource StrNcHopLimit}" Margin="0,10,0,2"/>
-                        <TextBox x:Name="HopLimitTextBox" Width="60" HorizontalAlignment="Left"/>
-                        <CheckBox x:Name="TxEnabledCheckBox" Content="{DynamicResource StrNcTxEnabled}" Margin="0,10,0,0"/>
-                        <TextBlock Text="{DynamicResource StrNcTxPower}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="TxPowerTextBox" Width="80" HorizontalAlignment="Left"/>
+                <!-- ═══════════════ LORA ═══════════════ -->
+                <ScrollViewer x:Name="PanelLora" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgConfig}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavLora}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorConfig}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="Region" Margin="0,0,0,2"/>
+                            <ComboBox x:Name="LoraRegionComboBox" Width="160" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="Unset" Tag="0"/>
+                                <ComboBoxItem Content="US" Tag="1"/>
+                                <ComboBoxItem Content="EU_868" Tag="3"/>
+                                <ComboBoxItem Content="CN" Tag="4"/>
+                                <ComboBoxItem Content="JP" Tag="5"/>
+                                <ComboBoxItem Content="ANZ" Tag="6"/>
+                                <ComboBoxItem Content="KR" Tag="7"/>
+                                <ComboBoxItem Content="TW" Tag="8"/>
+                                <ComboBoxItem Content="RU" Tag="9"/>
+                                <ComboBoxItem Content="IN" Tag="10"/>
+                                <ComboBoxItem Content="NZ_865" Tag="11"/>
+                                <ComboBoxItem Content="TH" Tag="12"/>
+                                <ComboBoxItem Content="UA_868" Tag="13"/>
+                                <ComboBoxItem Content="MY_919" Tag="14"/>
+                                <ComboBoxItem Content="SG_923" Tag="15"/>
+                                <ComboBoxItem Content="LORA_24" Tag="16"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescLoraRegion}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="LoraUsePresetCheckBox" Content="{DynamicResource StrNcUsePreset}" Margin="0,12,0,0"
+                                      Checked="LoraUsePresetCheckBox_Changed" Unchecked="LoraUsePresetCheckBox_Changed"/>
+                            <TextBlock Text="{DynamicResource StrNcDescUsePreset}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcModemPreset}" Margin="0,8,0,2"/>
+                            <ComboBox x:Name="LoraPresetComboBox" Width="200" HorizontalAlignment="Left" IsEnabled="False">
+                                <ComboBoxItem Content="LONG_FAST" Tag="0"/>
+                                <ComboBoxItem Content="LONG_SLOW" Tag="1"/>
+                                <ComboBoxItem Content="VERY_LONG_SLOW" Tag="2"/>
+                                <ComboBoxItem Content="MEDIUM_SLOW" Tag="3"/>
+                                <ComboBoxItem Content="MEDIUM_FAST" Tag="4"/>
+                                <ComboBoxItem Content="SHORT_SLOW" Tag="5"/>
+                                <ComboBoxItem Content="SHORT_FAST" Tag="6"/>
+                                <ComboBoxItem Content="LONG_MODERATE" Tag="7"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescModemPreset}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcHopLimit}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="HopLimitTextBox" Width="60" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescHopLimit}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="TxEnabledCheckBox" Content="{DynamicResource StrNcTxEnabled}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcTxPower}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="TxPowerTextBox" Width="80" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescTxPower}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcChannelNum}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="LoraChannelNumTextBox" Width="80" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescChannelNum}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="LoraOverrideDutyCycleCheckBox" Content="{DynamicResource StrNcDutyCycle}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescDutyCycle}" Style="{StaticResource DescStyle}" Foreground="Orange"/>
+                            <CheckBox x:Name="LoraSx126xRxBoostedCheckBox" Content="SX126x RX Boosted Gain" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSx126x}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
 
-            <!-- Tab: Position -->
-            <TabItem Header="Position">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="10">
-                        <TextBlock Text="{DynamicResource StrNcGpsMode}" Margin="0,8,0,2"/>
-                        <ComboBox x:Name="GpsModeComboBox" Width="160" HorizontalAlignment="Left">
-                            <ComboBoxItem Content="{DynamicResource StrNcGpsDisabled}" Tag="0"/>
-                            <ComboBoxItem Content="{DynamicResource StrNcGpsActive}" Tag="1"/>
-                            <ComboBoxItem Content="{DynamicResource StrNcGpsNotPresent}" Tag="2"/>
-                        </ComboBox>
-                        <TextBlock Text="{DynamicResource StrNcPosBroadcast}" Margin="0,10,0,2"/>
-                        <TextBox x:Name="PosBroadcastSecsTextBox" Width="150" HorizontalAlignment="Left"/>
-                        <CheckBox x:Name="SmartBroadcastCheckBox" Content="{DynamicResource StrNcSmartBroadcast}" Margin="0,10,0,0"/>
-                        <TextBlock Text="{DynamicResource StrNcMinDistance}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="MinDistanceTextBox" Width="120" HorizontalAlignment="Left"/>
-                        <TextBlock Text="{DynamicResource StrNcMinSpeed}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="MinSpeedTextBox" Width="120" HorizontalAlignment="Left"/>
+                <!-- ═══════════════ POSITION ═══════════════ -->
+                <ScrollViewer x:Name="PanelPosition" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgConfig}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavPosition}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorConfig}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="{DynamicResource StrNcGpsMode}" Margin="0,0,0,2"/>
+                            <ComboBox x:Name="GpsModeComboBox" Width="180" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="{DynamicResource StrNcGpsDisabled}" Tag="0"/>
+                                <ComboBoxItem Content="{DynamicResource StrNcGpsActive}" Tag="1"/>
+                                <ComboBoxItem Content="{DynamicResource StrNcGpsNotPresent}" Tag="2"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescGpsMode}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcPosBroadcast}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="PosBroadcastSecsTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescPosBroadcast}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="SmartBroadcastCheckBox" Content="{DynamicResource StrNcSmartBroadcast}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSmartBroadcast}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcMinDistance}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="MinDistanceTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMinDistance}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcMinSpeed}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="MinSpeedTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMinSpeed}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcGpsUpdateInterval}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="GpsUpdateIntervalTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescGpsInterval}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
 
-            <!-- Tab: MQTT -->
-            <TabItem Header="MQTT">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="10">
-                        <CheckBox x:Name="MqttEnabledCheckBox" Content="{DynamicResource StrNcMqttEnabled}" Margin="0,8,0,8"/>
-                        <TextBlock Text="{DynamicResource StrNcMqttServer}" Margin="0,4,0,2"/>
-                        <TextBox x:Name="MqttAddressTextBox"/>
-                        <TextBlock Text="{DynamicResource StrNcMqttUsername}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="MqttUsernameTextBox"/>
-                        <TextBlock Text="{DynamicResource StrNcMqttPassword}" Margin="0,8,0,2"/>
-                        <PasswordBox x:Name="MqttPasswordBox"/>
-                        <CheckBox x:Name="MqttEncryptionCheckBox" Content="{DynamicResource StrNcMqttEncryption}" Margin="0,10,0,0"/>
-                        <CheckBox x:Name="MqttJsonCheckBox" Content="{DynamicResource StrNcMqttJson}" Margin="0,4,0,0"/>
-                        <CheckBox x:Name="MqttTlsCheckBox" Content="{DynamicResource StrNcMqttTls}" Margin="0,4,0,0"/>
-                        <TextBlock Text="{DynamicResource StrNcMqttRootTopic}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="MqttRootTextBox"/>
-                        <CheckBox x:Name="MqttProxyCheckBox" Content="Proxy to Client" Margin="0,10,0,0"/>
-                        <CheckBox x:Name="MqttMapReportingCheckBox" Content="{DynamicResource StrNcMqttMapReporting}" Margin="0,4,0,0"/>
+                <!-- ═══════════════ POWER ═══════════════ -->
+                <ScrollViewer x:Name="PanelPower" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgConfig}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavPower}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorConfig}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="PowerSavingCheckBox" Content="{DynamicResource StrNcPowerSaving}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescPowerSaving}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcShutdownAfterSecs}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="ShutdownAfterSecsTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescShutdownAfter}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcWaitBtSecs}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="WaitBtSecsTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescWaitBt}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSdsSecs}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="SdsSecsTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSds}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcLsSecs}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="LsSecsTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescLs}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcMinWakeSecs}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="MinWakeSecsTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMinWake}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
 
-            <!-- Tab: Telemetrie -->
-            <TabItem Header="{DynamicResource StrNcTabTelemetry}">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="10">
-                        <TextBlock Text="{DynamicResource StrNcDeviceTelemetry}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="DeviceTelemetryIntervalTextBox" Width="150" HorizontalAlignment="Left"/>
-                        <TextBlock Text="{DynamicResource StrNcEnvironmentInterval}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="EnvironmentIntervalTextBox" Width="150" HorizontalAlignment="Left"/>
-                        <CheckBox x:Name="FahrenheitCheckBox" Content="{DynamicResource StrNcFahrenheit}" Margin="0,10,0,0"/>
-                        <CheckBox x:Name="EnvironmentMeasurementCheckBox" Content="{DynamicResource StrNcEnvironmentMeasurement}" Margin="0,4,0,0"/>
-                        <TextBlock Text="{DynamicResource StrNcAirQualityInterval}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="AirQualityIntervalTextBox" Width="150" HorizontalAlignment="Left"/>
-                        <TextBlock Text="{DynamicResource StrNcPowerInterval}" Margin="0,8,0,2"/>
-                        <TextBox x:Name="PowerIntervalTextBox" Width="150" HorizontalAlignment="Left"/>
+                <!-- ═══════════════ NETWORK ═══════════════ -->
+                <ScrollViewer x:Name="PanelNetwork" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgConfig}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavNetwork}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorConfig}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="WifiEnabledCheckBox" Content="{DynamicResource StrNcWifiEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescWifiEnabled}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcWifiSsid}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="WifiSsidTextBox" MaxLength="32"/>
+                            <TextBlock Text="{DynamicResource StrNcDescWifiSsid}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcWifiPsk}" Margin="0,10,0,2"/>
+                            <Grid Height="30">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <!-- Actual edit box (starts collapsed, shown when eye is clicked) -->
+                                <TextBox x:Name="WifiPskBox" Grid.Column="0" Height="30" Visibility="Collapsed"/>
+                                <!-- Mask/placeholder (shown by default, hidden when editing) -->
+                                <TextBox x:Name="WifiPskMaskBox" Grid.Column="0" Height="30"
+                                         IsReadOnly="True" IsHitTestVisible="False"
+                                         Text="{DynamicResource StrNcWifiPskHint}"
+                                         Foreground="Gray" FontStyle="Italic"/>
+                                <ToggleButton x:Name="WifiPskToggle" Grid.Column="1"
+                                              Width="34" Height="30" Margin="4,0,0,0"
+                                              Content="👁"
+                                              ToolTip="{DynamicResource StrNcShowPassword}"
+                                              Checked="WifiPskToggle_Checked"
+                                              Unchecked="WifiPskToggle_Unchecked"/>
+                            </Grid>
+                            <TextBlock Text="{DynamicResource StrNcDescWifiPsk}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcNtpServer}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="NtpServerTextBox" MaxLength="64"/>
+                            <TextBlock Text="{DynamicResource StrNcDescNtpServer}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
 
-            <!-- Tab: Bluetooth -->
-            <TabItem Header="Bluetooth">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="10">
-                        <CheckBox x:Name="BtEnabledCheckBox" Content="{DynamicResource StrNcBtEnabled}" Margin="0,8,0,0"/>
-                        <TextBlock Text="{DynamicResource StrNcBtPairingMode}" Margin="0,12,0,2"/>
-                        <ComboBox x:Name="BtModeComboBox" Width="180" HorizontalAlignment="Left"
-                                  SelectionChanged="BtModeComboBox_SelectionChanged">
-                            <ComboBoxItem Content="{DynamicResource StrNcBtRandomPin}" Tag="0"/>
-                            <ComboBoxItem Content="{DynamicResource StrNcBtFixedPin}" Tag="1"/>
-                            <ComboBoxItem Content="{DynamicResource StrNcBtNoPin}" Tag="2"/>
-                        </ComboBox>
-                        <TextBlock Text="{DynamicResource StrNcBtFixedPinLabel}" Margin="0,10,0,2"
-                                   x:Name="BtFixedPinLabel"/>
-                        <TextBox x:Name="BtFixedPinTextBox" Width="120" HorizontalAlignment="Left"
-                                 MaxLength="6" IsEnabled="False"/>
-                        <TextBlock Margin="0,12,0,0" TextWrapping="Wrap" Foreground="Gray"
-                                   Text="{DynamicResource StrNcBtRebootHint}"/>
+                <!-- ═══════════════ DISPLAY ═══════════════ -->
+                <ScrollViewer x:Name="PanelDisplay" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgConfig}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavDisplay}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorConfig}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="{DynamicResource StrNcScreenOnSecs}" Margin="0,0,0,2"/>
+                            <TextBox x:Name="ScreenOnSecsTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescScreenOn}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcAutoCarouselSecs}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="AutoCarouselSecsTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescAutoCarousel}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="CompassNorthTopCheckBox" Content="{DynamicResource StrNcCompassNorthTop}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescCompassNorth}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="FlipScreenCheckBox" Content="{DynamicResource StrNcFlipScreen}" Margin="0,8,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescFlipScreen}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
-            </TabItem>
 
-        </TabControl>
+                <!-- ═══════════════ BLUETOOTH ═══════════════ -->
+                <ScrollViewer x:Name="PanelBluetooth" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgConfig}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavBluetooth}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorConfig}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="BtEnabledCheckBox" Content="{DynamicResource StrNcBtEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescBtEnabled}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcBtPairingMode}" Margin="0,12,0,2"/>
+                            <ComboBox x:Name="BtModeComboBox" Width="200" HorizontalAlignment="Left"
+                                      SelectionChanged="BtModeComboBox_SelectionChanged">
+                                <ComboBoxItem Content="{DynamicResource StrNcBtRandomPin}" Tag="0"/>
+                                <ComboBoxItem Content="{DynamicResource StrNcBtFixedPin}" Tag="1"/>
+                                <ComboBoxItem Content="{DynamicResource StrNcBtNoPin}" Tag="2"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescBtPairing}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcBtFixedPinLabel}" Margin="0,10,0,2" x:Name="BtFixedPinLabel"/>
+                            <TextBox x:Name="BtFixedPinTextBox" Width="120" HorizontalAlignment="Left" MaxLength="6" IsEnabled="False"/>
+                            <TextBlock Margin="0,14,0,0" TextWrapping="Wrap" Foreground="Gray"
+                                       Text="{DynamicResource StrNcBtRebootHint}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
 
-        <!-- Buttons -->
-        <Grid Grid.Row="2" Margin="0,10,0,0">
+                <!-- ═══════════════ MQTT ═══════════════ -->
+                <ScrollViewer x:Name="PanelMqtt" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavMqtt}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="MqttEnabledCheckBox" Content="{DynamicResource StrNcMqttEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttEnabled}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcMqttServer}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="MqttAddressTextBox"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttServer}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcMqttUsername}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="MqttUsernameTextBox"/>
+                            <TextBlock Text="{DynamicResource StrNcMqttPassword}" Margin="0,8,0,2"/>
+                            <PasswordBox x:Name="MqttPasswordBox" Height="30"/>
+                            <CheckBox x:Name="MqttEncryptionCheckBox" Content="{DynamicResource StrNcMqttEncryption}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttEncryption}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="MqttJsonCheckBox" Content="{DynamicResource StrNcMqttJson}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttJson}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="MqttTlsCheckBox" Content="{DynamicResource StrNcMqttTls}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcMqttRootTopic}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="MqttRootTextBox"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttRootTopic}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="MqttProxyCheckBox" Content="{DynamicResource StrNcMqttProxy}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttProxy}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="MqttMapReportingCheckBox" Content="{DynamicResource StrNcMqttMapReporting}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttMapReport}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ TELEMETRY ═══════════════ -->
+                <ScrollViewer x:Name="PanelTelemetry" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavTelemetry}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <TextBlock Text="{DynamicResource StrNcDeviceTelemetry}" Margin="0,0,0,2"/>
+                            <TextBox x:Name="DeviceTelemetryIntervalTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescDeviceTelemetry}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcEnvironmentInterval}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="EnvironmentIntervalTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescEnvTelemetry}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="EnvironmentMeasurementCheckBox" Content="{DynamicResource StrNcEnvironmentMeasurement}" Margin="0,8,0,0"/>
+                            <CheckBox x:Name="FahrenheitCheckBox" Content="{DynamicResource StrNcFahrenheit}" Margin="0,4,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcAirQualityInterval}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="AirQualityIntervalTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescAirQuality}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcPowerInterval}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="PowerIntervalTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescPowerTelemetry}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="PowerMeasurementCheckBox" Content="{DynamicResource StrNcPowerMeasurement}" Margin="0,8,0,0"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ NEIGHBOR INFO ═══════════════ -->
+                <ScrollViewer x:Name="PanelNeighborInfo" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavNeighborInfo}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="NiEnabledCheckBox" Content="{DynamicResource StrNcNiEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescNiEnabled}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcNiInterval}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="NiIntervalTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescNiInterval}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ STORE &amp; FORWARD ═══════════════ -->
+                <ScrollViewer x:Name="PanelStoreForward" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavStoreForward}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="SfEnabledCheckBox" Content="{DynamicResource StrNcSfEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSfEnabled}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="SfHeartbeatCheckBox" Content="{DynamicResource StrNcSfHeartbeat}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSfHeartbeat}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSfRecords}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="SfRecordsTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSfRecords}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSfHistoryMax}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="SfHistoryMaxTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSfHistoryMax}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSfHistoryWindow}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="SfHistoryWindowTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSfHistoryWindow}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ EXT. NOTIFICATION ═══════════════ -->
+                <ScrollViewer x:Name="PanelExtNotif" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavExtNotif}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="EnEnabledCheckBox" Content="{DynamicResource StrNcEnEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescEnEnabled}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcEnOutput}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="EnOutputTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescEnOutput}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcEnOutputMs}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="EnOutputMsTextBox" Width="120" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescEnOutputMs}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="EnActiveCheckBox" Content="{DynamicResource StrNcEnActiveHigh}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescEnActive}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="EnAlertMessageCheckBox" Content="{DynamicResource StrNcEnAlertMessage}" Margin="0,8,0,0"/>
+                            <CheckBox x:Name="EnAlertBellCheckBox" Content="{DynamicResource StrNcEnAlertBell}" Margin="0,4,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescEnBell}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ CANNED MESSAGES ═══════════════ -->
+                <ScrollViewer x:Name="PanelCannedMsg" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavCannedMsg}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="CmEnabledCheckBox" Content="{DynamicResource StrNcCmEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescCmEnabled}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="CmSendBellCheckBox" Content="{DynamicResource StrNcCmSendBell}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescCmSendBell}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcCmAllowInputSource}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="CmAllowInputSourceTextBox" Width="200" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescCmInput}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="CmRotary1CheckBox" Content="{DynamicResource StrNcCmRotary1}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescCmRotary}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="CmUpdown1CheckBox" Content="{DynamicResource StrNcCmUpdown1}" Margin="0,6,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescCmUpdown}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ RANGE TEST ═══════════════ -->
+                <ScrollViewer x:Name="PanelRangeTest" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavRangeTest}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="RtEnabledCheckBox" Content="{DynamicResource StrNcRtEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescRtEnabled}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcRtSender}" Margin="0,12,0,2"/>
+                            <TextBox x:Name="RtSenderTextBox" Width="160" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescRtSender}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="RtSaveCheckBox" Content="{DynamicResource StrNcRtSave}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescRtSave}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ═══════════════ SERIAL ═══════════════ -->
+                <ScrollViewer x:Name="PanelSerial" Visibility="Collapsed" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="0,0,16,12">
+                        <Border Background="{StaticResource BgModule}" Padding="16,10" Margin="0,0,0,12">
+                            <TextBlock Text="{DynamicResource StrNcNavSerial}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource ColorModule}"/>
+                        </Border>
+                        <StackPanel Margin="16,0,0,0">
+                            <CheckBox x:Name="SerEnabledCheckBox" Content="{DynamicResource StrNcSerEnabled}" Margin="0,0,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSerEnabled}" Style="{StaticResource DescStyle}"/>
+                            <CheckBox x:Name="SerEchoCheckBox" Content="{DynamicResource StrNcSerEcho}" Margin="0,10,0,0"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSerEcho}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSerRxd}" Margin="0,10,0,2"/>
+                            <TextBox x:Name="SerRxdTextBox" Width="80" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcSerTxd}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="SerTxdTextBox" Width="80" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSerPins}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSerBaud}" Margin="0,8,0,2"/>
+                            <ComboBox x:Name="SerBaudComboBox" Width="160" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="Default (38400)" Tag="0"/>
+                                <ComboBoxItem Content="110 Baud" Tag="1"/>
+                                <ComboBoxItem Content="300 Baud" Tag="2"/>
+                                <ComboBoxItem Content="600 Baud" Tag="3"/>
+                                <ComboBoxItem Content="1200 Baud" Tag="4"/>
+                                <ComboBoxItem Content="2400 Baud" Tag="5"/>
+                                <ComboBoxItem Content="4800 Baud" Tag="6"/>
+                                <ComboBoxItem Content="9600 Baud" Tag="7"/>
+                                <ComboBoxItem Content="19200 Baud" Tag="8"/>
+                                <ComboBoxItem Content="38400 Baud" Tag="9"/>
+                                <ComboBoxItem Content="57600 Baud" Tag="10"/>
+                                <ComboBoxItem Content="115200 Baud" Tag="11"/>
+                                <ComboBoxItem Content="230400 Baud" Tag="12"/>
+                                <ComboBoxItem Content="460800 Baud" Tag="13"/>
+                                <ComboBoxItem Content="921600 Baud" Tag="14"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcSerTimeout}" Margin="0,8,0,2"/>
+                            <TextBox x:Name="SerTimeoutTextBox" Width="100" HorizontalAlignment="Left"/>
+                            <TextBlock Text="{DynamicResource StrNcDescSerTimeout}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcSerMode}" Margin="0,8,0,2"/>
+                            <ComboBox x:Name="SerModeComboBox" Width="200" HorizontalAlignment="Left">
+                                <ComboBoxItem Content="DEFAULT — Textnachrichten" Tag="0"/>
+                                <ComboBoxItem Content="SIMPLE — einfache Ausgabe" Tag="1"/>
+                                <ComboBoxItem Content="PROTO — Protobuf binär" Tag="2"/>
+                                <ComboBoxItem Content="TEXTMSG — nur Text-Pakete" Tag="3"/>
+                                <ComboBoxItem Content="NMEA — GPS NMEA-Sätze" Tag="4"/>
+                                <ComboBoxItem Content="CALTOPO — CalTopo/SARTopo" Tag="5"/>
+                            </ComboBox>
+                            <TextBlock Text="{DynamicResource StrNcDescSerMode}" Style="{StaticResource DescStyle}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+            </Grid>
+        </Grid>
+
+        <!-- Bottom buttons -->
+        <Grid Grid.Row="2" Margin="12,8,12,10">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
                 <Button Content="{DynamicResource StrNcNodeDbReset}" Width="180"
                         ToolTip="{DynamicResource StrNcNodeDbResetTip}"

--- a/MeshhessenClient/NodeConfigWindow.xaml
+++ b/MeshhessenClient/NodeConfigWindow.xaml
@@ -408,6 +408,10 @@
                                         <Button x:Name="PickFromMapButton" Click="PickFromMap_Click"
                                                 Content="{DynamicResource StrNcPickFromMap}"
                                                 ToolTip="{DynamicResource StrNcPickFromMapTip}"
+                                                Padding="10,4" Margin="0,0,8,0"/>
+                                        <Button x:Name="UseCurrentPosButton" Click="UseCurrentPosition_Click"
+                                                Content="{DynamicResource StrNcUseCurrentPos}"
+                                                ToolTip="{DynamicResource StrNcUseCurrentPosTip}"
                                                 Padding="10,4" Margin="0,0,10,0"/>
                                         <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="Gray">
                                             <Run Text="{DynamicResource StrNcMapCenterLabel}"/><Run Text=" "/><Run x:Name="MapCenterCoordRun" Text="–"/>
@@ -642,6 +646,9 @@
                             <TextBlock Text="{DynamicResource StrNcDescMqttProxy}" Style="{StaticResource DescStyle}"/>
                             <CheckBox x:Name="MqttMapReportingCheckBox" Content="{DynamicResource StrNcMqttMapReporting}" Margin="0,6,0,0"/>
                             <TextBlock Text="{DynamicResource StrNcDescMqttMapReport}" Style="{StaticResource DescStyle}"/>
+                            <TextBlock Text="{DynamicResource StrNcMqttMapReportPrecision}" Margin="0,8,0,2"/>
+                            <ComboBox x:Name="MqttMapReportPrecisionComboBox" Width="160" HorizontalAlignment="Left" FontSize="12" Height="26"/>
+                            <TextBlock Text="{DynamicResource StrNcDescMqttMapReportPrecision}" Style="{StaticResource DescStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
@@ -899,11 +906,11 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="#" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
-                                <TextBlock Grid.Column="1" Text="Role" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
-                                <TextBlock Grid.Column="2" Text="Name" FontWeight="SemiBold" FontSize="11" Foreground="Gray" Margin="4,0"/>
+                                <TextBlock Grid.Column="1" Text="{DynamicResource StrNcChannelRole}" FontWeight="SemiBold" FontSize="11" Foreground="Gray"/>
+                                <TextBlock Grid.Column="2" Text="{DynamicResource StrNcChannelName}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" Margin="4,0"/>
                                 <TextBlock Grid.Column="3" Text="{DynamicResource StrNcChannelUplink}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
                                 <TextBlock Grid.Column="4" Text="{DynamicResource StrNcChannelDownlink}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
                                 <TextBlock Grid.Column="5" Text="{DynamicResource StrNcChannelPosPrecision}" FontWeight="SemiBold" FontSize="11" Foreground="Gray" HorizontalAlignment="Center"/>
@@ -918,7 +925,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="0" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch0Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
@@ -935,7 +942,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="1" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch1Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
@@ -952,7 +959,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="2" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch2Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
@@ -969,7 +976,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="3" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch3Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
@@ -986,7 +993,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="4" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch4Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
@@ -1003,7 +1010,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="5" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch5Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
@@ -1020,7 +1027,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="6" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch6Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>
@@ -1037,7 +1044,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="58"/>
                                     <ColumnDefinition Width="68"/>
-                                    <ColumnDefinition Width="96"/>
+                                    <ColumnDefinition Width="116"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="7" VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
                                 <TextBlock x:Name="Ch7Role" Grid.Column="1" VerticalAlignment="Center" FontSize="10" Foreground="DarkGray"/>

--- a/MeshhessenClient/NodeConfigWindow.xaml
+++ b/MeshhessenClient/NodeConfigWindow.xaml
@@ -402,10 +402,17 @@
                                         </StackPanel>
                                     </Grid>
                                     <TextBlock Text="{DynamicResource StrNcDescFixedCoords}" Style="{StaticResource DescStyle}" Margin="0,6,0,6"/>
-                                    <Button x:Name="PickFromMapButton" Click="PickFromMap_Click"
-                                            Content="{DynamicResource StrNcPickFromMap}"
-                                            ToolTip="{DynamicResource StrNcPickFromMapTip}"
-                                            HorizontalAlignment="Left" Padding="10,4"/>
+                                    <TextBlock Text="{DynamicResource StrNcPickFromMapHint}"
+                                               FontSize="11" Foreground="Gray" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,0,4">
+                                        <Button x:Name="PickFromMapButton" Click="PickFromMap_Click"
+                                                Content="{DynamicResource StrNcPickFromMap}"
+                                                ToolTip="{DynamicResource StrNcPickFromMapTip}"
+                                                Padding="10,4" Margin="0,0,10,0"/>
+                                        <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="Gray">
+                                            <Run Text="{DynamicResource StrNcMapCenterLabel}"/><Run Text=" "/><Run x:Name="MapCenterCoordRun" Text="–"/>
+                                        </TextBlock>
+                                    </StackPanel>
                                 </StackPanel>
                             </Border>
                             <TextBlock Text="{DynamicResource StrNcPosBroadcast}" Margin="0,12,0,2"/>

--- a/MeshhessenClient/NodeConfigWindow.xaml.cs
+++ b/MeshhessenClient/NodeConfigWindow.xaml.cs
@@ -12,6 +12,8 @@ public partial class NodeConfigWindow : Window
 {
     private readonly MeshtasticProtocolService _protocolService;
     private Func<(double lat, double lon)?>? _mapCenterProvider;
+    private Func<(double lat, double lon)?>? _myPosProvider;
+    private Func<Mapsui.Tiling.Layers.TileLayer>? _tileLayerFactory;
 
     // Loaded configs (for clone-and-update pattern)
     private User?                      _loadedOwner;
@@ -42,11 +44,13 @@ public partial class NodeConfigWindow : Window
     // Map Tag → content panel
     private Dictionary<string, FrameworkElement> _panels = new();
 
-    public NodeConfigWindow(MeshtasticProtocolService protocolService, Func<(double lat, double lon)?>? mapCenterProvider = null)
+    public NodeConfigWindow(MeshtasticProtocolService protocolService, Func<(double lat, double lon)?>? mapCenterProvider = null, Func<(double lat, double lon)?>? myPosProvider = null, Func<Mapsui.Tiling.Layers.TileLayer>? tileLayerFactory = null)
     {
         InitializeComponent();
         _protocolService = protocolService;
         _mapCenterProvider = mapCenterProvider;
+        _myPosProvider = myPosProvider;
+        _tileLayerFactory = tileLayerFactory;
 
         // Wire up events
         _protocolService.OwnerReceived                    += OnOwnerReceived;
@@ -424,6 +428,7 @@ public partial class NodeConfigWindow : Window
             MqttRootTextBox.Text               = config.Root;
             MqttProxyCheckBox.IsChecked        = config.ProxyToClientEnabled;
             MqttMapReportingCheckBox.IsChecked = config.MapReportingEnabled;
+            SelectComboBoxByTag(MqttMapReportPrecisionComboBox, (int)config.MapReportPrecision);
             MarkReceived("mqtt");
         });
     }
@@ -680,24 +685,42 @@ public partial class NodeConfigWindow : Window
 
     // ========== Precision ComboBox helpers ==========
 
-    private static readonly (string Label, uint Value)[] PrecisionOptions =
+    private static readonly (string LabelKey, string Distance, uint Value)[] PrecisionOptions =
     {
-        ("Kein Standort", 0),
-        ("~23km",        10),
-        ("~2.9km",       13),
-        ("~360m",        16),
-        ("~45m",         19),
-        ("Genau",        32),
+        ("StrNcPrecNone", "",       0),
+        ("",              "~23km",  10),
+        ("",              "~11km",  11),
+        ("",              "~5.7km", 12),
+        ("",              "~2.9km", 13),
+        ("",              "~1.4km", 14),
+        ("",              "~720m",  15),
+        ("",              "~360m",  16),
+        ("",              "~180m",  17),
+        ("",              "~90m",   18),
+        ("",              "~45m",   19),
+        ("StrNcPrecExact","",       32),
     };
+
+    private string PrecisionLabel(int index)
+    {
+        var (key, dist, _) = PrecisionOptions[index];
+        if (!string.IsNullOrEmpty(key)) return Loc(key);
+        return dist;
+    }
 
     private void InitPrecisionComboBoxes()
     {
         foreach (var cb in new[] { Ch0Precision, Ch1Precision, Ch2Precision, Ch3Precision,
-                                   Ch4Precision, Ch5Precision, Ch6Precision, Ch7Precision })
+                                   Ch4Precision, Ch5Precision, Ch6Precision, Ch7Precision,
+                                   MqttMapReportPrecisionComboBox })
         {
+            if (cb == null) continue;
             cb.Items.Clear();
-            foreach (var (label, value) in PrecisionOptions)
-                cb.Items.Add(new ComboBoxItem { Content = label, Tag = value.ToString() });
+            for (int i = 0; i < PrecisionOptions.Length; i++)
+            {
+                var (_, _, value) = PrecisionOptions[i];
+                cb.Items.Add(new ComboBoxItem { Content = PrecisionLabel(i), Tag = value.ToString() });
+            }
             cb.SelectedIndex = 0;
         }
     }
@@ -732,15 +755,43 @@ public partial class NodeConfigWindow : Window
 
     private void PickFromMap_Click(object sender, RoutedEventArgs e)
     {
-        if (_mapCenterProvider == null)
+        // Get initial center: prefer current fixed-pos values, fall back to mapCenterProvider
+        double initLat = 50.5, initLon = 9.0;
+        if (double.TryParse(FixedLatTextBox.Text, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out double parsedLat) &&
+            double.TryParse(FixedLonTextBox.Text, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out double parsedLon) &&
+            parsedLat != 0 && parsedLon != 0)
         {
-            MessageBox.Show("Kein Kartenkontext verfügbar.", "Hinweis", MessageBoxButton.OK, MessageBoxImage.Information);
+            initLat = parsedLat;
+            initLon = parsedLon;
+        }
+        else if (_mapCenterProvider != null)
+        {
+            var center = _mapCenterProvider();
+            if (center.HasValue) { initLat = center.Value.lat; initLon = center.Value.lon; }
+        }
+
+        var picker = new MapPickerWindow(initLat, initLon, _tileLayerFactory) { Owner = this };
+        if (picker.ShowDialog() == true && picker.SelectedPosition.HasValue)
+        {
+            FixedLatTextBox.Text = picker.SelectedPosition.Value.lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+            FixedLonTextBox.Text = picker.SelectedPosition.Value.lon.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+            RefreshMapCenterHint();
+        }
+    }
+
+    private void UseCurrentPosition_Click(object sender, RoutedEventArgs e)
+    {
+        if (_myPosProvider == null)
+        {
+            MessageBox.Show(Loc("StrHint"), Loc("StrHint"), MessageBoxButton.OK, MessageBoxImage.Information);
             return;
         }
-        var pos = _mapCenterProvider();
-        if (pos == null)
+        var pos = _myPosProvider();
+        if (pos == null || (pos.Value.lat == 0 && pos.Value.lon == 0))
         {
-            MessageBox.Show("Konnte Kartenposition nicht lesen.", "Hinweis", MessageBoxButton.OK, MessageBoxImage.Information);
+            MessageBox.Show(Loc("StrHint"), Loc("StrHint"), MessageBoxButton.OK, MessageBoxImage.Information);
             return;
         }
         FixedLatTextBox.Text = pos.Value.lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
@@ -989,6 +1040,7 @@ public partial class NodeConfigWindow : Window
             newMqtt.Root                 = MqttRootTextBox.Text.Trim();
             newMqtt.ProxyToClientEnabled = MqttProxyCheckBox.IsChecked == true;
             newMqtt.MapReportingEnabled  = MqttMapReportingCheckBox.IsChecked == true;
+            newMqtt.MapReportPrecision   = (uint)GetComboBoxTag(MqttMapReportPrecisionComboBox);
             await _protocolService.SetMqttConfigAsync(newMqtt);
             await Delay();
 

--- a/MeshhessenClient/NodeConfigWindow.xaml.cs
+++ b/MeshhessenClient/NodeConfigWindow.xaml.cs
@@ -1,7 +1,9 @@
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
+using Google.Protobuf;
 using Meshtastic.Protobufs;
+using MeshhessenClient.Models;
 using MeshhessenClient.Services;
 
 namespace MeshhessenClient;
@@ -27,8 +29,14 @@ public partial class NodeConfigWindow : Window
     private CannedMessageConfig?       _loadedCannedMsg;
     private RangeTestConfig?           _loadedRangeTest;
     private SerialConfig?              _loadedSerial;
+    private SecurityConfig?            _loadedSecurity;
+    private readonly ChannelInfo?[] _loadedChannels = new ChannelInfo?[8];
 
-    private int _pendingRequests = 0;
+    // Loading progress tracking
+    private readonly HashSet<string> _expectedConfigs = new();
+    private readonly HashSet<string> _receivedConfigs = new();
+    private System.Threading.Timer? _loadingTimeoutTimer;
+    private bool _loadingDone;
 
     // Map Tag → content panel
     private Dictionary<string, FrameworkElement> _panels = new();
@@ -55,9 +63,12 @@ public partial class NodeConfigWindow : Window
         _protocolService.CannedMessageConfigReceived      += OnCannedMsgConfigReceived;
         _protocolService.RangeTestConfigReceived          += OnRangeTestConfigReceived;
         _protocolService.SerialConfigReceived             += OnSerialConfigReceived;
+        _protocolService.SecurityConfigReceived           += OnSecurityConfigReceived;
+        _protocolService.ChannelInfoReceived              += OnChannelInfoReceived;
 
         Closed += (s, e) =>
         {
+            _loadingTimeoutTimer?.Dispose();
             _protocolService.OwnerReceived                    -= OnOwnerReceived;
             _protocolService.DeviceConfigReceived             -= OnDeviceConfigReceived;
             _protocolService.PositionConfigReceived           -= OnPositionConfigReceived;
@@ -74,6 +85,8 @@ public partial class NodeConfigWindow : Window
             _protocolService.CannedMessageConfigReceived      -= OnCannedMsgConfigReceived;
             _protocolService.RangeTestConfigReceived          -= OnRangeTestConfigReceived;
             _protocolService.SerialConfigReceived             -= OnSerialConfigReceived;
+            _protocolService.SecurityConfigReceived           -= OnSecurityConfigReceived;
+            _protocolService.ChannelInfoReceived              -= OnChannelInfoReceived;
         };
 
         Loaded += (s, e) =>
@@ -97,6 +110,8 @@ public partial class NodeConfigWindow : Window
                 ["CannedMsg"]   = PanelCannedMsg,
                 ["RangeTest"]   = PanelRangeTest,
                 ["Serial"]      = PanelSerial,
+                ["Security"]    = PanelSecurity,
+                ["Channels"]    = PanelChannels,
             };
 
             // Select first real item (User)
@@ -126,9 +141,36 @@ public partial class NodeConfigWindow : Window
     {
         try
         {
-            _pendingRequests = 16;
-            UpdateStatus("Lade Konfiguration...");
+            _loadingDone = false;
+            _expectedConfigs.Clear();
+            _receivedConfigs.Clear();
+
+            // Register all configs we expect to receive
+            _expectedConfigs.UnionWith(new[]
+            {
+                "owner", "device", "lora", "position", "power", "network",
+                "display", "bluetooth", "mqtt", "telemetry", "neighborinfo",
+                "storeforward", "extnotif", "cannedmsg", "rangetest", "serial",
+                "security",
+                "ch0", "ch1", "ch2", "ch3", "ch4", "ch5", "ch6", "ch7"
+            });
+
+            UpdateStatus(Loc("StrNcLoadingProgress", "0", _expectedConfigs.Count.ToString()));
             SaveButton.IsEnabled = false;
+
+            // Start 30-second timeout
+            _loadingTimeoutTimer?.Dispose();
+            _loadingTimeoutTimer = new System.Threading.Timer(_ =>
+            {
+                Dispatcher.BeginInvoke(() =>
+                {
+                    if (_loadingDone) return;
+                    _loadingDone = true;
+                    var missing = _expectedConfigs.Except(_receivedConfigs).ToList();
+                    UpdateStatus(Loc("StrNcLoadingTimeout", string.Join(", ", missing)));
+                    SaveButton.IsEnabled = true;
+                });
+            }, null, 30000, System.Threading.Timeout.Infinite);
 
             await _protocolService.RequestOwnerAsync();
             await Delay();
@@ -161,6 +203,15 @@ public partial class NodeConfigWindow : Window
             await _protocolService.RequestRangeTestConfigAsync();
             await Delay();
             await _protocolService.RequestSerialConfigAsync();
+            await Delay();
+            await _protocolService.RequestSecurityConfigAsync();
+            await Delay();
+            // Request channels 0-7
+            for (int i = 0; i < 8; i++)
+            {
+                await _protocolService.RequestChannelConfigAsync(i);
+                await Delay();
+            }
         }
         catch (Exception ex)
         {
@@ -171,14 +222,30 @@ public partial class NodeConfigWindow : Window
     private static System.Threading.Tasks.Task Delay() =>
         System.Threading.Tasks.Task.Delay(200);
 
-    private void CheckAllLoaded()
+    private string Loc(string key, params string[] args)
     {
-        _pendingRequests--;
-        if (_pendingRequests <= 0)
+        var raw = (string?)Application.Current.TryFindResource(key) ?? key;
+        for (int i = 0; i < args.Length; i++)
+            raw = raw.Replace($"{{{i}}}", args[i]);
+        return raw;
+    }
+
+    private void MarkReceived(string key)
+    {
+        _receivedConfigs.Add(key);
+        if (_loadingDone) return;
+
+        var rcv = _receivedConfigs.Count;
+        var exp = _expectedConfigs.Count;
+        UpdateStatus(Loc("StrNcLoadingProgress", rcv.ToString(), exp.ToString()));
+
+        if (_receivedConfigs.IsSupersetOf(_expectedConfigs))
         {
-            var msg = (string?)Application.Current.TryFindResource("StrNcConfigLoaded")
-                      ?? "Configuration loaded.";
-            UpdateStatus(msg);
+            _loadingDone = true;
+            _loadingTimeoutTimer?.Dispose();
+            UpdateStatus(Loc("StrNcConfigLoaded") != "StrNcConfigLoaded"
+                ? Loc("StrNcConfigLoaded")
+                : "Konfiguration geladen.");
             SaveButton.IsEnabled = true;
         }
     }
@@ -219,7 +286,9 @@ public partial class NodeConfigWindow : Window
         {
             LongNameTextBox.Text  = user.LongName;
             ShortNameTextBox.Text = user.ShortName;
-            CheckAllLoaded();
+            IsLicensedCheckBox.IsChecked     = user.IsLicensed;
+            IsUnmessagableCheckBox.IsChecked = user.IsUnmessagable;
+            MarkReceived("owner");
         });
     }
 
@@ -230,11 +299,14 @@ public partial class NodeConfigWindow : Window
         {
             SelectComboBoxByTag(RoleComboBox, (int)config.Role);
             SelectComboBoxByTag(RebroadcastComboBox, (int)config.RebroadcastMode);
-            NodeInfoIntervalTextBox.Text  = SecondsToHumanTime(config.NodeInfoBroadcastSecs);
-            TzdefTextBox.Text             = config.Tzdef;
-            LedHeartbeatCheckBox.IsChecked = config.LedHeartbeatDisabled;
-            DoubleTapCheckBox.IsChecked   = config.DoubleTapAsButtonPress;
-            CheckAllLoaded();
+            NodeInfoIntervalTextBox.Text    = SecondsToHumanTime(config.NodeInfoBroadcastSecs);
+            TzdefTextBox.Text               = config.Tzdef;
+            LedHeartbeatCheckBox.IsChecked  = config.LedHeartbeatDisabled;
+            DoubleTapCheckBox.IsChecked     = config.DoubleTapAsButtonPress;
+            DisableTripleClickCheckBox.IsChecked = config.DisableTripleClick;
+            ButtonGpioTextBox.Text          = config.ButtonGpio > 0 ? config.ButtonGpio.ToString() : string.Empty;
+            BuzzerGpioTextBox.Text          = config.BuzzerGpio > 0 ? config.BuzzerGpio.ToString() : string.Empty;
+            MarkReceived("device");
         });
     }
 
@@ -244,12 +316,16 @@ public partial class NodeConfigWindow : Window
         Dispatcher.BeginInvoke(() =>
         {
             SelectComboBoxByTag(GpsModeComboBox, (int)config.GpsMode);
-            PosBroadcastSecsTextBox.Text  = SecondsToHumanTime(config.PositionBroadcastSecs);
+            FixedPositionCheckBox.IsChecked  = config.FixedPosition;
+            PosBroadcastSecsTextBox.Text     = SecondsToHumanTime(config.PositionBroadcastSecs);
             SmartBroadcastCheckBox.IsChecked = config.PositionBroadcastSmartEnabled;
-            MinDistanceTextBox.Text       = config.PositionBroadcastSmartMinimumDistance.ToString();
-            MinSpeedTextBox.Text          = config.PositionBroadcastSmartMinimumSpeed.ToString();
-            GpsUpdateIntervalTextBox.Text = config.GpsUpdateInterval.ToString();
-            CheckAllLoaded();
+            MinDistanceTextBox.Text          = config.BroadcastSmartMinimumDistance.ToString();
+            MinIntervalSecsTextBox.Text      = config.BroadcastSmartMinimumIntervalSecs.ToString();
+            GpsUpdateIntervalTextBox.Text    = config.GpsUpdateInterval.ToString();
+            GpsRxGpioTextBox.Text            = config.RxGpio > 0 ? config.RxGpio.ToString() : string.Empty;
+            GpsTxGpioTextBox.Text            = config.TxGpio > 0 ? config.TxGpio.ToString() : string.Empty;
+            GpsEnGpioTextBox.Text            = config.GpsEnGpio > 0 ? config.GpsEnGpio.ToString() : string.Empty;
+            MarkReceived("position");
         });
     }
 
@@ -261,14 +337,17 @@ public partial class NodeConfigWindow : Window
             SelectComboBoxByTag(LoraRegionComboBox, (int)config.Region, keepIfNotFound: true);
             LoraUsePresetCheckBox.IsChecked = config.UsePreset;
             SelectComboBoxByTag(LoraPresetComboBox, (int)config.ModemPreset, keepIfNotFound: true);
-            LoraPresetComboBox.IsEnabled   = config.UsePreset;
-            HopLimitTextBox.Text           = config.HopLimit.ToString();
-            TxEnabledCheckBox.IsChecked    = config.TxEnabled;
-            TxPowerTextBox.Text            = ((int)config.TxPower).ToString();
-            LoraChannelNumTextBox.Text     = config.ChannelNum.ToString();
+            LoraPresetComboBox.IsEnabled    = config.UsePreset;
+            HopLimitTextBox.Text            = config.HopLimit.ToString();
+            TxEnabledCheckBox.IsChecked     = config.TxEnabled;
+            TxPowerTextBox.Text             = config.TxPower.ToString();
+            LoraChannelNumTextBox.Text      = config.ChannelNum.ToString();
             LoraOverrideDutyCycleCheckBox.IsChecked = config.OverrideDutyCycle;
             LoraSx126xRxBoostedCheckBox.IsChecked   = config.Sx126XRxBoostedGain;
-            CheckAllLoaded();
+            LoraIgnoreMqttCheckBox.IsChecked = config.IgnoreMqtt;
+            LoraOkToMqttCheckBox.IsChecked   = config.ConfigOkToMqtt;
+            LoraOverrideFreqTextBox.Text     = config.OverrideFrequency > 0 ? config.OverrideFrequency.ToString("F3") : string.Empty;
+            MarkReceived("lora");
         });
     }
 
@@ -283,7 +362,9 @@ public partial class NodeConfigWindow : Window
             SdsSecsTextBox.Text             = config.SdsSecs.ToString();
             LsSecsTextBox.Text              = config.LsSecs.ToString();
             MinWakeSecsTextBox.Text         = config.MinWakeSecs.ToString();
-            CheckAllLoaded();
+            AdcMultTextBox.Text             = config.AdcMultiplierOverride > 0 ? config.AdcMultiplierOverride.ToString("F2") : string.Empty;
+            BatteryInaAddrTextBox.Text      = config.DeviceBatteryInaAddress > 0 ? $"0x{config.DeviceBatteryInaAddress:X2}" : string.Empty;
+            MarkReceived("power");
         });
     }
 
@@ -296,7 +377,10 @@ public partial class NodeConfigWindow : Window
             WifiSsidTextBox.Text          = config.WifiSsid;
             WifiPskBox.Text               = config.WifiPsk;   // device always returns empty (security)
             NtpServerTextBox.Text         = config.NtpServer;
-            CheckAllLoaded();
+            EthEnabledCheckBox.IsChecked  = config.EthEnabled;
+            SelectComboBoxByTag(AddressModeComboBox, (int)config.AddressMode);
+            RsyslogServerTextBox.Text     = config.RsyslogServer;
+            MarkReceived("network");
         });
     }
 
@@ -309,7 +393,14 @@ public partial class NodeConfigWindow : Window
             AutoCarouselSecsTextBox.Text      = config.AutoScreenCarouselSecs.ToString();
             CompassNorthTopCheckBox.IsChecked = config.CompassNorthTop;
             FlipScreenCheckBox.IsChecked      = config.FlipScreen;
-            CheckAllLoaded();
+            HeadingBoldCheckBox.IsChecked     = config.HeadingBold;
+            WakeOnTapCheckBox.IsChecked       = config.WakeOnTapOrMotion;
+            Use12hClockCheckBox.IsChecked     = config.Use12HClock;
+            SelectComboBoxByTag(DisplayUnitsComboBox, (int)config.Units);
+            SelectComboBoxByTag(DisplayModeComboBox, (int)config.Displaymode);
+            SelectComboBoxByTag(OledTypeComboBox, (int)config.Oled);
+            SelectComboBoxByTag(CompassOrientationComboBox, (int)config.CompassOrientation);
+            MarkReceived("display");
         });
     }
 
@@ -318,17 +409,17 @@ public partial class NodeConfigWindow : Window
         _loadedMqtt = config;
         Dispatcher.BeginInvoke(() =>
         {
-            MqttEnabledCheckBox.IsChecked    = config.Enabled;
-            MqttAddressTextBox.Text          = config.Address;
-            MqttUsernameTextBox.Text         = config.Username;
-            MqttPasswordBox.Password         = config.Password;
-            MqttEncryptionCheckBox.IsChecked = config.EncryptionEnabled;
-            MqttJsonCheckBox.IsChecked       = config.JsonEnabled;
-            MqttTlsCheckBox.IsChecked        = config.TlsEnabled;
-            MqttRootTextBox.Text             = config.Root;
-            MqttProxyCheckBox.IsChecked      = config.ProxyToClientEnabled;
+            MqttEnabledCheckBox.IsChecked      = config.Enabled;
+            MqttAddressTextBox.Text            = config.Address;
+            MqttUsernameTextBox.Text           = config.Username;
+            MqttPasswordBox.Text               = config.Password;
+            MqttEncryptionCheckBox.IsChecked   = config.EncryptionEnabled;
+            MqttJsonCheckBox.IsChecked         = config.JsonEnabled;
+            MqttTlsCheckBox.IsChecked          = config.TlsEnabled;
+            MqttRootTextBox.Text               = config.Root;
+            MqttProxyCheckBox.IsChecked        = config.ProxyToClientEnabled;
             MqttMapReportingCheckBox.IsChecked = config.MapReportingEnabled;
-            CheckAllLoaded();
+            MarkReceived("mqtt");
         });
     }
 
@@ -344,7 +435,7 @@ public partial class NodeConfigWindow : Window
             AirQualityIntervalTextBox.Text       = SecondsToHumanTime(config.AirQualityInterval);
             PowerIntervalTextBox.Text            = SecondsToHumanTime(config.PowerUpdateInterval);
             PowerMeasurementCheckBox.IsChecked   = config.PowerMeasurementEnabled;
-            CheckAllLoaded();
+            MarkReceived("telemetry");
         });
     }
 
@@ -357,7 +448,7 @@ public partial class NodeConfigWindow : Window
             SelectComboBoxByTag(BtModeComboBox, (int)config.Mode);
             BtFixedPinTextBox.Text      = config.FixedPin > 0 ? config.FixedPin.ToString() : string.Empty;
             BtFixedPinTextBox.IsEnabled = config.Mode == 1;
-            CheckAllLoaded();
+            MarkReceived("bluetooth");
         });
     }
 
@@ -368,7 +459,7 @@ public partial class NodeConfigWindow : Window
         {
             NiEnabledCheckBox.IsChecked = config.Enabled;
             NiIntervalTextBox.Text      = SecondsToHumanTime(config.UpdateInterval);
-            CheckAllLoaded();
+            MarkReceived("neighborinfo");
         });
     }
 
@@ -382,7 +473,7 @@ public partial class NodeConfigWindow : Window
             SfRecordsTextBox.Text          = config.Records.ToString();
             SfHistoryMaxTextBox.Text       = config.HistoryReturnMax.ToString();
             SfHistoryWindowTextBox.Text    = config.HistoryReturnWindow.ToString();
-            CheckAllLoaded();
+            MarkReceived("storeforward");
         });
     }
 
@@ -397,7 +488,7 @@ public partial class NodeConfigWindow : Window
             EnActiveCheckBox.IsChecked       = config.Active;
             EnAlertMessageCheckBox.IsChecked = config.AlertMessage;
             EnAlertBellCheckBox.IsChecked    = config.AlertBell;
-            CheckAllLoaded();
+            MarkReceived("extnotif");
         });
     }
 
@@ -411,7 +502,7 @@ public partial class NodeConfigWindow : Window
             CmAllowInputSourceTextBox.Text     = config.AllowInputSource;
             CmRotary1CheckBox.IsChecked        = config.Rotary1Enabled;
             CmUpdown1CheckBox.IsChecked        = config.Updown1Enabled;
-            CheckAllLoaded();
+            MarkReceived("cannedmsg");
         });
     }
 
@@ -423,7 +514,7 @@ public partial class NodeConfigWindow : Window
             RtEnabledCheckBox.IsChecked = config.Enabled;
             RtSenderTextBox.Text        = config.Sender.ToString();
             RtSaveCheckBox.IsChecked    = config.Save;
-            CheckAllLoaded();
+            MarkReceived("rangetest");
         });
     }
 
@@ -439,7 +530,56 @@ public partial class NodeConfigWindow : Window
             SelectComboBoxByTag(SerBaudComboBox, (int)config.Baud);
             SerTimeoutTextBox.Text       = config.Timeout.ToString();
             SelectComboBoxByTag(SerModeComboBox, (int)config.Mode);
-            CheckAllLoaded();
+            MarkReceived("serial");
+        });
+    }
+
+    private void OnSecurityConfigReceived(object? sender, SecurityConfig config)
+    {
+        _loadedSecurity = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            // Public key: hex display (read-only)
+            SecPublicKeyTextBox.Text = config.PublicKey != null && config.PublicKey.Length > 0
+                ? BitConverter.ToString(config.PublicKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
+                : string.Empty;
+
+            // Admin keys: one Base64 per line
+            SecAdminKeyTextBox.Text = string.Join(Environment.NewLine,
+                config.AdminKey.Select(k => Convert.ToBase64String(k.ToByteArray())));
+
+            SecSerialEnabledCheckBox.IsChecked = config.SerialEnabled;
+            SecDebugLogCheckBox.IsChecked      = config.DebugLogApiEnabled;
+            SecIsManagedCheckBox.IsChecked     = config.IsManaged;
+            SecAdminChannelCheckBox.IsChecked  = config.AdminChannelEnabled;
+            MarkReceived("security");
+        });
+    }
+
+    private void OnChannelInfoReceived(object? sender, ChannelInfo info)
+    {
+        if (info.Index < 0 || info.Index >= 8) return;
+        _loadedChannels[info.Index] = info;
+
+        Dispatcher.BeginInvoke(() =>
+        {
+            // Set the row UI for this channel
+            var role = info.Role;
+            var name = string.IsNullOrEmpty(info.Name) ? $"Ch {info.Index}" : info.Name;
+
+            switch (info.Index)
+            {
+                case 0: Ch0Role.Text = role; Ch0Name.Text = name; Ch0Uplink.IsChecked = info.Uplink; Ch0Downlink.IsChecked = info.Downlink; break;
+                case 1: Ch1Role.Text = role; Ch1Name.Text = name; Ch1Uplink.IsChecked = info.Uplink; Ch1Downlink.IsChecked = info.Downlink; break;
+                case 2: Ch2Role.Text = role; Ch2Name.Text = name; Ch2Uplink.IsChecked = info.Uplink; Ch2Downlink.IsChecked = info.Downlink; break;
+                case 3: Ch3Role.Text = role; Ch3Name.Text = name; Ch3Uplink.IsChecked = info.Uplink; Ch3Downlink.IsChecked = info.Downlink; break;
+                case 4: Ch4Role.Text = role; Ch4Name.Text = name; Ch4Uplink.IsChecked = info.Uplink; Ch4Downlink.IsChecked = info.Downlink; break;
+                case 5: Ch5Role.Text = role; Ch5Name.Text = name; Ch5Uplink.IsChecked = info.Uplink; Ch5Downlink.IsChecked = info.Downlink; break;
+                case 6: Ch6Role.Text = role; Ch6Name.Text = name; Ch6Uplink.IsChecked = info.Uplink; Ch6Downlink.IsChecked = info.Downlink; break;
+                case 7: Ch7Role.Text = role; Ch7Name.Text = name; Ch7Uplink.IsChecked = info.Uplink; Ch7Downlink.IsChecked = info.Downlink; break;
+            }
+
+            MarkReceived($"ch{info.Index}");
         });
     }
 
@@ -599,8 +739,10 @@ public partial class NodeConfigWindow : Window
 
             // Owner
             var newOwner = _loadedOwner != null ? _loadedOwner.Clone() : new User();
-            newOwner.LongName  = LongNameTextBox.Text.Trim();
-            newOwner.ShortName = ShortNameTextBox.Text.Trim();
+            newOwner.LongName        = LongNameTextBox.Text.Trim();
+            newOwner.ShortName       = ShortNameTextBox.Text.Trim();
+            newOwner.IsLicensed      = IsLicensedCheckBox.IsChecked == true;
+            newOwner.IsUnmessagable  = IsUnmessagableCheckBox.IsChecked == true;
             await _protocolService.SetOwnerAsync(newOwner);
             await Delay();
 
@@ -612,6 +754,9 @@ public partial class NodeConfigWindow : Window
             newDevice.Tzdef                  = TzdefTextBox.Text.Trim();
             newDevice.LedHeartbeatDisabled   = LedHeartbeatCheckBox.IsChecked == true;
             newDevice.DoubleTapAsButtonPress = DoubleTapCheckBox.IsChecked == true;
+            newDevice.DisableTripleClick     = DisableTripleClickCheckBox.IsChecked == true;
+            newDevice.ButtonGpio             = uint.TryParse(ButtonGpioTextBox.Text, out var bgp) ? bgp : 0;
+            newDevice.BuzzerGpio             = uint.TryParse(BuzzerGpioTextBox.Text, out var bzg) ? bzg : 0;
             await _protocolService.SetDeviceConfigAsync(newDevice);
             await Delay();
 
@@ -619,15 +764,18 @@ public partial class NodeConfigWindow : Window
             if (_loadedLora != null)
             {
                 var newLora = _loadedLora.Clone();
-                newLora.Region            = (Meshtastic.Protobufs.Region)GetComboBoxTag(LoraRegionComboBox);
-                newLora.UsePreset         = LoraUsePresetCheckBox.IsChecked == true;
-                newLora.ModemPreset       = (Meshtastic.Protobufs.ModemPreset)GetComboBoxTag(LoraPresetComboBox);
-                newLora.HopLimit          = uint.TryParse(HopLimitTextBox.Text, out var hl) ? hl : 3;
-                newLora.TxEnabled         = TxEnabledCheckBox.IsChecked == true;
-                newLora.TxPower           = int.TryParse(TxPowerTextBox.Text, out var tp) ? tp : 0;
-                newLora.ChannelNum        = uint.TryParse(LoraChannelNumTextBox.Text, out var cn) ? cn : 0;
-                newLora.OverrideDutyCycle = LoraOverrideDutyCycleCheckBox.IsChecked == true;
+                newLora.Region              = (Meshtastic.Protobufs.Region)GetComboBoxTag(LoraRegionComboBox);
+                newLora.UsePreset           = LoraUsePresetCheckBox.IsChecked == true;
+                newLora.ModemPreset         = (Meshtastic.Protobufs.ModemPreset)GetComboBoxTag(LoraPresetComboBox);
+                newLora.HopLimit            = uint.TryParse(HopLimitTextBox.Text, out var hl) ? hl : 3;
+                newLora.TxEnabled           = TxEnabledCheckBox.IsChecked == true;
+                newLora.TxPower             = int.TryParse(TxPowerTextBox.Text, out var tp) ? tp : 0;
+                newLora.ChannelNum          = uint.TryParse(LoraChannelNumTextBox.Text, out var cn) ? cn : 0;
+                newLora.OverrideDutyCycle   = LoraOverrideDutyCycleCheckBox.IsChecked == true;
                 newLora.Sx126XRxBoostedGain = LoraSx126xRxBoostedCheckBox.IsChecked == true;
+                newLora.IgnoreMqtt          = LoraIgnoreMqttCheckBox.IsChecked == true;
+                newLora.ConfigOkToMqtt      = LoraOkToMqttCheckBox.IsChecked == true;
+                newLora.OverrideFrequency   = float.TryParse(LoraOverrideFreqTextBox.Text, out var ovf) ? ovf : 0f;
                 await _protocolService.SetLoRaConfigAsync(newLora);
                 await Delay();
             }
@@ -635,11 +783,15 @@ public partial class NodeConfigWindow : Window
             // Position Config
             var newPosition = _loadedPosition != null ? _loadedPosition.Clone() : new PositionConfig();
             newPosition.GpsMode                             = (GpsMode)GetComboBoxTag(GpsModeComboBox);
+            newPosition.FixedPosition                       = FixedPositionCheckBox.IsChecked == true;
             newPosition.PositionBroadcastSecs               = HumanTimeToSeconds(PosBroadcastSecsTextBox.Text);
             newPosition.PositionBroadcastSmartEnabled       = SmartBroadcastCheckBox.IsChecked == true;
-            newPosition.PositionBroadcastSmartMinimumDistance = uint.TryParse(MinDistanceTextBox.Text, out var md) ? md : 0;
-            newPosition.PositionBroadcastSmartMinimumSpeed  = uint.TryParse(MinSpeedTextBox.Text, out var ms) ? ms : 0;
+            newPosition.BroadcastSmartMinimumDistance       = uint.TryParse(MinDistanceTextBox.Text, out var md) ? md : 0;
+            newPosition.BroadcastSmartMinimumIntervalSecs   = uint.TryParse(MinIntervalSecsTextBox.Text, out var mis) ? mis : 0;
             newPosition.GpsUpdateInterval                   = uint.TryParse(GpsUpdateIntervalTextBox.Text, out var gu) ? gu : 0;
+            newPosition.RxGpio                              = uint.TryParse(GpsRxGpioTextBox.Text, out var rxg) ? rxg : 0;
+            newPosition.TxGpio                              = uint.TryParse(GpsTxGpioTextBox.Text, out var txg) ? txg : 0;
+            newPosition.GpsEnGpio                           = uint.TryParse(GpsEnGpioTextBox.Text, out var eng) ? eng : 0;
             await _protocolService.SetPositionConfigAsync(newPosition);
             await Delay();
 
@@ -653,6 +805,12 @@ public partial class NodeConfigWindow : Window
                 newPower.SdsSecs                    = uint.TryParse(SdsSecsTextBox.Text, out var sds) ? sds : 0;
                 newPower.LsSecs                     = uint.TryParse(LsSecsTextBox.Text, out var ls) ? ls : 0;
                 newPower.MinWakeSecs                = uint.TryParse(MinWakeSecsTextBox.Text, out var mw) ? mw : 0;
+                newPower.AdcMultiplierOverride       = float.TryParse(AdcMultTextBox.Text, out var adc) ? adc : 0f;
+                // Battery INA address: accept hex (0x..) or decimal
+                var inaText = BatteryInaAddrTextBox.Text.Trim();
+                newPower.DeviceBatteryInaAddress = inaText.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                    ? (uint.TryParse(inaText[2..], System.Globalization.NumberStyles.HexNumber, null, out var inaH) ? inaH : 0)
+                    : (uint.TryParse(inaText, out var inaD) ? inaD : 0);
                 await _protocolService.SetPowerConfigAsync(newPower);
                 await Delay();
             }
@@ -661,10 +819,13 @@ public partial class NodeConfigWindow : Window
             if (_loadedNetwork != null)
             {
                 var newNetwork = _loadedNetwork.Clone();
-                newNetwork.WifiEnabled = WifiEnabledCheckBox.IsChecked == true;
-                newNetwork.WifiSsid    = WifiSsidTextBox.Text.Trim();
-                newNetwork.WifiPsk     = WifiPskBox.Text.Trim();
-                newNetwork.NtpServer   = NtpServerTextBox.Text.Trim();
+                newNetwork.WifiEnabled  = WifiEnabledCheckBox.IsChecked == true;
+                newNetwork.WifiSsid     = WifiSsidTextBox.Text.Trim();
+                newNetwork.WifiPsk      = WifiPskBox.Text.Trim();
+                newNetwork.NtpServer    = NtpServerTextBox.Text.Trim();
+                newNetwork.EthEnabled   = EthEnabledCheckBox.IsChecked == true;
+                newNetwork.AddressMode  = (uint)GetComboBoxTag(AddressModeComboBox);
+                newNetwork.RsyslogServer = RsyslogServerTextBox.Text.Trim();
                 await _protocolService.SetNetworkConfigAsync(newNetwork);
                 await Delay();
             }
@@ -677,6 +838,13 @@ public partial class NodeConfigWindow : Window
                 newDisplay.AutoScreenCarouselSecs = uint.TryParse(AutoCarouselSecsTextBox.Text, out var carousel) ? carousel : 0;
                 newDisplay.CompassNorthTop        = CompassNorthTopCheckBox.IsChecked == true;
                 newDisplay.FlipScreen             = FlipScreenCheckBox.IsChecked == true;
+                newDisplay.HeadingBold            = HeadingBoldCheckBox.IsChecked == true;
+                newDisplay.WakeOnTapOrMotion      = WakeOnTapCheckBox.IsChecked == true;
+                newDisplay.Use12HClock            = Use12hClockCheckBox.IsChecked == true;
+                newDisplay.Units                  = (uint)GetComboBoxTag(DisplayUnitsComboBox);
+                newDisplay.Displaymode            = (uint)GetComboBoxTag(DisplayModeComboBox);
+                newDisplay.Oled                   = (uint)GetComboBoxTag(OledTypeComboBox);
+                newDisplay.CompassOrientation     = (uint)GetComboBoxTag(CompassOrientationComboBox);
                 await _protocolService.SetDisplayConfigAsync(newDisplay);
                 await Delay();
             }
@@ -691,16 +859,16 @@ public partial class NodeConfigWindow : Window
 
             // MQTT Config
             var newMqtt = _loadedMqtt != null ? _loadedMqtt.Clone() : new MQTTConfig();
-            newMqtt.Enabled             = MqttEnabledCheckBox.IsChecked == true;
-            newMqtt.Address             = MqttAddressTextBox.Text.Trim();
-            newMqtt.Username            = MqttUsernameTextBox.Text.Trim();
-            newMqtt.Password            = MqttPasswordBox.Password;
-            newMqtt.EncryptionEnabled   = MqttEncryptionCheckBox.IsChecked == true;
-            newMqtt.JsonEnabled         = MqttJsonCheckBox.IsChecked == true;
-            newMqtt.TlsEnabled          = MqttTlsCheckBox.IsChecked == true;
-            newMqtt.Root                = MqttRootTextBox.Text.Trim();
+            newMqtt.Enabled              = MqttEnabledCheckBox.IsChecked == true;
+            newMqtt.Address              = MqttAddressTextBox.Text.Trim();
+            newMqtt.Username             = MqttUsernameTextBox.Text.Trim();
+            newMqtt.Password             = MqttPasswordBox.Text.Trim();
+            newMqtt.EncryptionEnabled    = MqttEncryptionCheckBox.IsChecked == true;
+            newMqtt.JsonEnabled          = MqttJsonCheckBox.IsChecked == true;
+            newMqtt.TlsEnabled           = MqttTlsCheckBox.IsChecked == true;
+            newMqtt.Root                 = MqttRootTextBox.Text.Trim();
             newMqtt.ProxyToClientEnabled = MqttProxyCheckBox.IsChecked == true;
-            newMqtt.MapReportingEnabled = MqttMapReportingCheckBox.IsChecked == true;
+            newMqtt.MapReportingEnabled  = MqttMapReportingCheckBox.IsChecked == true;
             await _protocolService.SetMqttConfigAsync(newMqtt);
             await Delay();
 
@@ -789,6 +957,51 @@ public partial class NodeConfigWindow : Window
                 newSer.Timeout  = uint.TryParse(SerTimeoutTextBox.Text, out var sto) ? sto : 0;
                 newSer.Mode     = (uint)GetComboBoxTag(SerModeComboBox);
                 await _protocolService.SetSerialConfigAsync(newSer);
+                await Delay();
+            }
+
+            // Security Config (only writable fields; public key is read-only)
+            if (_loadedSecurity != null)
+            {
+                var newSec = _loadedSecurity.Clone();
+                newSec.SerialEnabled      = SecSerialEnabledCheckBox.IsChecked == true;
+                newSec.DebugLogApiEnabled = SecDebugLogCheckBox.IsChecked == true;
+                newSec.IsManaged          = SecIsManagedCheckBox.IsChecked == true;
+                newSec.AdminChannelEnabled = SecAdminChannelCheckBox.IsChecked == true;
+                await _protocolService.SetSecurityConfigAsync(newSec);
+                await Delay();
+            }
+
+            // Channel uplink/downlink
+            var chBoxes = new (CheckBox? Up, CheckBox? Dn)[]
+            {
+                (Ch0Uplink, Ch0Downlink), (Ch1Uplink, Ch1Downlink),
+                (Ch2Uplink, Ch2Downlink), (Ch3Uplink, Ch3Downlink),
+                (Ch4Uplink, Ch4Downlink), (Ch5Uplink, Ch5Downlink),
+                (Ch6Uplink, Ch6Downlink), (Ch7Uplink, Ch7Downlink),
+            };
+            for (int i = 0; i < 8; i++)
+            {
+                var info = _loadedChannels[i];
+                if (info == null) continue;
+
+                bool newUplink   = chBoxes[i].Up?.IsChecked == true;
+                bool newDownlink = chBoxes[i].Dn?.IsChecked == true;
+                if (newUplink == info.Uplink && newDownlink == info.Downlink) continue; // no change
+
+                var ch = new Channel { Index = i };
+                var roleEnum = info.Role.ToUpperInvariant() switch
+                {
+                    "PRIMARY"   => ChannelRole.Primary,
+                    "SECONDARY" => ChannelRole.Secondary,
+                    _           => ChannelRole.Disabled
+                };
+                ch.Role = roleEnum;
+                var settings = new ChannelSettings { UplinkEnabled = newUplink, DownlinkEnabled = newDownlink };
+                if (!string.IsNullOrEmpty(info.Psk))
+                    settings.Psk = ByteString.CopyFrom(Convert.FromBase64String(info.Psk));
+                ch.Settings = settings;
+                await _protocolService.UpdateChannelUplinkDownlinkAsync(ch);
                 await Delay();
             }
 

--- a/MeshhessenClient/NodeConfigWindow.xaml.cs
+++ b/MeshhessenClient/NodeConfigWindow.xaml.cs
@@ -713,8 +713,21 @@ public partial class NodeConfigWindow : Window
     private void FixedPositionCheckBox_Changed(object sender, RoutedEventArgs e)
     {
         if (FixedPositionPanel != null)
+        {
             FixedPositionPanel.Visibility = FixedPositionCheckBox.IsChecked == true
                 ? Visibility.Visible : Visibility.Collapsed;
+            if (FixedPositionCheckBox.IsChecked == true)
+                RefreshMapCenterHint();
+        }
+    }
+
+    private void RefreshMapCenterHint()
+    {
+        if (_mapCenterProvider == null || MapCenterCoordRun == null) return;
+        var pos = _mapCenterProvider();
+        MapCenterCoordRun.Text = pos.HasValue
+            ? $"{pos.Value.lat:F5}, {pos.Value.lon:F5}"
+            : "–";
     }
 
     private void PickFromMap_Click(object sender, RoutedEventArgs e)
@@ -732,6 +745,7 @@ public partial class NodeConfigWindow : Window
         }
         FixedLatTextBox.Text = pos.Value.lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
         FixedLonTextBox.Text = pos.Value.lon.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+        RefreshMapCenterHint();
     }
 
     private void BtModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/MeshhessenClient/NodeConfigWindow.xaml.cs
+++ b/MeshhessenClient/NodeConfigWindow.xaml.cs
@@ -11,63 +11,156 @@ public partial class NodeConfigWindow : Window
     private readonly MeshtasticProtocolService _protocolService;
 
     // Loaded configs (for clone-and-update pattern)
-    private User? _loadedOwner;
-    private DeviceConfig? _loadedDevice;
-    private PositionConfig? _loadedPosition;
-    private LoRaConfig? _loadedLora;
-    private MQTTConfig? _loadedMqtt;
-    private TelemetryConfig? _loadedTelemetry;
-    private BluetoothConfig? _loadedBluetooth;
+    private User?                      _loadedOwner;
+    private DeviceConfig?              _loadedDevice;
+    private PositionConfig?            _loadedPosition;
+    private LoRaConfig?                _loadedLora;
+    private PowerConfig?               _loadedPower;
+    private NetworkConfig?             _loadedNetwork;
+    private DisplayConfig?             _loadedDisplay;
+    private MQTTConfig?                _loadedMqtt;
+    private TelemetryConfig?           _loadedTelemetry;
+    private BluetoothConfig?           _loadedBluetooth;
+    private NeighborInfoConfig?        _loadedNeighborInfo;
+    private StoreForwardConfig?        _loadedStoreForward;
+    private ExternalNotificationConfig? _loadedExtNotif;
+    private CannedMessageConfig?       _loadedCannedMsg;
+    private RangeTestConfig?           _loadedRangeTest;
+    private SerialConfig?              _loadedSerial;
+
     private int _pendingRequests = 0;
+
+    // Map Tag → content panel
+    private Dictionary<string, FrameworkElement> _panels = new();
 
     public NodeConfigWindow(MeshtasticProtocolService protocolService)
     {
         InitializeComponent();
         _protocolService = protocolService;
 
-        _protocolService.OwnerReceived += OnOwnerReceived;
-        _protocolService.DeviceConfigReceived += OnDeviceConfigReceived;
-        _protocolService.PositionConfigReceived += OnPositionConfigReceived;
-        _protocolService.LoRaConfigReceived += OnLoRaConfigReceived;
-        _protocolService.MqttConfigReceived += OnMqttConfigReceived;
-        _protocolService.TelemetryConfigReceived += OnTelemetryConfigReceived;
-        _protocolService.BluetoothConfigReceived += OnBluetoothConfigReceived;
+        // Wire up events
+        _protocolService.OwnerReceived                    += OnOwnerReceived;
+        _protocolService.DeviceConfigReceived             += OnDeviceConfigReceived;
+        _protocolService.PositionConfigReceived           += OnPositionConfigReceived;
+        _protocolService.LoRaConfigReceived               += OnLoRaConfigReceived;
+        _protocolService.PowerConfigReceived              += OnPowerConfigReceived;
+        _protocolService.NetworkConfigReceived            += OnNetworkConfigReceived;
+        _protocolService.DisplayConfigReceived            += OnDisplayConfigReceived;
+        _protocolService.MqttConfigReceived               += OnMqttConfigReceived;
+        _protocolService.TelemetryConfigReceived          += OnTelemetryConfigReceived;
+        _protocolService.BluetoothConfigReceived          += OnBluetoothConfigReceived;
+        _protocolService.NeighborInfoConfigReceived       += OnNeighborInfoConfigReceived;
+        _protocolService.StoreForwardConfigReceived       += OnStoreForwardConfigReceived;
+        _protocolService.ExternalNotificationConfigReceived += OnExtNotifConfigReceived;
+        _protocolService.CannedMessageConfigReceived      += OnCannedMsgConfigReceived;
+        _protocolService.RangeTestConfigReceived          += OnRangeTestConfigReceived;
+        _protocolService.SerialConfigReceived             += OnSerialConfigReceived;
 
         Closed += (s, e) =>
         {
-            _protocolService.OwnerReceived -= OnOwnerReceived;
-            _protocolService.DeviceConfigReceived -= OnDeviceConfigReceived;
-            _protocolService.PositionConfigReceived -= OnPositionConfigReceived;
-            _protocolService.LoRaConfigReceived -= OnLoRaConfigReceived;
-            _protocolService.MqttConfigReceived -= OnMqttConfigReceived;
-            _protocolService.TelemetryConfigReceived -= OnTelemetryConfigReceived;
-            _protocolService.BluetoothConfigReceived -= OnBluetoothConfigReceived;
+            _protocolService.OwnerReceived                    -= OnOwnerReceived;
+            _protocolService.DeviceConfigReceived             -= OnDeviceConfigReceived;
+            _protocolService.PositionConfigReceived           -= OnPositionConfigReceived;
+            _protocolService.LoRaConfigReceived               -= OnLoRaConfigReceived;
+            _protocolService.PowerConfigReceived              -= OnPowerConfigReceived;
+            _protocolService.NetworkConfigReceived            -= OnNetworkConfigReceived;
+            _protocolService.DisplayConfigReceived            -= OnDisplayConfigReceived;
+            _protocolService.MqttConfigReceived               -= OnMqttConfigReceived;
+            _protocolService.TelemetryConfigReceived          -= OnTelemetryConfigReceived;
+            _protocolService.BluetoothConfigReceived          -= OnBluetoothConfigReceived;
+            _protocolService.NeighborInfoConfigReceived       -= OnNeighborInfoConfigReceived;
+            _protocolService.StoreForwardConfigReceived       -= OnStoreForwardConfigReceived;
+            _protocolService.ExternalNotificationConfigReceived -= OnExtNotifConfigReceived;
+            _protocolService.CannedMessageConfigReceived      -= OnCannedMsgConfigReceived;
+            _protocolService.RangeTestConfigReceived          -= OnRangeTestConfigReceived;
+            _protocolService.SerialConfigReceived             -= OnSerialConfigReceived;
         };
 
-        Loaded += async (s, e) => await RequestAllConfigsAsync();
+        Loaded += (s, e) =>
+        {
+            // Build panel map from NavList tags
+            _panels = new Dictionary<string, FrameworkElement>
+            {
+                ["User"]        = PanelUser,
+                ["Device"]      = PanelDevice,
+                ["Lora"]        = PanelLora,
+                ["Position"]    = PanelPosition,
+                ["Power"]       = PanelPower,
+                ["Network"]     = PanelNetwork,
+                ["Display"]     = PanelDisplay,
+                ["Bluetooth"]   = PanelBluetooth,
+                ["Mqtt"]        = PanelMqtt,
+                ["Telemetry"]   = PanelTelemetry,
+                ["NeighborInfo"] = PanelNeighborInfo,
+                ["StoreForward"] = PanelStoreForward,
+                ["ExtNotif"]    = PanelExtNotif,
+                ["CannedMsg"]   = PanelCannedMsg,
+                ["RangeTest"]   = PanelRangeTest,
+                ["Serial"]      = PanelSerial,
+            };
+
+            // Select first real item (User)
+            foreach (ListBoxItem item in NavList.Items)
+                if (item.Tag is string) { NavList.SelectedItem = item; break; }
+
+            _ = RequestAllConfigsAsync();
+        };
     }
+
+    // ========== Navigation ==========
+
+    private void NavList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (NavList.SelectedItem is not ListBoxItem item || item.Tag is not string tag) return;
+
+        foreach (var panel in _panels.Values)
+            panel.Visibility = Visibility.Collapsed;
+
+        if (_panels.TryGetValue(tag, out var selected))
+            selected.Visibility = Visibility.Visible;
+    }
+
+    // ========== Config loading ==========
 
     private async System.Threading.Tasks.Task RequestAllConfigsAsync()
     {
         try
         {
-            _pendingRequests = 7;
+            _pendingRequests = 16;
             UpdateStatus("Lade Konfiguration...");
             SaveButton.IsEnabled = false;
 
             await _protocolService.RequestOwnerAsync();
-            await System.Threading.Tasks.Task.Delay(200);
+            await Delay();
             await _protocolService.RequestDeviceConfigAsync();
-            await System.Threading.Tasks.Task.Delay(200);
-            await _protocolService.RequestPositionConfigAsync();
-            await System.Threading.Tasks.Task.Delay(200);
+            await Delay();
             await _protocolService.RequestLoRaConfigAsync();
-            await System.Threading.Tasks.Task.Delay(200);
-            await _protocolService.RequestMqttConfigAsync();
-            await System.Threading.Tasks.Task.Delay(200);
-            await _protocolService.RequestTelemetryConfigAsync();
-            await System.Threading.Tasks.Task.Delay(200);
+            await Delay();
+            await _protocolService.RequestPositionConfigAsync();
+            await Delay();
+            await _protocolService.RequestPowerConfigAsync();
+            await Delay();
+            await _protocolService.RequestNetworkConfigAsync();
+            await Delay();
+            await _protocolService.RequestDisplayConfigAsync();
+            await Delay();
             await _protocolService.RequestBluetoothConfigAsync();
+            await Delay();
+            await _protocolService.RequestMqttConfigAsync();
+            await Delay();
+            await _protocolService.RequestTelemetryConfigAsync();
+            await Delay();
+            await _protocolService.RequestNeighborInfoConfigAsync();
+            await Delay();
+            await _protocolService.RequestStoreForwardConfigAsync();
+            await Delay();
+            await _protocolService.RequestExternalNotificationConfigAsync();
+            await Delay();
+            await _protocolService.RequestCannedMessageConfigAsync();
+            await Delay();
+            await _protocolService.RequestRangeTestConfigAsync();
+            await Delay();
+            await _protocolService.RequestSerialConfigAsync();
         }
         catch (Exception ex)
         {
@@ -75,29 +168,56 @@ public partial class NodeConfigWindow : Window
         }
     }
 
+    private static System.Threading.Tasks.Task Delay() =>
+        System.Threading.Tasks.Task.Delay(200);
+
     private void CheckAllLoaded()
     {
         _pendingRequests--;
         if (_pendingRequests <= 0)
         {
-            UpdateStatus("Konfiguration geladen.");
+            var msg = (string?)Application.Current.TryFindResource("StrNcConfigLoaded")
+                      ?? "Configuration loaded.";
+            UpdateStatus(msg);
             SaveButton.IsEnabled = true;
         }
     }
 
-    private void UpdateStatus(string text)
+    private void WifiPskToggle_Checked(object sender, RoutedEventArgs e)
     {
-        Dispatcher.BeginInvoke(() => StatusText.Text = text);
+        // Reveal: hide mask, show real TextBox
+        WifiPskMaskBox.Visibility = Visibility.Collapsed;
+        WifiPskBox.Visibility     = Visibility.Visible;
+        WifiPskBox.Focus();
+        WifiPskToggle.ToolTip = Application.Current.TryFindResource("StrNcHidePassword");
     }
 
-    // ========== Event handlers — populate UI ==========
+    private void WifiPskToggle_Unchecked(object sender, RoutedEventArgs e)
+    {
+        // Hide: update mask to show bullets if password was typed, then swap
+        WifiPskMaskBox.Text      = WifiPskBox.Text.Length > 0
+            ? new string('●', Math.Min(WifiPskBox.Text.Length, 16))
+            : (string?)Application.Current.TryFindResource("StrNcWifiPskHint") ?? "";
+        WifiPskMaskBox.FontStyle = WifiPskBox.Text.Length > 0 ? FontStyles.Normal : FontStyles.Italic;
+        WifiPskMaskBox.Foreground = WifiPskBox.Text.Length > 0
+            ? SystemColors.ControlTextBrush
+            : System.Windows.Media.Brushes.Gray;
+        WifiPskBox.Visibility     = Visibility.Collapsed;
+        WifiPskMaskBox.Visibility = Visibility.Visible;
+        WifiPskToggle.ToolTip = Application.Current.TryFindResource("StrNcShowPassword");
+    }
+
+    private void UpdateStatus(string text) =>
+        Dispatcher.BeginInvoke(() => StatusText.Text = text);
+
+    // ========== Receive handlers ==========
 
     private void OnOwnerReceived(object? sender, User user)
     {
         _loadedOwner = user;
         Dispatcher.BeginInvoke(() =>
         {
-            LongNameTextBox.Text = user.LongName;
+            LongNameTextBox.Text  = user.LongName;
             ShortNameTextBox.Text = user.ShortName;
             CheckAllLoaded();
         });
@@ -110,9 +230,10 @@ public partial class NodeConfigWindow : Window
         {
             SelectComboBoxByTag(RoleComboBox, (int)config.Role);
             SelectComboBoxByTag(RebroadcastComboBox, (int)config.RebroadcastMode);
-            NodeInfoIntervalTextBox.Text = SecondsToHumanTime(config.NodeInfoBroadcastSecs);
-            TzdefTextBox.Text = config.Tzdef;
+            NodeInfoIntervalTextBox.Text  = SecondsToHumanTime(config.NodeInfoBroadcastSecs);
+            TzdefTextBox.Text             = config.Tzdef;
             LedHeartbeatCheckBox.IsChecked = config.LedHeartbeatDisabled;
+            DoubleTapCheckBox.IsChecked   = config.DoubleTapAsButtonPress;
             CheckAllLoaded();
         });
     }
@@ -123,10 +244,11 @@ public partial class NodeConfigWindow : Window
         Dispatcher.BeginInvoke(() =>
         {
             SelectComboBoxByTag(GpsModeComboBox, (int)config.GpsMode);
-            PosBroadcastSecsTextBox.Text = SecondsToHumanTime(config.PositionBroadcastSecs);
+            PosBroadcastSecsTextBox.Text  = SecondsToHumanTime(config.PositionBroadcastSecs);
             SmartBroadcastCheckBox.IsChecked = config.PositionBroadcastSmartEnabled;
-            MinDistanceTextBox.Text = config.PositionBroadcastSmartMinimumDistance.ToString();
-            MinSpeedTextBox.Text = config.PositionBroadcastSmartMinimumSpeed.ToString();
+            MinDistanceTextBox.Text       = config.PositionBroadcastSmartMinimumDistance.ToString();
+            MinSpeedTextBox.Text          = config.PositionBroadcastSmartMinimumSpeed.ToString();
+            GpsUpdateIntervalTextBox.Text = config.GpsUpdateInterval.ToString();
             CheckAllLoaded();
         });
     }
@@ -136,14 +258,57 @@ public partial class NodeConfigWindow : Window
         _loadedLora = config;
         Dispatcher.BeginInvoke(() =>
         {
-            // Use -1 fallback to preserve original value if not in list
             SelectComboBoxByTag(LoraRegionComboBox, (int)config.Region, keepIfNotFound: true);
             LoraUsePresetCheckBox.IsChecked = config.UsePreset;
             SelectComboBoxByTag(LoraPresetComboBox, (int)config.ModemPreset, keepIfNotFound: true);
-            LoraPresetComboBox.IsEnabled = config.UsePreset;
-            HopLimitTextBox.Text = config.HopLimit.ToString();
-            TxEnabledCheckBox.IsChecked = config.TxEnabled;
-            TxPowerTextBox.Text = config.TxPower.ToString();
+            LoraPresetComboBox.IsEnabled   = config.UsePreset;
+            HopLimitTextBox.Text           = config.HopLimit.ToString();
+            TxEnabledCheckBox.IsChecked    = config.TxEnabled;
+            TxPowerTextBox.Text            = ((int)config.TxPower).ToString();
+            LoraChannelNumTextBox.Text     = config.ChannelNum.ToString();
+            LoraOverrideDutyCycleCheckBox.IsChecked = config.OverrideDutyCycle;
+            LoraSx126xRxBoostedCheckBox.IsChecked   = config.Sx126XRxBoostedGain;
+            CheckAllLoaded();
+        });
+    }
+
+    private void OnPowerConfigReceived(object? sender, PowerConfig config)
+    {
+        _loadedPower = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            PowerSavingCheckBox.IsChecked   = config.IsPowerSaving;
+            ShutdownAfterSecsTextBox.Text   = config.OnBatteryShutdownAfterSecs.ToString();
+            WaitBtSecsTextBox.Text          = config.WaitBluetoothSecs.ToString();
+            SdsSecsTextBox.Text             = config.SdsSecs.ToString();
+            LsSecsTextBox.Text              = config.LsSecs.ToString();
+            MinWakeSecsTextBox.Text         = config.MinWakeSecs.ToString();
+            CheckAllLoaded();
+        });
+    }
+
+    private void OnNetworkConfigReceived(object? sender, NetworkConfig config)
+    {
+        _loadedNetwork = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            WifiEnabledCheckBox.IsChecked = config.WifiEnabled;
+            WifiSsidTextBox.Text          = config.WifiSsid;
+            WifiPskBox.Text               = config.WifiPsk;   // device always returns empty (security)
+            NtpServerTextBox.Text         = config.NtpServer;
+            CheckAllLoaded();
+        });
+    }
+
+    private void OnDisplayConfigReceived(object? sender, DisplayConfig config)
+    {
+        _loadedDisplay = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            ScreenOnSecsTextBox.Text          = SecondsToHumanTime(config.ScreenOnSecs);
+            AutoCarouselSecsTextBox.Text      = config.AutoScreenCarouselSecs.ToString();
+            CompassNorthTopCheckBox.IsChecked = config.CompassNorthTop;
+            FlipScreenCheckBox.IsChecked      = config.FlipScreen;
             CheckAllLoaded();
         });
     }
@@ -153,15 +318,15 @@ public partial class NodeConfigWindow : Window
         _loadedMqtt = config;
         Dispatcher.BeginInvoke(() =>
         {
-            MqttEnabledCheckBox.IsChecked = config.Enabled;
-            MqttAddressTextBox.Text = config.Address;
-            MqttUsernameTextBox.Text = config.Username;
-            MqttPasswordBox.Password = config.Password;
+            MqttEnabledCheckBox.IsChecked    = config.Enabled;
+            MqttAddressTextBox.Text          = config.Address;
+            MqttUsernameTextBox.Text         = config.Username;
+            MqttPasswordBox.Password         = config.Password;
             MqttEncryptionCheckBox.IsChecked = config.EncryptionEnabled;
-            MqttJsonCheckBox.IsChecked = config.JsonEnabled;
-            MqttTlsCheckBox.IsChecked = config.TlsEnabled;
-            MqttRootTextBox.Text = config.Root;
-            MqttProxyCheckBox.IsChecked = config.ProxyToClientEnabled;
+            MqttJsonCheckBox.IsChecked       = config.JsonEnabled;
+            MqttTlsCheckBox.IsChecked        = config.TlsEnabled;
+            MqttRootTextBox.Text             = config.Root;
+            MqttProxyCheckBox.IsChecked      = config.ProxyToClientEnabled;
             MqttMapReportingCheckBox.IsChecked = config.MapReportingEnabled;
             CheckAllLoaded();
         });
@@ -172,12 +337,13 @@ public partial class NodeConfigWindow : Window
         _loadedTelemetry = config;
         Dispatcher.BeginInvoke(() =>
         {
-            DeviceTelemetryIntervalTextBox.Text = SecondsToHumanTime(config.DeviceUpdateInterval);
-            EnvironmentIntervalTextBox.Text = SecondsToHumanTime(config.EnvironmentUpdateInterval);
-            FahrenheitCheckBox.IsChecked = config.EnvironmentDisplayFahrenheit;
+            DeviceTelemetryIntervalTextBox.Text  = SecondsToHumanTime(config.DeviceUpdateInterval);
+            EnvironmentIntervalTextBox.Text      = SecondsToHumanTime(config.EnvironmentUpdateInterval);
             EnvironmentMeasurementCheckBox.IsChecked = config.EnvironmentMeasurementEnabled;
-            AirQualityIntervalTextBox.Text = SecondsToHumanTime(config.AirQualityInterval);
-            PowerIntervalTextBox.Text = SecondsToHumanTime(config.PowerUpdateInterval);
+            FahrenheitCheckBox.IsChecked         = config.EnvironmentDisplayFahrenheit;
+            AirQualityIntervalTextBox.Text       = SecondsToHumanTime(config.AirQualityInterval);
+            PowerIntervalTextBox.Text            = SecondsToHumanTime(config.PowerUpdateInterval);
+            PowerMeasurementCheckBox.IsChecked   = config.PowerMeasurementEnabled;
             CheckAllLoaded();
         });
     }
@@ -189,15 +355,96 @@ public partial class NodeConfigWindow : Window
         {
             BtEnabledCheckBox.IsChecked = config.Enabled;
             SelectComboBoxByTag(BtModeComboBox, (int)config.Mode);
-            BtFixedPinTextBox.Text = config.FixedPin > 0 ? config.FixedPin.ToString() : string.Empty;
-            BtFixedPinTextBox.IsEnabled = config.Mode == 1; // 1 = FIXED_PIN
+            BtFixedPinTextBox.Text      = config.FixedPin > 0 ? config.FixedPin.ToString() : string.Empty;
+            BtFixedPinTextBox.IsEnabled = config.Mode == 1;
             CheckAllLoaded();
         });
     }
 
-    // ========== Interval format helpers ==========
+    private void OnNeighborInfoConfigReceived(object? sender, NeighborInfoConfig config)
+    {
+        _loadedNeighborInfo = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            NiEnabledCheckBox.IsChecked = config.Enabled;
+            NiIntervalTextBox.Text      = SecondsToHumanTime(config.UpdateInterval);
+            CheckAllLoaded();
+        });
+    }
 
-    /// <summary>Converts seconds to human-readable format, e.g. 3600 → "1h", 5400 → "1h 30m"</summary>
+    private void OnStoreForwardConfigReceived(object? sender, StoreForwardConfig config)
+    {
+        _loadedStoreForward = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            SfEnabledCheckBox.IsChecked    = config.Enabled;
+            SfHeartbeatCheckBox.IsChecked  = config.Heartbeat;
+            SfRecordsTextBox.Text          = config.Records.ToString();
+            SfHistoryMaxTextBox.Text       = config.HistoryReturnMax.ToString();
+            SfHistoryWindowTextBox.Text    = config.HistoryReturnWindow.ToString();
+            CheckAllLoaded();
+        });
+    }
+
+    private void OnExtNotifConfigReceived(object? sender, ExternalNotificationConfig config)
+    {
+        _loadedExtNotif = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            EnEnabledCheckBox.IsChecked      = config.Enabled;
+            EnOutputTextBox.Text             = config.Output.ToString();
+            EnOutputMsTextBox.Text           = config.OutputMs.ToString();
+            EnActiveCheckBox.IsChecked       = config.Active;
+            EnAlertMessageCheckBox.IsChecked = config.AlertMessage;
+            EnAlertBellCheckBox.IsChecked    = config.AlertBell;
+            CheckAllLoaded();
+        });
+    }
+
+    private void OnCannedMsgConfigReceived(object? sender, CannedMessageConfig config)
+    {
+        _loadedCannedMsg = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            CmEnabledCheckBox.IsChecked        = config.Enabled;
+            CmSendBellCheckBox.IsChecked       = config.SendBell;
+            CmAllowInputSourceTextBox.Text     = config.AllowInputSource;
+            CmRotary1CheckBox.IsChecked        = config.Rotary1Enabled;
+            CmUpdown1CheckBox.IsChecked        = config.Updown1Enabled;
+            CheckAllLoaded();
+        });
+    }
+
+    private void OnRangeTestConfigReceived(object? sender, RangeTestConfig config)
+    {
+        _loadedRangeTest = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            RtEnabledCheckBox.IsChecked = config.Enabled;
+            RtSenderTextBox.Text        = config.Sender.ToString();
+            RtSaveCheckBox.IsChecked    = config.Save;
+            CheckAllLoaded();
+        });
+    }
+
+    private void OnSerialConfigReceived(object? sender, SerialConfig config)
+    {
+        _loadedSerial = config;
+        Dispatcher.BeginInvoke(() =>
+        {
+            SerEnabledCheckBox.IsChecked = config.Enabled;
+            SerEchoCheckBox.IsChecked    = config.Echo;
+            SerRxdTextBox.Text           = config.Rxd.ToString();
+            SerTxdTextBox.Text           = config.Txd.ToString();
+            SelectComboBoxByTag(SerBaudComboBox, (int)config.Baud);
+            SerTimeoutTextBox.Text       = config.Timeout.ToString();
+            SelectComboBoxByTag(SerModeComboBox, (int)config.Mode);
+            CheckAllLoaded();
+        });
+    }
+
+    // ========== Interval helpers ==========
+
     private static string SecondsToHumanTime(uint seconds)
     {
         if (seconds == 0) return "0";
@@ -210,13 +457,10 @@ public partial class NodeConfigWindow : Window
         return string.Join(" ", parts);
     }
 
-    /// <summary>Parses human-readable time string to seconds, e.g. "1h 30m" → 5400. Plain number = seconds.</summary>
     private static uint HumanTimeToSeconds(string input)
     {
         if (string.IsNullOrWhiteSpace(input)) return 0;
-        // Try plain number first
         if (uint.TryParse(input.Trim(), out var plain)) return plain;
-        // Parse tokens like 1d, 2h, 30m, 45s
         uint total = 0;
         var matches = Regex.Matches(input, @"(\d+)\s*([dhms])", RegexOptions.IgnoreCase);
         foreach (Match m in matches)
@@ -233,7 +477,7 @@ public partial class NodeConfigWindow : Window
         return total;
     }
 
-    // ========== Helpers ==========
+    // ========== ComboBox helpers ==========
 
     private static void SelectComboBoxByTag(ComboBox cb, int tag, bool keepIfNotFound = false)
     {
@@ -245,10 +489,8 @@ public partial class NodeConfigWindow : Window
                 return;
             }
         }
-        // If not found: either keep current selection or fall back to first item
         if (!keepIfNotFound && cb.Items.Count > 0)
             cb.SelectedIndex = 0;
-        // keepIfNotFound=true → don't change selection (avoids accidental Unset)
     }
 
     private static int GetComboBoxTag(ComboBox cb)
@@ -258,61 +500,59 @@ public partial class NodeConfigWindow : Window
         return 0;
     }
 
-    // ========== UI Events ==========
+    // ========== UI events ==========
 
     private void LoraUsePresetCheckBox_Changed(object sender, RoutedEventArgs e)
     {
         LoraPresetComboBox.IsEnabled = LoraUsePresetCheckBox.IsChecked == true;
     }
 
+    private void BtModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (BtFixedPinTextBox != null)
+            BtFixedPinTextBox.IsEnabled = GetComboBoxTag(BtModeComboBox) == 1;
+    }
+
     private void TzFromWindows_Click(object sender, RoutedEventArgs e)
     {
         try
         {
-            var tz = TimeZoneInfo.Local;
-            var posix = WindowsToPosixTz(tz);
-            TzdefTextBox.Text = posix;
+            TzdefTextBox.Text = WindowsToPosixTz(TimeZoneInfo.Local);
         }
         catch (Exception ex)
         {
-            MessageBox.Show($"Fehler beim Lesen der Windows-Zeitzone: {ex.Message}", "Fehler", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show($"Fehler: {ex.Message}", "Fehler", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 
-    /// <summary>Converts Windows TimeZoneInfo to a POSIX TZ string for Meshtastic.</summary>
     private static string WindowsToPosixTz(TimeZoneInfo tz)
     {
-        // Lookup table for common Windows TZ IDs → POSIX
         var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["W. Europe Standard Time"]       = "CET-1CEST,M3.5.0,M10.5.0/3",
-            ["Central Europe Standard Time"]  = "CET-1CEST,M3.5.0,M10.5.0/3",
-            ["Central European Standard Time"]= "CET-1CEST,M3.5.0,M10.5.0/3",
-            ["Romance Standard Time"]         = "CET-1CEST,M3.5.0,M10.5.0/3",
-            ["GTB Standard Time"]             = "EET-2EEST,M3.5.0/3,M10.5.0/4",
-            ["FLE Standard Time"]             = "EET-2EEST,M3.5.0/3,M10.5.0/4",
-            ["E. Europe Standard Time"]       = "EET-2EEST,M3.5.0/3,M10.5.0/4",
-            ["GMT Standard Time"]             = "GMT0BST,M3.5.0/1,M10.5.0",
-            ["UTC"]                           = "UTC0",
-            ["Eastern Standard Time"]         = "EST5EDT,M3.2.0,M11.1.0",
-            ["Central Standard Time"]         = "CST6CDT,M3.2.0,M11.1.0",
-            ["Mountain Standard Time"]        = "MST7MDT,M3.2.0,M11.1.0",
-            ["Pacific Standard Time"]         = "PST8PDT,M3.2.0,M11.1.0",
-            ["Tokyo Standard Time"]           = "JST-9",
-            ["China Standard Time"]           = "CST-8",
-            ["AUS Eastern Standard Time"]     = "AEST-10AEDT,M10.1.0,M4.1.0/3",
+            ["W. Europe Standard Time"]        = "CET-1CEST,M3.5.0,M10.5.0/3",
+            ["Central Europe Standard Time"]   = "CET-1CEST,M3.5.0,M10.5.0/3",
+            ["Central European Standard Time"] = "CET-1CEST,M3.5.0,M10.5.0/3",
+            ["Romance Standard Time"]          = "CET-1CEST,M3.5.0,M10.5.0/3",
+            ["GTB Standard Time"]              = "EET-2EEST,M3.5.0/3,M10.5.0/4",
+            ["FLE Standard Time"]              = "EET-2EEST,M3.5.0/3,M10.5.0/4",
+            ["E. Europe Standard Time"]        = "EET-2EEST,M3.5.0/3,M10.5.0/4",
+            ["GMT Standard Time"]              = "GMT0BST,M3.5.0/1,M10.5.0",
+            ["UTC"]                            = "UTC0",
+            ["Eastern Standard Time"]          = "EST5EDT,M3.2.0,M11.1.0",
+            ["Central Standard Time"]          = "CST6CDT,M3.2.0,M11.1.0",
+            ["Mountain Standard Time"]         = "MST7MDT,M3.2.0,M11.1.0",
+            ["Pacific Standard Time"]          = "PST8PDT,M3.2.0,M11.1.0",
+            ["Tokyo Standard Time"]            = "JST-9",
+            ["China Standard Time"]            = "CST-8",
+            ["AUS Eastern Standard Time"]      = "AEST-10AEDT,M10.1.0,M4.1.0/3",
         };
-
-        if (map.TryGetValue(tz.Id, out var posix))
-            return posix;
-
-        // Fallback: generate minimal POSIX string from offset (no DST info)
+        if (map.TryGetValue(tz.Id, out var posix)) return posix;
         var offsetHours = -(int)tz.BaseUtcOffset.TotalHours;
         var offsetStr = offsetHours == 0 ? "0" : $"{offsetHours:+0;-0}";
-        return tz.SupportsDaylightSavingTime
-            ? $"STD{offsetStr}DST"
-            : $"STD{offsetStr}";
+        return tz.SupportsDaylightSavingTime ? $"STD{offsetStr}DST" : $"STD{offsetStr}";
     }
+
+    // ========== NodeDB reset ==========
 
     private async void NodeDbReset_Click(object sender, RoutedEventArgs e)
     {
@@ -321,14 +561,13 @@ public partial class NodeConfigWindow : Window
             "NodeDB zurücksetzen",
             MessageBoxButton.YesNo,
             MessageBoxImage.Warning);
-
         if (result != MessageBoxResult.Yes) return;
 
         try
         {
             await _protocolService.ResetNodeDbAsync();
             UpdateStatus("NodeDB-Reset gesendet. Gerät startet neu...");
-            Services.Logger.WriteLine("NodeDB reset sent");
+            Logger.WriteLine("NodeDB reset sent");
         }
         catch (Exception ex)
         {
@@ -336,110 +575,233 @@ public partial class NodeConfigWindow : Window
         }
     }
 
+    // ========== Save ==========
+
     private async void Save_Click(object sender, RoutedEventArgs e)
     {
+        var confirm = MessageBox.Show(
+            (string)Application.Current.TryFindResource("StrNcSaveRebootWarning")
+                ?? "Konfiguration speichern und Gerät neu starten?",
+            (string)Application.Current.TryFindResource("StrNcSaveRebootTitle")
+                ?? "Gerät neu starten?",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+        if (confirm != MessageBoxResult.Yes) return;
+
         try
         {
             SaveButton.IsEnabled = false;
             UpdateStatus("Speichern...");
 
+            // Begin batch edit so device applies all at once and reboots once
+            await _protocolService.BeginEditSettingsAsync();
+            await Delay();
+
             // Owner
-            var newOwner = new User
-            {
-                LongName = LongNameTextBox.Text.Trim(),
-                ShortName = ShortNameTextBox.Text.Trim()
-            };
-            if (_loadedOwner != null)
-                newOwner.Id = _loadedOwner.Id;
+            var newOwner = _loadedOwner != null ? _loadedOwner.Clone() : new User();
+            newOwner.LongName  = LongNameTextBox.Text.Trim();
+            newOwner.ShortName = ShortNameTextBox.Text.Trim();
             await _protocolService.SetOwnerAsync(newOwner);
-            await System.Threading.Tasks.Task.Delay(300);
+            await Delay();
 
             // Device Config
-            var newDevice = new DeviceConfig
-            {
-                Role = (Role)GetComboBoxTag(RoleComboBox),
-                RebroadcastMode = (RebroadcastMode)GetComboBoxTag(RebroadcastComboBox),
-                NodeInfoBroadcastSecs = HumanTimeToSeconds(NodeInfoIntervalTextBox.Text),
-                Tzdef = TzdefTextBox.Text.Trim(),
-                LedHeartbeatDisabled = LedHeartbeatCheckBox.IsChecked == true
-            };
+            var newDevice = _loadedDevice != null ? _loadedDevice.Clone() : new DeviceConfig();
+            newDevice.Role                   = (Role)GetComboBoxTag(RoleComboBox);
+            newDevice.RebroadcastMode        = (RebroadcastMode)GetComboBoxTag(RebroadcastComboBox);
+            newDevice.NodeInfoBroadcastSecs  = HumanTimeToSeconds(NodeInfoIntervalTextBox.Text);
+            newDevice.Tzdef                  = TzdefTextBox.Text.Trim();
+            newDevice.LedHeartbeatDisabled   = LedHeartbeatCheckBox.IsChecked == true;
+            newDevice.DoubleTapAsButtonPress = DoubleTapCheckBox.IsChecked == true;
             await _protocolService.SetDeviceConfigAsync(newDevice);
-            await System.Threading.Tasks.Task.Delay(300);
+            await Delay();
 
-            // Position Config
-            var newPosition = new PositionConfig
-            {
-                GpsMode = (GpsMode)GetComboBoxTag(GpsModeComboBox),
-                PositionBroadcastSecs = HumanTimeToSeconds(PosBroadcastSecsTextBox.Text),
-                PositionBroadcastSmartEnabled = SmartBroadcastCheckBox.IsChecked == true,
-                PositionBroadcastSmartMinimumDistance = uint.TryParse(MinDistanceTextBox.Text, out var md) ? md : 0,
-                PositionBroadcastSmartMinimumSpeed = uint.TryParse(MinSpeedTextBox.Text, out var ms) ? ms : 0
-            };
-            await _protocolService.SetPositionConfigAsync(newPosition);
-            await System.Threading.Tasks.Task.Delay(300);
-
-            // LoRa Config — clone to preserve all fields, only update what we show
+            // LoRa Config
             if (_loadedLora != null)
             {
                 var newLora = _loadedLora.Clone();
-                // Only update region if a selection was made (keepIfNotFound=true means original stays if unrecognized)
-                var regionTag = GetComboBoxTag(LoraRegionComboBox);
-                newLora.Region = (Meshtastic.Protobufs.Region)regionTag;
-                newLora.UsePreset = LoraUsePresetCheckBox.IsChecked == true;
-                newLora.ModemPreset = (Meshtastic.Protobufs.ModemPreset)GetComboBoxTag(LoraPresetComboBox);
-                newLora.HopLimit = uint.TryParse(HopLimitTextBox.Text, out var hl) ? hl : 3;
-                newLora.TxEnabled = TxEnabledCheckBox.IsChecked == true;
-                newLora.TxPower = int.TryParse(TxPowerTextBox.Text, out var tp) ? tp : 0;
+                newLora.Region            = (Meshtastic.Protobufs.Region)GetComboBoxTag(LoraRegionComboBox);
+                newLora.UsePreset         = LoraUsePresetCheckBox.IsChecked == true;
+                newLora.ModemPreset       = (Meshtastic.Protobufs.ModemPreset)GetComboBoxTag(LoraPresetComboBox);
+                newLora.HopLimit          = uint.TryParse(HopLimitTextBox.Text, out var hl) ? hl : 3;
+                newLora.TxEnabled         = TxEnabledCheckBox.IsChecked == true;
+                newLora.TxPower           = int.TryParse(TxPowerTextBox.Text, out var tp) ? tp : 0;
+                newLora.ChannelNum        = uint.TryParse(LoraChannelNumTextBox.Text, out var cn) ? cn : 0;
+                newLora.OverrideDutyCycle = LoraOverrideDutyCycleCheckBox.IsChecked == true;
+                newLora.Sx126XRxBoostedGain = LoraSx126xRxBoostedCheckBox.IsChecked == true;
                 await _protocolService.SetLoRaConfigAsync(newLora);
-                await System.Threading.Tasks.Task.Delay(300);
+                await Delay();
             }
 
-            // MQTT Config
-            var newMqtt = new MQTTConfig
-            {
-                Enabled = MqttEnabledCheckBox.IsChecked == true,
-                Address = MqttAddressTextBox.Text.Trim(),
-                Username = MqttUsernameTextBox.Text.Trim(),
-                Password = MqttPasswordBox.Password,
-                EncryptionEnabled = MqttEncryptionCheckBox.IsChecked == true,
-                JsonEnabled = MqttJsonCheckBox.IsChecked == true,
-                TlsEnabled = MqttTlsCheckBox.IsChecked == true,
-                Root = MqttRootTextBox.Text.Trim(),
-                ProxyToClientEnabled = MqttProxyCheckBox.IsChecked == true,
-                MapReportingEnabled = MqttMapReportingCheckBox.IsChecked == true
-            };
-            await _protocolService.SetMqttConfigAsync(newMqtt);
-            await System.Threading.Tasks.Task.Delay(300);
+            // Position Config
+            var newPosition = _loadedPosition != null ? _loadedPosition.Clone() : new PositionConfig();
+            newPosition.GpsMode                             = (GpsMode)GetComboBoxTag(GpsModeComboBox);
+            newPosition.PositionBroadcastSecs               = HumanTimeToSeconds(PosBroadcastSecsTextBox.Text);
+            newPosition.PositionBroadcastSmartEnabled       = SmartBroadcastCheckBox.IsChecked == true;
+            newPosition.PositionBroadcastSmartMinimumDistance = uint.TryParse(MinDistanceTextBox.Text, out var md) ? md : 0;
+            newPosition.PositionBroadcastSmartMinimumSpeed  = uint.TryParse(MinSpeedTextBox.Text, out var ms) ? ms : 0;
+            newPosition.GpsUpdateInterval                   = uint.TryParse(GpsUpdateIntervalTextBox.Text, out var gu) ? gu : 0;
+            await _protocolService.SetPositionConfigAsync(newPosition);
+            await Delay();
 
-            // Telemetry Config
-            var newTelemetry = new TelemetryConfig
+            // Power Config
+            if (_loadedPower != null)
             {
-                DeviceUpdateInterval = HumanTimeToSeconds(DeviceTelemetryIntervalTextBox.Text),
-                EnvironmentUpdateInterval = HumanTimeToSeconds(EnvironmentIntervalTextBox.Text),
-                EnvironmentDisplayFahrenheit = FahrenheitCheckBox.IsChecked == true,
-                EnvironmentMeasurementEnabled = EnvironmentMeasurementCheckBox.IsChecked == true,
-                AirQualityInterval = HumanTimeToSeconds(AirQualityIntervalTextBox.Text),
-                PowerUpdateInterval = HumanTimeToSeconds(PowerIntervalTextBox.Text)
-            };
-            await _protocolService.SetTelemetryConfigAsync(newTelemetry);
-            await System.Threading.Tasks.Task.Delay(300);
+                var newPower = _loadedPower.Clone();
+                newPower.IsPowerSaving              = PowerSavingCheckBox.IsChecked == true;
+                newPower.OnBatteryShutdownAfterSecs = uint.TryParse(ShutdownAfterSecsTextBox.Text, out var sa) ? sa : 0;
+                newPower.WaitBluetoothSecs          = uint.TryParse(WaitBtSecsTextBox.Text, out var wb) ? wb : 0;
+                newPower.SdsSecs                    = uint.TryParse(SdsSecsTextBox.Text, out var sds) ? sds : 0;
+                newPower.LsSecs                     = uint.TryParse(LsSecsTextBox.Text, out var ls) ? ls : 0;
+                newPower.MinWakeSecs                = uint.TryParse(MinWakeSecsTextBox.Text, out var mw) ? mw : 0;
+                await _protocolService.SetPowerConfigAsync(newPower);
+                await Delay();
+            }
+
+            // Network Config
+            if (_loadedNetwork != null)
+            {
+                var newNetwork = _loadedNetwork.Clone();
+                newNetwork.WifiEnabled = WifiEnabledCheckBox.IsChecked == true;
+                newNetwork.WifiSsid    = WifiSsidTextBox.Text.Trim();
+                newNetwork.WifiPsk     = WifiPskBox.Text.Trim();
+                newNetwork.NtpServer   = NtpServerTextBox.Text.Trim();
+                await _protocolService.SetNetworkConfigAsync(newNetwork);
+                await Delay();
+            }
+
+            // Display Config
+            if (_loadedDisplay != null)
+            {
+                var newDisplay = _loadedDisplay.Clone();
+                newDisplay.ScreenOnSecs           = HumanTimeToSeconds(ScreenOnSecsTextBox.Text);
+                newDisplay.AutoScreenCarouselSecs = uint.TryParse(AutoCarouselSecsTextBox.Text, out var carousel) ? carousel : 0;
+                newDisplay.CompassNorthTop        = CompassNorthTopCheckBox.IsChecked == true;
+                newDisplay.FlipScreen             = FlipScreenCheckBox.IsChecked == true;
+                await _protocolService.SetDisplayConfigAsync(newDisplay);
+                await Delay();
+            }
 
             // Bluetooth Config
-            var newBluetooth = new BluetoothConfig
-            {
-                Enabled = BtEnabledCheckBox.IsChecked == true,
-                Mode = (uint)GetComboBoxTag(BtModeComboBox),
-                FixedPin = uint.TryParse(BtFixedPinTextBox.Text.Trim(), out var pin) ? pin : 0
-            };
+            var newBluetooth = _loadedBluetooth != null ? _loadedBluetooth.Clone() : new BluetoothConfig();
+            newBluetooth.Enabled  = BtEnabledCheckBox.IsChecked == true;
+            newBluetooth.Mode     = (uint)GetComboBoxTag(BtModeComboBox);
+            newBluetooth.FixedPin = uint.TryParse(BtFixedPinTextBox.Text.Trim(), out var pin) ? pin : 0;
             await _protocolService.SetBluetoothConfigAsync(newBluetooth);
+            await Delay();
 
-            UpdateStatus("Gespeichert! Gerät wendet Änderungen an...");
-            Services.Logger.WriteLine("NodeConfigWindow: All configs saved");
+            // MQTT Config
+            var newMqtt = _loadedMqtt != null ? _loadedMqtt.Clone() : new MQTTConfig();
+            newMqtt.Enabled             = MqttEnabledCheckBox.IsChecked == true;
+            newMqtt.Address             = MqttAddressTextBox.Text.Trim();
+            newMqtt.Username            = MqttUsernameTextBox.Text.Trim();
+            newMqtt.Password            = MqttPasswordBox.Password;
+            newMqtt.EncryptionEnabled   = MqttEncryptionCheckBox.IsChecked == true;
+            newMqtt.JsonEnabled         = MqttJsonCheckBox.IsChecked == true;
+            newMqtt.TlsEnabled          = MqttTlsCheckBox.IsChecked == true;
+            newMqtt.Root                = MqttRootTextBox.Text.Trim();
+            newMqtt.ProxyToClientEnabled = MqttProxyCheckBox.IsChecked == true;
+            newMqtt.MapReportingEnabled = MqttMapReportingCheckBox.IsChecked == true;
+            await _protocolService.SetMqttConfigAsync(newMqtt);
+            await Delay();
+
+            // Telemetry Config
+            var newTelemetry = _loadedTelemetry != null ? _loadedTelemetry.Clone() : new TelemetryConfig();
+            newTelemetry.DeviceUpdateInterval         = HumanTimeToSeconds(DeviceTelemetryIntervalTextBox.Text);
+            newTelemetry.EnvironmentUpdateInterval    = HumanTimeToSeconds(EnvironmentIntervalTextBox.Text);
+            newTelemetry.EnvironmentMeasurementEnabled = EnvironmentMeasurementCheckBox.IsChecked == true;
+            newTelemetry.EnvironmentDisplayFahrenheit = FahrenheitCheckBox.IsChecked == true;
+            newTelemetry.AirQualityInterval           = HumanTimeToSeconds(AirQualityIntervalTextBox.Text);
+            newTelemetry.PowerUpdateInterval          = HumanTimeToSeconds(PowerIntervalTextBox.Text);
+            newTelemetry.PowerMeasurementEnabled      = PowerMeasurementCheckBox.IsChecked == true;
+            await _protocolService.SetTelemetryConfigAsync(newTelemetry);
+            await Delay();
+
+            // Neighbor Info Config
+            if (_loadedNeighborInfo != null)
+            {
+                var newNi = _loadedNeighborInfo.Clone();
+                newNi.Enabled        = NiEnabledCheckBox.IsChecked == true;
+                newNi.UpdateInterval = HumanTimeToSeconds(NiIntervalTextBox.Text);
+                await _protocolService.SetNeighborInfoConfigAsync(newNi);
+                await Delay();
+            }
+
+            // Store & Forward Config
+            if (_loadedStoreForward != null)
+            {
+                var newSf = _loadedStoreForward.Clone();
+                newSf.Enabled           = SfEnabledCheckBox.IsChecked == true;
+                newSf.Heartbeat         = SfHeartbeatCheckBox.IsChecked == true;
+                newSf.Records           = uint.TryParse(SfRecordsTextBox.Text, out var sr) ? sr : 0;
+                newSf.HistoryReturnMax  = uint.TryParse(SfHistoryMaxTextBox.Text, out var shm) ? shm : 0;
+                newSf.HistoryReturnWindow = uint.TryParse(SfHistoryWindowTextBox.Text, out var shw) ? shw : 0;
+                await _protocolService.SetStoreForwardConfigAsync(newSf);
+                await Delay();
+            }
+
+            // External Notification Config
+            if (_loadedExtNotif != null)
+            {
+                var newEn = _loadedExtNotif.Clone();
+                newEn.Enabled       = EnEnabledCheckBox.IsChecked == true;
+                newEn.Output        = uint.TryParse(EnOutputTextBox.Text, out var eo) ? eo : 0;
+                newEn.OutputMs      = uint.TryParse(EnOutputMsTextBox.Text, out var ems) ? ems : 1000;
+                newEn.Active        = EnActiveCheckBox.IsChecked == true;
+                newEn.AlertMessage  = EnAlertMessageCheckBox.IsChecked == true;
+                newEn.AlertBell     = EnAlertBellCheckBox.IsChecked == true;
+                await _protocolService.SetExternalNotificationConfigAsync(newEn);
+                await Delay();
+            }
+
+            // Canned Message Config
+            if (_loadedCannedMsg != null)
+            {
+                var newCm = _loadedCannedMsg.Clone();
+                newCm.Enabled          = CmEnabledCheckBox.IsChecked == true;
+                newCm.SendBell         = CmSendBellCheckBox.IsChecked == true;
+                newCm.AllowInputSource = CmAllowInputSourceTextBox.Text.Trim();
+                newCm.Rotary1Enabled   = CmRotary1CheckBox.IsChecked == true;
+                newCm.Updown1Enabled   = CmUpdown1CheckBox.IsChecked == true;
+                await _protocolService.SetCannedMessageConfigAsync(newCm);
+                await Delay();
+            }
+
+            // Range Test Config
+            if (_loadedRangeTest != null)
+            {
+                var newRt = _loadedRangeTest.Clone();
+                newRt.Enabled = RtEnabledCheckBox.IsChecked == true;
+                newRt.Sender  = uint.TryParse(RtSenderTextBox.Text, out var rts) ? rts : 0;
+                newRt.Save    = RtSaveCheckBox.IsChecked == true;
+                await _protocolService.SetRangeTestConfigAsync(newRt);
+                await Delay();
+            }
+
+            // Serial Config
+            if (_loadedSerial != null)
+            {
+                var newSer = _loadedSerial.Clone();
+                newSer.Enabled  = SerEnabledCheckBox.IsChecked == true;
+                newSer.Echo     = SerEchoCheckBox.IsChecked == true;
+                newSer.Rxd      = uint.TryParse(SerRxdTextBox.Text, out var srx) ? srx : 0;
+                newSer.Txd      = uint.TryParse(SerTxdTextBox.Text, out var stx) ? stx : 0;
+                newSer.Baud     = (uint)GetComboBoxTag(SerBaudComboBox);
+                newSer.Timeout  = uint.TryParse(SerTimeoutTextBox.Text, out var sto) ? sto : 0;
+                newSer.Mode     = (uint)GetComboBoxTag(SerModeComboBox);
+                await _protocolService.SetSerialConfigAsync(newSer);
+                await Delay();
+            }
+
+            // Commit — device applies all changes and reboots
+            await _protocolService.CommitEditSettingsAsync();
+
+            UpdateStatus("Gespeichert! Gerät wendet Änderungen an und startet neu...");
+            Logger.WriteLine("NodeConfigWindow: All configs saved (commit sent)");
         }
         catch (Exception ex)
         {
             UpdateStatus($"Fehler beim Speichern: {ex.Message}");
-            Services.Logger.WriteLine($"NodeConfigWindow save error: {ex.Message}");
+            Logger.WriteLine($"NodeConfigWindow save error: {ex.Message}");
             MessageBox.Show($"Fehler beim Speichern: {ex.Message}", "Fehler", MessageBoxButton.OK, MessageBoxImage.Error);
         }
         finally
@@ -448,15 +810,5 @@ public partial class NodeConfigWindow : Window
         }
     }
 
-    private void BtModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        // Enable fixed-PIN field only when mode 1 (FIXED_PIN) is selected
-        if (BtFixedPinTextBox != null)
-            BtFixedPinTextBox.IsEnabled = GetComboBoxTag(BtModeComboBox) == 1;
-    }
-
-    private void Close_Click(object sender, RoutedEventArgs e)
-    {
-        Close();
-    }
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/MeshhessenClient/NodeConfigWindow.xaml.cs
+++ b/MeshhessenClient/NodeConfigWindow.xaml.cs
@@ -11,6 +11,7 @@ namespace MeshhessenClient;
 public partial class NodeConfigWindow : Window
 {
     private readonly MeshtasticProtocolService _protocolService;
+    private Func<(double lat, double lon)?>? _mapCenterProvider;
 
     // Loaded configs (for clone-and-update pattern)
     private User?                      _loadedOwner;
@@ -41,10 +42,11 @@ public partial class NodeConfigWindow : Window
     // Map Tag → content panel
     private Dictionary<string, FrameworkElement> _panels = new();
 
-    public NodeConfigWindow(MeshtasticProtocolService protocolService)
+    public NodeConfigWindow(MeshtasticProtocolService protocolService, Func<(double lat, double lon)?>? mapCenterProvider = null)
     {
         InitializeComponent();
         _protocolService = protocolService;
+        _mapCenterProvider = mapCenterProvider;
 
         // Wire up events
         _protocolService.OwnerReceived                    += OnOwnerReceived;
@@ -114,6 +116,8 @@ public partial class NodeConfigWindow : Window
                 ["Channels"]    = PanelChannels,
             };
 
+            InitPrecisionComboBoxes();
+
             // Select first real item (User)
             foreach (ListBoxItem item in NavList.Items)
                 if (item.Tag is string) { NavList.SelectedItem = item; break; }
@@ -146,13 +150,13 @@ public partial class NodeConfigWindow : Window
             _receivedConfigs.Clear();
 
             // Register all configs we expect to receive
+            // Channels are NOT included — disabled channels never fire, so they'd block completion
             _expectedConfigs.UnionWith(new[]
             {
                 "owner", "device", "lora", "position", "power", "network",
                 "display", "bluetooth", "mqtt", "telemetry", "neighborinfo",
                 "storeforward", "extnotif", "cannedmsg", "rangetest", "serial",
-                "security",
-                "ch0", "ch1", "ch2", "ch3", "ch4", "ch5", "ch6", "ch7"
+                "security"
             });
 
             UpdateStatus(Loc("StrNcLoadingProgress", "0", _expectedConfigs.Count.ToString()));
@@ -317,6 +321,7 @@ public partial class NodeConfigWindow : Window
         {
             SelectComboBoxByTag(GpsModeComboBox, (int)config.GpsMode);
             FixedPositionCheckBox.IsChecked  = config.FixedPosition;
+            FixedPositionPanel.Visibility    = config.FixedPosition ? Visibility.Visible : Visibility.Collapsed;
             PosBroadcastSecsTextBox.Text     = SecondsToHumanTime(config.PositionBroadcastSecs);
             SmartBroadcastCheckBox.IsChecked = config.PositionBroadcastSmartEnabled;
             MinDistanceTextBox.Text          = config.BroadcastSmartMinimumDistance.ToString();
@@ -544,9 +549,20 @@ public partial class NodeConfigWindow : Window
                 ? BitConverter.ToString(config.PublicKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
                 : string.Empty;
 
-            // Admin keys: one Base64 per line
-            SecAdminKeyTextBox.Text = string.Join(Environment.NewLine,
-                config.AdminKey.Select(k => Convert.ToBase64String(k.ToByteArray())));
+            // Private key: stored in box but masked; toggle reveals it
+            SecPrivKeyBox.Text = config.PrivateKey != null && config.PrivateKey.Length > 0
+                ? BitConverter.ToString(config.PrivateKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
+                : string.Empty;
+            // Ensure masked view is visible
+            SecPrivKeyToggle.IsChecked = false;
+            SecPrivKeyMaskBox.Visibility = Visibility.Visible;
+            SecPrivKeyBox.Visibility     = Visibility.Collapsed;
+
+            // Admin keys: separate fields
+            var keys = config.AdminKey.ToList();
+            SecAdminKey1TextBox.Text = keys.Count > 0 ? Convert.ToBase64String(keys[0].ToByteArray()) : string.Empty;
+            SecAdminKey2TextBox.Text = keys.Count > 1 ? Convert.ToBase64String(keys[1].ToByteArray()) : string.Empty;
+            SecAdminKey3TextBox.Text = keys.Count > 2 ? Convert.ToBase64String(keys[2].ToByteArray()) : string.Empty;
 
             SecSerialEnabledCheckBox.IsChecked = config.SerialEnabled;
             SecDebugLogCheckBox.IsChecked      = config.DebugLogApiEnabled;
@@ -556,6 +572,21 @@ public partial class NodeConfigWindow : Window
         });
     }
 
+    private void SecPrivKeyToggle_Checked(object sender, RoutedEventArgs e)
+    {
+        SecPrivKeyMaskBox.Visibility = Visibility.Collapsed;
+        SecPrivKeyBox.Visibility     = Visibility.Visible;
+        SecPrivKeyBox.Focus();
+        SecPrivKeyToggle.ToolTip = Application.Current.TryFindResource("StrNcHidePassword");
+    }
+
+    private void SecPrivKeyToggle_Unchecked(object sender, RoutedEventArgs e)
+    {
+        SecPrivKeyBox.Visibility     = Visibility.Collapsed;
+        SecPrivKeyMaskBox.Visibility = Visibility.Visible;
+        SecPrivKeyToggle.ToolTip = Application.Current.TryFindResource("StrNcShowPassword");
+    }
+
     private void OnChannelInfoReceived(object? sender, ChannelInfo info)
     {
         if (info.Index < 0 || info.Index >= 8) return;
@@ -563,25 +594,32 @@ public partial class NodeConfigWindow : Window
 
         Dispatcher.BeginInvoke(() =>
         {
-            // Set the row UI for this channel
-            var role = info.Role;
-            var name = string.IsNullOrEmpty(info.Name) ? $"Ch {info.Index}" : info.Name;
+            bool isActive = !string.Equals(info.Role, "Disabled", StringComparison.OrdinalIgnoreCase);
+            var name = string.IsNullOrEmpty(info.Name) ? (isActive ? $"Ch {info.Index}" : "—") : info.Name;
 
-            switch (info.Index)
+            (TextBlock role, TextBlock nameTb, CheckBox up, CheckBox dn, ComboBox prec, Grid row) = info.Index switch
             {
-                case 0: Ch0Role.Text = role; Ch0Name.Text = name; Ch0Uplink.IsChecked = info.Uplink; Ch0Downlink.IsChecked = info.Downlink; break;
-                case 1: Ch1Role.Text = role; Ch1Name.Text = name; Ch1Uplink.IsChecked = info.Uplink; Ch1Downlink.IsChecked = info.Downlink; break;
-                case 2: Ch2Role.Text = role; Ch2Name.Text = name; Ch2Uplink.IsChecked = info.Uplink; Ch2Downlink.IsChecked = info.Downlink; break;
-                case 3: Ch3Role.Text = role; Ch3Name.Text = name; Ch3Uplink.IsChecked = info.Uplink; Ch3Downlink.IsChecked = info.Downlink; break;
-                case 4: Ch4Role.Text = role; Ch4Name.Text = name; Ch4Uplink.IsChecked = info.Uplink; Ch4Downlink.IsChecked = info.Downlink; break;
-                case 5: Ch5Role.Text = role; Ch5Name.Text = name; Ch5Uplink.IsChecked = info.Uplink; Ch5Downlink.IsChecked = info.Downlink; break;
-                case 6: Ch6Role.Text = role; Ch6Name.Text = name; Ch6Uplink.IsChecked = info.Uplink; Ch6Downlink.IsChecked = info.Downlink; break;
-                case 7: Ch7Role.Text = role; Ch7Name.Text = name; Ch7Uplink.IsChecked = info.Uplink; Ch7Downlink.IsChecked = info.Downlink; break;
-            }
-
-            MarkReceived($"ch{info.Index}");
+                0 => (Ch0Role, Ch0Name, Ch0Uplink, Ch0Downlink, Ch0Precision, ChRow0),
+                1 => (Ch1Role, Ch1Name, Ch1Uplink, Ch1Downlink, Ch1Precision, ChRow1),
+                2 => (Ch2Role, Ch2Name, Ch2Uplink, Ch2Downlink, Ch2Precision, ChRow2),
+                3 => (Ch3Role, Ch3Name, Ch3Uplink, Ch3Downlink, Ch3Precision, ChRow3),
+                4 => (Ch4Role, Ch4Name, Ch4Uplink, Ch4Downlink, Ch4Precision, ChRow4),
+                5 => (Ch5Role, Ch5Name, Ch5Uplink, Ch5Downlink, Ch5Precision, ChRow5),
+                6 => (Ch6Role, Ch6Name, Ch6Uplink, Ch6Downlink, Ch6Precision, ChRow6),
+                _ => (Ch7Role, Ch7Name, Ch7Uplink, Ch7Downlink, Ch7Precision, ChRow7),
+            };
+            role.Text = info.Role;
+            nameTb.Text = name;
+            up.IsChecked = info.Uplink;
+            dn.IsChecked = info.Downlink;
+            SelectComboBoxByTag(prec, (int)info.PositionPrecision);
+            // Dim disabled channels visually but keep all controls interactive
+            row.Opacity = isActive ? 1.0 : 0.45;
         });
     }
+
+    private static bool IsValidHex(string s) =>
+        s.Length % 2 == 0 && s.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'));
 
     // ========== Interval helpers ==========
 
@@ -640,11 +678,60 @@ public partial class NodeConfigWindow : Window
         return 0;
     }
 
+    // ========== Precision ComboBox helpers ==========
+
+    private static readonly (string Label, uint Value)[] PrecisionOptions =
+    {
+        ("Kein Standort", 0),
+        ("~23km",        10),
+        ("~2.9km",       13),
+        ("~360m",        16),
+        ("~45m",         19),
+        ("Genau",        32),
+    };
+
+    private void InitPrecisionComboBoxes()
+    {
+        foreach (var cb in new[] { Ch0Precision, Ch1Precision, Ch2Precision, Ch3Precision,
+                                   Ch4Precision, Ch5Precision, Ch6Precision, Ch7Precision })
+        {
+            cb.Items.Clear();
+            foreach (var (label, value) in PrecisionOptions)
+                cb.Items.Add(new ComboBoxItem { Content = label, Tag = value.ToString() });
+            cb.SelectedIndex = 0;
+        }
+    }
+
+
     // ========== UI events ==========
 
     private void LoraUsePresetCheckBox_Changed(object sender, RoutedEventArgs e)
     {
         LoraPresetComboBox.IsEnabled = LoraUsePresetCheckBox.IsChecked == true;
+    }
+
+    private void FixedPositionCheckBox_Changed(object sender, RoutedEventArgs e)
+    {
+        if (FixedPositionPanel != null)
+            FixedPositionPanel.Visibility = FixedPositionCheckBox.IsChecked == true
+                ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void PickFromMap_Click(object sender, RoutedEventArgs e)
+    {
+        if (_mapCenterProvider == null)
+        {
+            MessageBox.Show("Kein Kartenkontext verfügbar.", "Hinweis", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+        var pos = _mapCenterProvider();
+        if (pos == null)
+        {
+            MessageBox.Show("Konnte Kartenposition nicht lesen.", "Hinweis", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+        FixedLatTextBox.Text = pos.Value.lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+        FixedLonTextBox.Text = pos.Value.lon.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private void BtModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -747,20 +834,21 @@ public partial class NodeConfigWindow : Window
             await Delay();
 
             // Device Config
-            var newDevice = _loadedDevice != null ? _loadedDevice.Clone() : new DeviceConfig();
-            newDevice.Role                   = (Role)GetComboBoxTag(RoleComboBox);
-            newDevice.RebroadcastMode        = (RebroadcastMode)GetComboBoxTag(RebroadcastComboBox);
-            newDevice.NodeInfoBroadcastSecs  = HumanTimeToSeconds(NodeInfoIntervalTextBox.Text);
-            newDevice.Tzdef                  = TzdefTextBox.Text.Trim();
-            newDevice.LedHeartbeatDisabled   = LedHeartbeatCheckBox.IsChecked == true;
-            newDevice.DoubleTapAsButtonPress = DoubleTapCheckBox.IsChecked == true;
-            newDevice.DisableTripleClick     = DisableTripleClickCheckBox.IsChecked == true;
-            newDevice.ButtonGpio             = uint.TryParse(ButtonGpioTextBox.Text, out var bgp) ? bgp : 0;
-            newDevice.BuzzerGpio             = uint.TryParse(BuzzerGpioTextBox.Text, out var bzg) ? bzg : 0;
-            await _protocolService.SetDeviceConfigAsync(newDevice);
-            await Delay();
-
-            // LoRa Config
+            if (_loadedDevice != null)
+            {
+                var newDevice = _loadedDevice.Clone();
+                newDevice.Role                   = (Role)GetComboBoxTag(RoleComboBox);
+                newDevice.RebroadcastMode        = (RebroadcastMode)GetComboBoxTag(RebroadcastComboBox);
+                newDevice.NodeInfoBroadcastSecs  = HumanTimeToSeconds(NodeInfoIntervalTextBox.Text);
+                newDevice.Tzdef                  = TzdefTextBox.Text.Trim();
+                newDevice.LedHeartbeatDisabled   = LedHeartbeatCheckBox.IsChecked == true;
+                newDevice.DoubleTapAsButtonPress = DoubleTapCheckBox.IsChecked == true;
+                newDevice.DisableTripleClick     = DisableTripleClickCheckBox.IsChecked == true;
+                newDevice.ButtonGpio             = uint.TryParse(ButtonGpioTextBox.Text, out var bgp) ? bgp : 0;
+                newDevice.BuzzerGpio             = uint.TryParse(BuzzerGpioTextBox.Text, out var bzg) ? bzg : 0;
+                await _protocolService.SetDeviceConfigAsync(newDevice);
+                await Delay();
+            }
             if (_loadedLora != null)
             {
                 var newLora = _loadedLora.Clone();
@@ -781,19 +869,34 @@ public partial class NodeConfigWindow : Window
             }
 
             // Position Config
-            var newPosition = _loadedPosition != null ? _loadedPosition.Clone() : new PositionConfig();
-            newPosition.GpsMode                             = (GpsMode)GetComboBoxTag(GpsModeComboBox);
-            newPosition.FixedPosition                       = FixedPositionCheckBox.IsChecked == true;
-            newPosition.PositionBroadcastSecs               = HumanTimeToSeconds(PosBroadcastSecsTextBox.Text);
-            newPosition.PositionBroadcastSmartEnabled       = SmartBroadcastCheckBox.IsChecked == true;
-            newPosition.BroadcastSmartMinimumDistance       = uint.TryParse(MinDistanceTextBox.Text, out var md) ? md : 0;
-            newPosition.BroadcastSmartMinimumIntervalSecs   = uint.TryParse(MinIntervalSecsTextBox.Text, out var mis) ? mis : 0;
-            newPosition.GpsUpdateInterval                   = uint.TryParse(GpsUpdateIntervalTextBox.Text, out var gu) ? gu : 0;
-            newPosition.RxGpio                              = uint.TryParse(GpsRxGpioTextBox.Text, out var rxg) ? rxg : 0;
-            newPosition.TxGpio                              = uint.TryParse(GpsTxGpioTextBox.Text, out var txg) ? txg : 0;
-            newPosition.GpsEnGpio                           = uint.TryParse(GpsEnGpioTextBox.Text, out var eng) ? eng : 0;
-            await _protocolService.SetPositionConfigAsync(newPosition);
-            await Delay();
+            if (_loadedPosition != null)
+            {
+                var newPosition = _loadedPosition.Clone();
+                newPosition.GpsMode                           = (GpsMode)GetComboBoxTag(GpsModeComboBox);
+                newPosition.FixedPosition                     = FixedPositionCheckBox.IsChecked == true;
+                newPosition.PositionBroadcastSecs             = HumanTimeToSeconds(PosBroadcastSecsTextBox.Text);
+                newPosition.PositionBroadcastSmartEnabled     = SmartBroadcastCheckBox.IsChecked == true;
+                newPosition.BroadcastSmartMinimumDistance     = uint.TryParse(MinDistanceTextBox.Text, out var md) ? md : 0;
+                newPosition.BroadcastSmartMinimumIntervalSecs = uint.TryParse(MinIntervalSecsTextBox.Text, out var mis) ? mis : 0;
+                newPosition.GpsUpdateInterval                 = uint.TryParse(GpsUpdateIntervalTextBox.Text, out var gu) ? gu : 0;
+                newPosition.RxGpio                            = uint.TryParse(GpsRxGpioTextBox.Text, out var rxg) ? rxg : 0;
+                newPosition.TxGpio                            = uint.TryParse(GpsTxGpioTextBox.Text, out var txg) ? txg : 0;
+                newPosition.GpsEnGpio                         = uint.TryParse(GpsEnGpioTextBox.Text, out var eng) ? eng : 0;
+                await _protocolService.SetPositionConfigAsync(newPosition);
+                await Delay();
+
+                // Feste Position übertragen wenn aktiviert und Koordinaten eingegeben
+                if (newPosition.FixedPosition &&
+                    double.TryParse(FixedLatTextBox.Text, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out double lat) &&
+                    double.TryParse(FixedLonTextBox.Text, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out double lon))
+                {
+                    int alt = int.TryParse(FixedAltTextBox.Text, out var a) ? a : 0;
+                    await _protocolService.SetFixedPositionAsync(lat, lon, alt);
+                    await Delay();
+                }
+            }
 
             // Power Config
             if (_loadedPower != null)
@@ -850,12 +953,15 @@ public partial class NodeConfigWindow : Window
             }
 
             // Bluetooth Config
-            var newBluetooth = _loadedBluetooth != null ? _loadedBluetooth.Clone() : new BluetoothConfig();
-            newBluetooth.Enabled  = BtEnabledCheckBox.IsChecked == true;
-            newBluetooth.Mode     = (uint)GetComboBoxTag(BtModeComboBox);
-            newBluetooth.FixedPin = uint.TryParse(BtFixedPinTextBox.Text.Trim(), out var pin) ? pin : 0;
-            await _protocolService.SetBluetoothConfigAsync(newBluetooth);
-            await Delay();
+            if (_loadedBluetooth != null)
+            {
+                var newBluetooth = _loadedBluetooth.Clone();
+                newBluetooth.Enabled  = BtEnabledCheckBox.IsChecked == true;
+                newBluetooth.Mode     = (uint)GetComboBoxTag(BtModeComboBox);
+                newBluetooth.FixedPin = uint.TryParse(BtFixedPinTextBox.Text.Trim(), out var pin) ? pin : 0;
+                await _protocolService.SetBluetoothConfigAsync(newBluetooth);
+                await Delay();
+            }
 
             // MQTT Config
             var newMqtt = _loadedMqtt != null ? _loadedMqtt.Clone() : new MQTTConfig();
@@ -873,16 +979,19 @@ public partial class NodeConfigWindow : Window
             await Delay();
 
             // Telemetry Config
-            var newTelemetry = _loadedTelemetry != null ? _loadedTelemetry.Clone() : new TelemetryConfig();
-            newTelemetry.DeviceUpdateInterval         = HumanTimeToSeconds(DeviceTelemetryIntervalTextBox.Text);
-            newTelemetry.EnvironmentUpdateInterval    = HumanTimeToSeconds(EnvironmentIntervalTextBox.Text);
-            newTelemetry.EnvironmentMeasurementEnabled = EnvironmentMeasurementCheckBox.IsChecked == true;
-            newTelemetry.EnvironmentDisplayFahrenheit = FahrenheitCheckBox.IsChecked == true;
-            newTelemetry.AirQualityInterval           = HumanTimeToSeconds(AirQualityIntervalTextBox.Text);
-            newTelemetry.PowerUpdateInterval          = HumanTimeToSeconds(PowerIntervalTextBox.Text);
-            newTelemetry.PowerMeasurementEnabled      = PowerMeasurementCheckBox.IsChecked == true;
-            await _protocolService.SetTelemetryConfigAsync(newTelemetry);
-            await Delay();
+            if (_loadedTelemetry != null)
+            {
+                var newTelemetry = _loadedTelemetry.Clone();
+                newTelemetry.DeviceUpdateInterval          = HumanTimeToSeconds(DeviceTelemetryIntervalTextBox.Text);
+                newTelemetry.EnvironmentUpdateInterval     = HumanTimeToSeconds(EnvironmentIntervalTextBox.Text);
+                newTelemetry.EnvironmentMeasurementEnabled = EnvironmentMeasurementCheckBox.IsChecked == true;
+                newTelemetry.EnvironmentDisplayFahrenheit  = FahrenheitCheckBox.IsChecked == true;
+                newTelemetry.AirQualityInterval            = HumanTimeToSeconds(AirQualityIntervalTextBox.Text);
+                newTelemetry.PowerUpdateInterval           = HumanTimeToSeconds(PowerIntervalTextBox.Text);
+                newTelemetry.PowerMeasurementEnabled       = PowerMeasurementCheckBox.IsChecked == true;
+                await _protocolService.SetTelemetryConfigAsync(newTelemetry);
+                await Delay();
+            }
 
             // Neighbor Info Config
             if (_loadedNeighborInfo != null)
@@ -960,46 +1069,77 @@ public partial class NodeConfigWindow : Window
                 await Delay();
             }
 
-            // Security Config (only writable fields; public key is read-only)
+            // Security Config
             if (_loadedSecurity != null)
             {
                 var newSec = _loadedSecurity.Clone();
-                newSec.SerialEnabled      = SecSerialEnabledCheckBox.IsChecked == true;
-                newSec.DebugLogApiEnabled = SecDebugLogCheckBox.IsChecked == true;
-                newSec.IsManaged          = SecIsManagedCheckBox.IsChecked == true;
+                newSec.SerialEnabled       = SecSerialEnabledCheckBox.IsChecked == true;
+                newSec.DebugLogApiEnabled  = SecDebugLogCheckBox.IsChecked == true;
+                newSec.IsManaged           = SecIsManagedCheckBox.IsChecked == true;
                 newSec.AdminChannelEnabled = SecAdminChannelCheckBox.IsChecked == true;
+
+                // Private key: only overwrite if user typed a new hex key (different from loaded)
+                var privHex = SecPrivKeyBox.Text.Trim().Replace(" ", "");
+                var loadedHex = _loadedSecurity.PrivateKey != null && _loadedSecurity.PrivateKey.Length > 0
+                    ? BitConverter.ToString(_loadedSecurity.PrivateKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
+                    : string.Empty;
+                if (!string.Equals(privHex, loadedHex, StringComparison.OrdinalIgnoreCase)
+                    && privHex.Length == 64
+                    && IsValidHex(privHex))
+                {
+                    newSec.PrivateKey = ByteString.CopyFrom(Convert.FromHexString(privHex));
+                }
+
+                // Admin keys: rebuild repeated field from 3 text boxes
+                newSec.AdminKey.Clear();
+                foreach (var box in new[] { SecAdminKey1TextBox.Text.Trim(), SecAdminKey2TextBox.Text.Trim(), SecAdminKey3TextBox.Text.Trim() })
+                {
+                    if (string.IsNullOrEmpty(box)) continue;
+                    try { newSec.AdminKey.Add(ByteString.CopyFrom(Convert.FromBase64String(box))); }
+                    catch { /* skip invalid */ }
+                }
+
                 await _protocolService.SetSecurityConfigAsync(newSec);
                 await Delay();
             }
 
-            // Channel uplink/downlink
-            var chBoxes = new (CheckBox? Up, CheckBox? Dn)[]
+            // Channel settings: uplink/downlink/precision (only for active channels)
+            var chControls = new (CheckBox Up, CheckBox Dn, ComboBox Prec)[]
             {
-                (Ch0Uplink, Ch0Downlink), (Ch1Uplink, Ch1Downlink),
-                (Ch2Uplink, Ch2Downlink), (Ch3Uplink, Ch3Downlink),
-                (Ch4Uplink, Ch4Downlink), (Ch5Uplink, Ch5Downlink),
-                (Ch6Uplink, Ch6Downlink), (Ch7Uplink, Ch7Downlink),
+                (Ch0Uplink, Ch0Downlink, Ch0Precision),
+                (Ch1Uplink, Ch1Downlink, Ch1Precision),
+                (Ch2Uplink, Ch2Downlink, Ch2Precision),
+                (Ch3Uplink, Ch3Downlink, Ch3Precision),
+                (Ch4Uplink, Ch4Downlink, Ch4Precision),
+                (Ch5Uplink, Ch5Downlink, Ch5Precision),
+                (Ch6Uplink, Ch6Downlink, Ch6Precision),
+                (Ch7Uplink, Ch7Downlink, Ch7Precision),
             };
             for (int i = 0; i < 8; i++)
             {
                 var info = _loadedChannels[i];
                 if (info == null) continue;
 
-                bool newUplink   = chBoxes[i].Up?.IsChecked == true;
-                bool newDownlink = chBoxes[i].Dn?.IsChecked == true;
-                if (newUplink == info.Uplink && newDownlink == info.Downlink) continue; // no change
-
-                var ch = new Channel { Index = i };
-                var roleEnum = info.Role.ToUpperInvariant() switch
+                // Only save active channels (Primary/Secondary)
+                var loadedRole = info.Role.ToUpperInvariant() switch
                 {
                     "PRIMARY"   => ChannelRole.Primary,
                     "SECONDARY" => ChannelRole.Secondary,
                     _           => ChannelRole.Disabled
                 };
-                ch.Role = roleEnum;
+                if (loadedRole == ChannelRole.Disabled) continue;
+
+                bool newUplink    = chControls[i].Up.IsChecked == true;
+                bool newDownlink  = chControls[i].Dn.IsChecked == true;
+                uint newPrecision = (uint)GetComboBoxTag(chControls[i].Prec);
+
+                if (newUplink == info.Uplink && newDownlink == info.Downlink && newPrecision == info.PositionPrecision) continue;
+
+                var ch = new Channel { Index = i, Role = loadedRole };
                 var settings = new ChannelSettings { UplinkEnabled = newUplink, DownlinkEnabled = newDownlink };
                 if (!string.IsNullOrEmpty(info.Psk))
                     settings.Psk = ByteString.CopyFrom(Convert.FromBase64String(info.Psk));
+                settings.ModuleSettings = new ModuleSettings { PositionPrecision = newPrecision };
                 ch.Settings = settings;
                 await _protocolService.UpdateChannelUplinkDownlinkAsync(ch);
                 await Delay();

--- a/MeshhessenClient/Proto/admin.proto
+++ b/MeshhessenClient/Proto/admin.proto
@@ -43,5 +43,7 @@ message AdminMessage {
     bool nodedb_reset = 100;
     bool get_device_metadata_request = 12;
     DeviceMetadata get_device_metadata_response = 13;
+    Position set_position = 88;
+    bool remove_position = 89;
   }
 }

--- a/MeshhessenClient/Proto/mesh.proto
+++ b/MeshhessenClient/Proto/mesh.proto
@@ -316,6 +316,7 @@ message MQTTConfig {
   string root = 8;
   bool proxy_to_client_enabled = 9;
   bool map_reporting_enabled = 10;
+  uint32 map_report_precision = 11;
 }
 
 message SerialConfig {

--- a/MeshhessenClient/Proto/mesh.proto
+++ b/MeshhessenClient/Proto/mesh.proto
@@ -138,6 +138,11 @@ message Channel {
   ChannelRole role = 3;
 }
 
+message ModuleSettings {
+  uint32 position_precision = 1;
+  bool is_client_muted = 2;
+}
+
 message ChannelSettings {
   uint32 channel_num = 1;
   bytes psk = 2;
@@ -145,6 +150,7 @@ message ChannelSettings {
   fixed32 id = 4;
   bool uplink_enabled = 5;
   bool downlink_enabled = 6;
+  ModuleSettings module_settings = 7;
 }
 
 message SecurityConfig {

--- a/MeshhessenClient/Proto/mesh.proto
+++ b/MeshhessenClient/Proto/mesh.proto
@@ -22,6 +22,7 @@ message User {
   bool is_licensed = 6;
   Role role = 7;
   bytes public_key = 8;
+  optional bool is_unmessagable = 9;
 }
 
 message RouteDiscovery {
@@ -97,6 +98,15 @@ message DeviceMetrics {
   uint32 uptime_seconds = 5;
 }
 
+message MqttClientProxyMessage {
+  string topic = 1;
+  oneof payload_variant {
+    bytes data = 2;
+    string text = 3;
+  }
+  bool retained = 4;
+}
+
 message FromRadio {
   uint32 id = 1;
   oneof payload_variant {
@@ -108,6 +118,7 @@ message FromRadio {
     bool rebooted = 8;
     ModuleConfig module_config = 9;
     Channel channel = 10;
+    MqttClientProxyMessage mqtt_client_proxy_message = 14;
   }
 }
 
@@ -117,6 +128,7 @@ message ToRadio {
     uint32 want_config_id = 3;
     bool disconnect = 4;
     bytes xmodem_packet = 5;
+    MqttClientProxyMessage mqtt_client_proxy_message = 6;
   }
 }
 
@@ -182,11 +194,12 @@ enum GpsMode {
 message DeviceConfig {
   Role role = 1;
   // serial_enabled = 2 deprecated
-  // button_gpio = 4, buzzer_gpio = 5 (GPIO - skipped)
+  uint32 button_gpio = 4;
+  uint32 buzzer_gpio = 5;
   RebroadcastMode rebroadcast_mode = 6;
   uint32 node_info_broadcast_secs = 7;
   bool double_tap_as_button_press = 8;
-  // is_managed = 9 deprecated, disable_triple_click = 10
+  bool disable_triple_click = 10;
   string tzdef = 11;
   bool led_heartbeat_disabled = 12;
 }
@@ -194,21 +207,29 @@ message DeviceConfig {
 message PositionConfig {
   uint32 position_broadcast_secs = 1;
   bool position_broadcast_smart_enabled = 2;
-  uint32 gps_update_interval = 3;
-  uint32 position_broadcast_smart_minimum_distance = 4;
-  uint32 position_broadcast_smart_minimum_speed = 5;
-  GpsMode gps_mode = 6;
+  bool fixed_position = 3;
+  // gps_enabled = 4 deprecated
+  uint32 gps_update_interval = 5;
+  // gps_attempt_time = 6 deprecated
+  uint32 position_flags = 7;
+  uint32 rx_gpio = 8;
+  uint32 tx_gpio = 9;
+  uint32 broadcast_smart_minimum_distance = 10;
+  uint32 broadcast_smart_minimum_interval_secs = 11;
+  uint32 gps_en_gpio = 12;
+  GpsMode gps_mode = 13;
 }
 
 message PowerConfig {
   bool is_power_saving = 1;
   uint32 on_battery_shutdown_after_secs = 2;
-  float adc_multiplier_override = 3;    // preserved but not shown in UI
+  float adc_multiplier_override = 3;
   uint32 wait_bluetooth_secs = 4;
   // field 5 reserved/skipped in firmware
   uint32 sds_secs = 6;
   uint32 ls_secs = 7;
   uint32 min_wake_secs = 8;
+  uint32 device_battery_ina_address = 9;
 }
 
 message NetworkConfig {
@@ -217,14 +238,25 @@ message NetworkConfig {
   string wifi_ssid = 3;
   string wifi_psk = 4;
   string ntp_server = 5;
+  bool eth_enabled = 6;
+  uint32 address_mode = 7;   // 0=DHCP, 1=STATIC
+  // ipv4_config = 8 (nested, skip for now)
+  string rsyslog_server = 9;
 }
 
 message DisplayConfig {
   uint32 screen_on_secs = 1;
-  // gps_format = 2 deprecated in firmware
-  uint32 auto_screen_carousel_secs = 3; // seconds, 0=off
-  bool compass_north_top = 4;
+  // gps_format = 2 deprecated
+  uint32 auto_screen_carousel_secs = 3;
+  bool compass_north_top = 4;           // deprecated in 2.7.4
   bool flip_screen = 5;
+  uint32 units = 6;                     // 0=METRIC, 1=IMPERIAL
+  uint32 oled = 7;                      // 0=AUTO, 1=SSD1306, 2=SH1106, 3=SH1107
+  uint32 displaymode = 8;              // 0=DEFAULT, 1=TWOCOLOR, 2=INVERTED, 3=COLOR
+  bool heading_bold = 9;
+  bool wake_on_tap_or_motion = 10;
+  uint32 compass_orientation = 11;     // 0=0°, 1=90°, 2=180°, 3=270°
+  bool use_12h_clock = 12;
 }
 
 message LoRaConfig {
@@ -233,15 +265,17 @@ message LoRaConfig {
   uint32 bandwidth = 3;
   uint32 spread_factor = 4;
   uint32 coding_rate = 5;
-  uint32 frequency_offset = 6;
+  float frequency_offset = 6;
   Region region = 7;
   uint32 hop_limit = 8;
   bool tx_enabled = 9;
-  float tx_power = 10;
+  int32 tx_power = 10;
   uint32 channel_num = 11;
   bool override_duty_cycle = 12;
   bool sx126x_rx_boosted_gain = 13;
-  uint32 override_frequency = 14;
+  float override_frequency = 14;
+  bool ignore_mqtt = 104;
+  bool config_ok_to_mqtt = 105;
 }
 
 message BluetoothConfig {
@@ -500,6 +534,8 @@ enum Role {
   CLIENT_HIDDEN = 8;
   LOST_AND_FOUND = 9;
   TAK_TRACKER = 10;
+  ROUTER_LATE = 11;
+  CLIENT_BASE = 12;
 }
 
 enum ChannelRole {

--- a/MeshhessenClient/Proto/mesh.proto
+++ b/MeshhessenClient/Proto/mesh.proto
@@ -203,26 +203,28 @@ message PositionConfig {
 message PowerConfig {
   bool is_power_saving = 1;
   uint32 on_battery_shutdown_after_secs = 2;
-  uint32 adc_multiplier_override = 3;
+  float adc_multiplier_override = 3;    // preserved but not shown in UI
   uint32 wait_bluetooth_secs = 4;
-  uint32 sds_secs = 5;
-  uint32 ls_secs = 6;
-  uint32 min_wake_secs = 7;
+  // field 5 reserved/skipped in firmware
+  uint32 sds_secs = 6;
+  uint32 ls_secs = 7;
+  uint32 min_wake_secs = 8;
 }
 
 message NetworkConfig {
   bool wifi_enabled = 1;
-  string wifi_ssid = 2;
-  string wifi_psk = 3;
-  string ntp_server = 4;
+  // field 2 reserved/skipped in firmware
+  string wifi_ssid = 3;
+  string wifi_psk = 4;
+  string ntp_server = 5;
 }
 
 message DisplayConfig {
   uint32 screen_on_secs = 1;
-  bool auto_screen_carousel_secs = 2;
-  bool compass_north_top = 3;
-  bool flip_screen = 4;
-  GpsCoordinateFormat gps_format = 5;
+  // gps_format = 2 deprecated in firmware
+  uint32 auto_screen_carousel_secs = 3; // seconds, 0=off
+  bool compass_north_top = 4;
+  bool flip_screen = 5;
 }
 
 message LoRaConfig {

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -346,7 +346,9 @@
     <sys:String x:Key="StrNcDescMqttJson">Sendet zusätzlich entschlüsselte Pakete als JSON-Text (z. B. für Home Assistant, Node-RED, Grafana).</sys:String>
     <sys:String x:Key="StrNcDescMqttRootTopic">Basis-Topic für alle MQTT-Nachrichten dieses Geräts. Standard: msh</sys:String>
     <sys:String x:Key="StrNcDescMqttProxy">Die verbundene App (Telefon/PC) leitet MQTT-Nachrichten für das Gerät weiter – kein direktes WLAN am Gerät nötig. Hinweis: Dieser Windows-Client unterstützt den Proxy-Modus aktuell nicht aktiv.</sys:String>
-    <sys:String x:Key="StrNcDescMqttMapReport">Sendet die eigene Position an die öffentliche Meshtastic-Weltkarte (map.meshtastic.org).</sys:String>
+    <sys:String x:Key="StrNcDescMqttMapReport">Sendet die eigene Position an die öffentliche Meshtastic-Weltkarte (map.meshtastic.org) und an map.meshhessen.de.</sys:String>
+    <sys:String x:Key="StrNcMqttMapReportPrecision">Genauigkeit Map Report</sys:String>
+    <sys:String x:Key="StrNcDescMqttMapReportPrecision">Positions-Genauigkeit für Map-Report-Pakete. Empfohlen: ~370m oder höher für öffentliche Karten.</sys:String>
     <sys:String x:Key="StrNcDescDeviceTelemetry">Gerätemetriken: Akku-%, Spannung, Kanalauslastung, TX-Airtime. Erscheinen im Telemetrie-Fenster des Clients.</sys:String>
     <sys:String x:Key="StrNcDescEnvTelemetry">Umgebungssensoren (Temperatur, Luftfeuchte, Luftdruck) – benötigt angeschlossenen I²C-Sensor (z. B. BME280).</sys:String>
     <sys:String x:Key="StrNcDescAirQuality">Luftqualitätssensor (PM2.5 u. a.) – benötigt angeschlossenen Sensor (z. B. PMSA003I).</sys:String>
@@ -404,10 +406,16 @@
     <sys:String x:Key="StrNcFixedLon">Längengrad (Longitude)</sys:String>
     <sys:String x:Key="StrNcFixedAlt">Höhe (m)</sys:String>
     <sys:String x:Key="StrNcDescFixedCoords">Dezimalgrad, z.B. 50.123456 / 8.654321. Wird beim Speichern an den Node übertragen.</sys:String>
-    <sys:String x:Key="StrNcPickFromMap">Von Karte übernehmen</sys:String>
-    <sys:String x:Key="StrNcPickFromMapTip">Aktuellen Kartenmittelpunkt als feste Position übernehmen</sys:String>
-    <sys:String x:Key="StrNcPickFromMapHint">Navigiere die Karte auf den gewünschten Standort, dann diesen Button klicken.</sys:String>
+    <sys:String x:Key="StrNcPickFromMap">Von Karte wählen</sys:String>
+    <sys:String x:Key="StrNcPickFromMapTip">Öffnet ein Kartenfenster – dort auf den gewünschten Punkt klicken</sys:String>
+    <sys:String x:Key="StrNcPickFromMapHint">Klicke auf „Von Karte wählen", um ein Kartenfenster zu öffnen und den Standort dort auszuwählen.</sys:String>
     <sys:String x:Key="StrNcMapCenterLabel">Aktueller Kartenmittelpunkt:</sys:String>
+    <sys:String x:Key="StrNcUseCurrentPos">Eigener Kartenpin</sys:String>
+    <sys:String x:Key="StrNcUseCurrentPosTip">Übernimmt die eigene Position (gesetzt per Rechtsklick → „Meine Position setzen" auf der Karte)</sys:String>
+    <sys:String x:Key="StrMapPickerTitle">Position auswählen</sys:String>
+    <sys:String x:Key="StrMapPickerHint">Klicke auf die Karte, um einen Punkt zu wählen – dann „Übernehmen".</sys:String>
+    <sys:String x:Key="StrMapPickerAccept">Übernehmen</sys:String>
+    <sys:String x:Key="StrMapPickerCancel">Abbrechen</sys:String>
     <sys:String x:Key="StrNcMinIntervalSecs">Mindestintervall Smart-Broadcast (s)</sys:String>
     <sys:String x:Key="StrNcDescMinIntervalSecs">Minimale Wartezeit in Sekunden zwischen zwei Smart-Positionssendungen.</sys:String>
     <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>
@@ -467,10 +475,14 @@
     <sys:String x:Key="StrNcDescSecAdminKeys">Öffentliche Schlüssel von Admin-Geräten (Base64). Leeres Feld = nicht gesetzt.</sys:String>
     <!-- Node config: Channels panel -->
     <sys:String x:Key="StrNcNavChannels">Kanäle</sys:String>
+    <sys:String x:Key="StrNcChannelRole">Rolle</sys:String>
+    <sys:String x:Key="StrNcChannelName">Name</sys:String>
     <sys:String x:Key="StrNcChannelPosPrecision">Genauigkeit</sys:String>
-    <sys:String x:Key="StrNcDescChannelPosPrecision">Positions-Genauigkeit für diesen Kanal (0=aus, 10≈23km, 13≈2.8km, 16≈350m, 19≈44m, 32=exakt)</sys:String>
+    <sys:String x:Key="StrNcDescChannelPosPrecision">Positions-Genauigkeit für diesen Kanal. Bit 10–19: von ~23km bis ~45m. 0=deaktiviert, 32=exakt.</sys:String>
     <sys:String x:Key="StrNcChannelUplink">Uplink</sys:String>
     <sys:String x:Key="StrNcChannelDownlink">Downlink</sys:String>
+    <sys:String x:Key="StrNcPrecNone">Kein Standort</sys:String>
+    <sys:String x:Key="StrNcPrecExact">Exakt</sys:String>
     <sys:String x:Key="StrNcDescChannelUplink">Uplink: Empfangene LoRa-Pakete dieses Kanals werden an den MQTT-Broker weitergeleitet.</sys:String>
     <sys:String x:Key="StrNcDescChannelDownlink">Downlink: Vom MQTT-Broker empfangene Nachrichten werden über diesen Kanal ins Mesh gesendet.</sys:String>
     <sys:String x:Key="StrNcLoadingProgress">Lade Konfiguration ({0}/{1})…</sys:String>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -49,6 +49,10 @@
 
     <!-- Node config window -->
     <sys:String x:Key="StrLoadingConfig">Lade Konfiguration...</sys:String>
+    <sys:String x:Key="StrNcConfigLoaded">Konfiguration geladen. Hinweis: Gerät startet nach dem Speichern neu.</sys:String>
+    <sys:String x:Key="StrNcShowPassword">Passwort anzeigen</sys:String>
+    <sys:String x:Key="StrNcHidePassword">Passwort verbergen</sys:String>
+    <sys:String x:Key="StrNcWifiPskHint">— klicke 👁 um Passwort einzugeben (leer = unverändert) —</sys:String>
     <sys:String x:Key="StrConfigSaved">Gespeichert!</sys:String>
 
     <!-- Messages -->
@@ -211,6 +215,167 @@
     <sys:String x:Key="StrNcBtRebootHint">Hinweis: Nach Änderung der Bluetooth-Einstellungen startet das Gerät neu.</sys:String>
     <sys:String x:Key="StrNcNodeDbReset">NodeDB zurücksetzen...</sys:String>
     <sys:String x:Key="StrNcNodeDbResetTip">Löscht die bekannten Nodes auf dem Gerät (kein Factory Reset)</sys:String>
+    <sys:String x:Key="StrNcSaveRebootHint">Hinweis: Das Gerät startet nach dem Speichern neu.</sys:String>
+    <sys:String x:Key="StrNcSaveRebootWarning">Die Konfiguration wird gespeichert und das Gerät startet neu. Fortfahren?</sys:String>
+    <sys:String x:Key="StrNcSaveRebootTitle">Gerät neu starten?</sys:String>
+    <!-- Nav sections -->
+    <sys:String x:Key="StrNcSectionNode">NODE</sys:String>
+    <sys:String x:Key="StrNcSectionConfig">KONFIGURATION</sys:String>
+    <sys:String x:Key="StrNcSectionModules">MODULE</sys:String>
+    <!-- Nav items -->
+    <sys:String x:Key="StrNcNavUser">Benutzer</sys:String>
+    <sys:String x:Key="StrNcNavDevice">Gerät</sys:String>
+    <sys:String x:Key="StrNcNavLora">LoRa</sys:String>
+    <sys:String x:Key="StrNcNavPosition">Position</sys:String>
+    <sys:String x:Key="StrNcNavPower">Energie</sys:String>
+    <sys:String x:Key="StrNcNavNetwork">Netzwerk</sys:String>
+    <sys:String x:Key="StrNcNavDisplay">Display</sys:String>
+    <sys:String x:Key="StrNcNavBluetooth">Bluetooth</sys:String>
+    <sys:String x:Key="StrNcNavMqtt">MQTT</sys:String>
+    <sys:String x:Key="StrNcNavTelemetry">Telemetrie</sys:String>
+    <sys:String x:Key="StrNcNavNeighborInfo">Nachbarknoten</sys:String>
+    <sys:String x:Key="StrNcNavStoreForward">Nachrichtenspeicher</sys:String>
+    <sys:String x:Key="StrNcNavExtNotif">Ext. Benachrichtigung</sys:String>
+    <sys:String x:Key="StrNcNavCannedMsg">Vordef. Nachrichten</sys:String>
+    <sys:String x:Key="StrNcNavRangeTest">Reichweiten-Test</sys:String>
+    <sys:String x:Key="StrNcNavSerial">Seriell</sys:String>
+    <!-- Power config -->
+    <sys:String x:Key="StrNcPowerSaving">Stromspar-Modus</sys:String>
+    <sys:String x:Key="StrNcPowerSavingTip">Schaltet alles Mögliche ab um Strom zu sparen</sys:String>
+    <sys:String x:Key="StrNcShutdownAfterSecs">Abschalten nach (Sekunden, 0=nie)</sys:String>
+    <sys:String x:Key="StrNcWaitBtSecs">Bluetooth aus nach (Sekunden, 0=nie)</sys:String>
+    <sys:String x:Key="StrNcSdsSecs">Super-Deep-Sleep nach (Sekunden, 0=nie)</sys:String>
+    <sys:String x:Key="StrNcLsSecs">Light-Sleep nach (Sekunden, 0=nie)</sys:String>
+    <sys:String x:Key="StrNcMinWakeSecs">Min. Wachzeit nach Paketempfang (Sekunden)</sys:String>
+    <!-- Network config -->
+    <sys:String x:Key="StrNcWifiEnabled">WLAN aktivieren</sys:String>
+    <sys:String x:Key="StrNcWifiSsid">WLAN-Name (SSID)</sys:String>
+    <sys:String x:Key="StrNcWifiPsk">WLAN-Passwort</sys:String>
+    <sys:String x:Key="StrNcNtpServer">NTP-Server (Zeitserver)</sys:String>
+    <!-- Display config -->
+    <sys:String x:Key="StrNcScreenOnSecs">Display-Timeout (z.B. 1m, 30s, 0=immer an)</sys:String>
+    <sys:String x:Key="StrNcAutoCarousel">Auto-Bildschirmwechsel aktivieren</sys:String>
+    <sys:String x:Key="StrNcCompassNorthTop">Kompass zeigt immer nach Norden</sys:String>
+    <sys:String x:Key="StrNcFlipScreen">Display umdrehen</sys:String>
+    <sys:String x:Key="StrNcGpsFormat">GPS-Koordinatenformat</sys:String>
+    <!-- Neighbor Info module -->
+    <sys:String x:Key="StrNcNiEnabled">Nachbarknoten-Modul aktivieren</sys:String>
+    <sys:String x:Key="StrNcNiInterval">Update-Intervall (z.B. 4h, 6h)</sys:String>
+    <!-- Store & Forward module -->
+    <sys:String x:Key="StrNcSfEnabled">Nachrichtenspeicher aktivieren</sys:String>
+    <sys:String x:Key="StrNcSfHeartbeat">Heartbeat senden</sys:String>
+    <sys:String x:Key="StrNcSfRecords">Max. gespeicherte Nachrichten</sys:String>
+    <sys:String x:Key="StrNcSfHistoryMax">Max. Nachrichten in Verlaufsantwort</sys:String>
+    <sys:String x:Key="StrNcSfHistoryWindow">Zeitfenster Verlauf (Sekunden)</sys:String>
+    <!-- External Notification module -->
+    <sys:String x:Key="StrNcEnEnabled">Ext. Benachrichtigung aktivieren</sys:String>
+    <sys:String x:Key="StrNcEnOutputMs">Impulsdauer (ms)</sys:String>
+    <sys:String x:Key="StrNcEnOutput">Ausgangs-GPIO</sys:String>
+    <sys:String x:Key="StrNcEnActiveHigh">Aktiv-High (sonst Aktiv-Low)</sys:String>
+    <sys:String x:Key="StrNcEnAlertMessage">Bei Textnachricht benachrichtigen</sys:String>
+    <sys:String x:Key="StrNcEnAlertBell">Bei Bell-Zeichen benachrichtigen</sys:String>
+    <!-- Canned Messages module -->
+    <sys:String x:Key="StrNcCmEnabled">Modul aktivieren</sys:String>
+    <sys:String x:Key="StrNcCmSendBell">Bell-Zeichen mitsenden</sys:String>
+    <sys:String x:Key="StrNcCmAllowInputSource">Erlaubte Eingabequelle (leer=alle)</sys:String>
+    <sys:String x:Key="StrNcCmRotary1">Drehencoder 1 aktivieren</sys:String>
+    <sys:String x:Key="StrNcCmUpdown1">Auf/Ab-Encoder 1 aktivieren</sys:String>
+    <!-- Range Test module -->
+    <sys:String x:Key="StrNcRtEnabled">Reichweiten-Test aktivieren</sys:String>
+    <sys:String x:Key="StrNcRtSender">Sender-Intervall (Sekunden, 0=kein Sender)</sys:String>
+    <sys:String x:Key="StrNcRtSave">Ergebnisse auf SD-Karte speichern</sys:String>
+    <!-- Serial module -->
+    <sys:String x:Key="StrNcSerEnabled">Serielles Modul aktivieren</sys:String>
+    <sys:String x:Key="StrNcSerEcho">Echo</sys:String>
+    <sys:String x:Key="StrNcSerRxd">RX-Pin (GPIO)</sys:String>
+    <sys:String x:Key="StrNcSerTxd">TX-Pin (GPIO)</sys:String>
+    <sys:String x:Key="StrNcSerBaud">Baudrate</sys:String>
+    <sys:String x:Key="StrNcSerTimeout">Timeout (ms)</sys:String>
+    <sys:String x:Key="StrNcSerMode">Modus</sys:String>
+    <!-- Telemetry additions -->
+    <sys:String x:Key="StrNcPowerMeasurement">Energiemessung aktivieren</sys:String>
+
+    <!-- NodeConfig: new label strings (previously hardcoded) -->
+    <sys:String x:Key="StrNcDoubleTap">Double-tap als Tastendruck</sys:String>
+    <sys:String x:Key="StrNcDutyCycle">Duty-Cycle-Limit überschreiben</sys:String>
+    <sys:String x:Key="StrNcChannelNum">Channel Number</sys:String>
+    <sys:String x:Key="StrNcGpsUpdateInterval">GPS-Update-Intervall (Sek., 0=Standard)</sys:String>
+    <sys:String x:Key="StrNcMqttProxy">Proxy to Client</sys:String>
+    <sys:String x:Key="StrNcAutoCarouselSecs">Auto-Carousel (Sek., 0=aus)</sys:String>
+
+    <!-- NodeConfig: description strings -->
+    <sys:String x:Key="StrNcDescLongName">Vollständiger Name, der anderen Nutzern angezeigt wird (max. 39 Zeichen).</sys:String>
+    <sys:String x:Key="StrNcDescShortName">Kurzname für die Geräteanzeige (max. 4 Zeichen, z. B. Initialen).</sys:String>
+    <sys:String x:Key="StrNcDescRebroadcast">Steuert, welche empfangenen Pakete weitergeleitet werden. ALL = alles · LOCAL_ONLY = nur eigener Channel · NONE = nichts weiterleiten.</sys:String>
+    <sys:String x:Key="StrNcDescNodeInfo">Wie oft das Gerät seinen Namen/Status ins Mesh sendet (Sekunden). Standard: 900 s. 0 = Firmware-Standard.</sys:String>
+    <sys:String x:Key="StrNcDescTimezone">POSIX-Zeitzone für die interne Uhr des Geräts (z. B. für Datum/Uhrzeit-Anzeige auf dem Display).</sys:String>
+    <sys:String x:Key="StrNcDescDoubleTap">Beschleunigungssensor: Doppeltippen auf das Gehäuse löst den Tastenknopf aus (z. B. für GPS-Toggle).</sys:String>
+    <sys:String x:Key="StrNcDescLoraRegion">Gesetzliche Frequenzregion. In Deutschland / EU: EU_868 (868 MHz Band).</sys:String>
+    <sys:String x:Key="StrNcDescUsePreset">Empfohlen: Preset verwenden. Nur deaktivieren für manuelle Anpassung von Bandbreite und Spreading-Faktor.</sys:String>
+    <sys:String x:Key="StrNcDescModemPreset">Höherer Spreading Factor (SF) = bessere Empfindlichkeit und mehr Reichweite, aber geringerer Durchsatz. · VERY_LONG_SLOW (SF12, 62,5 kHz) = maximale Reichweite, ~90 bps · LONG_SLOW (SF12, 125 kHz) = sehr große Reichweite, ~180 bps · LONG_FAST (SF11, 250 kHz) = gute Reichweite, ~1 kbit/s – Meshtastic-Standard · SHORT_SLOW (SF8, 250 kHz) = deutlich kürzere Reichweite, ~8 kbit/s – Standard im Mesh Hessen für dichte Netze · SHORT_FAST (SF7) = kürzeste Reichweite, ~17 kbit/s. Alle Nodes im Mesh müssen dasselbe Preset verwenden.</sys:String>
+    <sys:String x:Key="StrNcDescHopLimit">Max. Anzahl Weiterleitungen (Hops) pro Paket. Standard: 3. Höhere Werte erhöhen die Netzlast erheblich.</sys:String>
+    <sys:String x:Key="StrNcDescTxPower">Sendeleistung in dBm. 0 = maximale für die gewählte Region erlaubte Leistung (empfohlen).</sys:String>
+    <sys:String x:Key="StrNcDescChannelNum">Frequenz-Slot innerhalb der Region. 0 = wird automatisch aus dem Channel-Namen berechnet (Hash) – Standard für alle normalen Setups. Nur manuell setzen, wenn ein bestimmter Frequenz-Slot gezielt genutzt werden soll (Experten-Einstellung).</sys:String>
+    <sys:String x:Key="StrNcDescDutyCycle">⚠ Achtung: Die meisten Funkregionen schreiben ein gesetzliches Duty-Cycle-Limit für LoRa-Sender vor. Das Überschreiten dieses Limits kann gegen lokale Funkregelungen verstoßen.</sys:String>
+    <sys:String x:Key="StrNcDescSx126x">Höhere Empfangsempfindlichkeit (~1–2 dB Gewinn) auf Kosten von ca. 2 mA Mehrverbrauch. Empfohlen für stationäre Nodes.</sys:String>
+    <sys:String x:Key="StrNcDescGpsMode">DISABLED = GPS abgeschaltet (spart Strom) · ENABLED = GPS aktiv · NOT_PRESENT = kein GPS-Modul verbaut.</sys:String>
+    <sys:String x:Key="StrNcDescPosBroadcast">Maximales Intervall zwischen zwei Positionssendungen (Sekunden). 0 = Smart Broadcast bestimmt das Intervall.</sys:String>
+    <sys:String x:Key="StrNcDescSmartBroadcast">Sendet Position nur, wenn sich das Gerät weit genug bewegt hat (Mindestabstand + Mindestgeschwindigkeit).</sys:String>
+    <sys:String x:Key="StrNcDescMinDistance">Mindestabstand in Metern, den das Gerät zurückgelegt haben muss, bevor eine neue Position gesendet wird.</sys:String>
+    <sys:String x:Key="StrNcDescMinSpeed">Mindestgeschwindigkeit in cm/s. Unter diesem Wert wird bei Stillstand keine neue Position gesendet.</sys:String>
+    <sys:String x:Key="StrNcDescGpsInterval">Wie oft das GPS-Modul neue Koordinaten abfragt. 0 = Firmware-Standard (ca. 30 s).</sys:String>
+    <sys:String x:Key="StrNcDescPowerSaving">Schläft so viel wie möglich: Display, GPS und Bluetooth werden abgeschaltet, die CPU wechselt in Deep/Light-Sleep. Das Gerät wacht nur auf, wenn ein LoRa-Paket empfangen wird oder ein Sleep-Zyklus abläuft. Nicht aktivieren, wenn das Gerät dauerhaft per Bluetooth oder USB verbunden sein soll.</sys:String>
+    <sys:String x:Key="StrNcDescShutdownAfter">Gerät schaltet sich automatisch ab, wenn es länger als diese Zeit vom Akku betrieben wird (kein USB). 0 = nie abschalten.</sys:String>
+    <sys:String x:Key="StrNcDescWaitBt">Bluetooth wird abgeschaltet, wenn seit dieser Zeit keine Verbindung bestand (Sekunden). 0 = Bluetooth dauerhaft aktiv.</sys:String>
+    <sys:String x:Key="StrNcDescSds">Super Deep Sleep: extremer Stromsparmodus – nur ein physischer Reset-Knopfdruck weckt das Gerät wieder auf (Sekunden). 0 = deaktiviert.</sys:String>
+    <sys:String x:Key="StrNcDescLs">Light Sleep: Gerät bleibt empfangsbereit (LoRa aktiv), CPU und andere Verbraucher schlafen (Sekunden). 0 = deaktiviert.</sys:String>
+    <sys:String x:Key="StrNcDescMinWake">Wie lange das Gerät nach dem Empfang eines Pakets wach bleibt, bevor es erneut schlafen geht (Sekunden).</sys:String>
+    <sys:String x:Key="StrNcDescWifiEnabled">Nur für ESP32-basierte Geräte (z. B. T-Beam, Heltec). nRF52-Geräte (RAK, T-Echo) haben kein WLAN-Modul.</sys:String>
+    <sys:String x:Key="StrNcDescWifiSsid">Name des WLAN-Netzwerks (SSID), mit dem sich das Gerät verbinden soll (max. 32 Zeichen).</sys:String>
+    <sys:String x:Key="StrNcDescWifiPsk">WLAN-Passwort. Das Gerät gibt dieses Feld aus Sicherheitsgründen leer zurück – es erscheint immer leer. Leer lassen = Passwort bleibt unverändert.</sys:String>
+    <sys:String x:Key="StrNcDescNtpServer">Zeitserver für automatische Zeitsynchronisation. Standard: meshtastic.pool.ntp.org</sys:String>
+    <sys:String x:Key="StrNcDescScreenOn">Wie lange das Display nach der letzten Aktion aktiv bleibt (Sekunden). 0 = Display immer an.</sys:String>
+    <sys:String x:Key="StrNcDescAutoCarousel">Wechselt automatisch zwischen den Display-Seiten. Angabe in Sekunden. 0 = deaktiviert.</sys:String>
+    <sys:String x:Key="StrNcDescCompassNorth">Kompassanzeige zeigt immer geographischen Norden oben (statt Fahrtrichtung).</sys:String>
+    <sys:String x:Key="StrNcDescFlipScreen">Dreht das Display um 180° (für umgekehrt montierte Gehäuse).</sys:String>
+    <sys:String x:Key="StrNcDescBtEnabled">Deaktivieren spart Strom – dann ist Verbindung nur noch über USB/Serial möglich.</sys:String>
+    <sys:String x:Key="StrNcDescBtPairing">RANDOM = neuer PIN bei jedem Koppeln (sicher) · FIXED = immer gleicher PIN · NO_PIN = kein PIN (unsicher).</sys:String>
+    <sys:String x:Key="StrNcDescMqttEnabled">Verbindet das Gerät als Gateway zwischen LoRa-Mesh und MQTT-Broker (Internet-Brücke für Nachrichten und Telemetrie).</sys:String>
+    <sys:String x:Key="StrNcDescMqttServer">Hostname oder IP des MQTT-Brokers. Standard: mqtt.meshtastic.org</sys:String>
+    <sys:String x:Key="StrNcDescMqttEncryption">Pakete werden verschlüsselt über MQTT übertragen (LoRa-Schlüssel verbleibt im Paket).</sys:String>
+    <sys:String x:Key="StrNcDescMqttJson">Sendet zusätzlich entschlüsselte Pakete als JSON-Text (z. B. für Home Assistant, Node-RED, Grafana).</sys:String>
+    <sys:String x:Key="StrNcDescMqttRootTopic">Basis-Topic für alle MQTT-Nachrichten dieses Geräts. Standard: msh</sys:String>
+    <sys:String x:Key="StrNcDescMqttProxy">Die verbundene App (Telefon/PC) leitet MQTT-Nachrichten für das Gerät weiter – kein direktes WLAN am Gerät nötig. Hinweis: Dieser Windows-Client unterstützt den Proxy-Modus aktuell nicht aktiv.</sys:String>
+    <sys:String x:Key="StrNcDescMqttMapReport">Sendet die eigene Position an die öffentliche Meshtastic-Weltkarte (map.meshtastic.org).</sys:String>
+    <sys:String x:Key="StrNcDescDeviceTelemetry">Gerätemetriken: Akku-%, Spannung, Kanalauslastung, TX-Airtime. Erscheinen im Telemetrie-Fenster des Clients.</sys:String>
+    <sys:String x:Key="StrNcDescEnvTelemetry">Umgebungssensoren (Temperatur, Luftfeuchte, Luftdruck) – benötigt angeschlossenen I²C-Sensor (z. B. BME280).</sys:String>
+    <sys:String x:Key="StrNcDescAirQuality">Luftqualitätssensor (PM2.5 u. a.) – benötigt angeschlossenen Sensor (z. B. PMSA003I).</sys:String>
+    <sys:String x:Key="StrNcDescPowerTelemetry">Energiemessung (Spannung/Strom) – benötigt INA2xx-Sensor.</sys:String>
+    <sys:String x:Key="StrNcDescNiEnabled">Das Gerät sendet periodisch eine Liste aller direkt empfangbaren Nachbar-Nodes (inkl. SNR-Werte). Nützlich für Netzwerkanalyse.</sys:String>
+    <sys:String x:Key="StrNcDescNiInterval">Mindestintervall laut Spezifikation: 4 h (14400 Sekunden). Kleinere Werte werden von der Firmware ignoriert.</sys:String>
+    <sys:String x:Key="StrNcDescSfEnabled">Speichert Nachrichten für temporär offline Nodes und sendet sie beim nächsten Kontakt nach. Benötigt dedizierten Server-Node (ESP32 mit ausreichend Speicher).</sys:String>
+    <sys:String x:Key="StrNcDescSfHeartbeat">Sendet regelmäßig einen Heartbeat, damit Clients wissen, dass der Store-and-Forward-Server erreichbar ist.</sys:String>
+    <sys:String x:Key="StrNcDescSfRecords">Maximale Anzahl gespeicherter Nachrichten auf dem Server-Node. 0 = Firmware-Limit.</sys:String>
+    <sys:String x:Key="StrNcDescSfHistoryMax">Maximale Anzahl Nachrichten, die auf eine einzelne Verlaufsanfrage gesendet werden.</sys:String>
+    <sys:String x:Key="StrNcDescSfHistoryWindow">Zeitraum in Sekunden, aus dem Nachrichten für eine Verlaufsanfrage zurückgesendet werden.</sys:String>
+    <sys:String x:Key="StrNcDescEnEnabled">Steuert einen externen GPIO-Ausgang (LED, Buzzer, Vibrationsmotor) bei eingehenden Nachrichten.</sys:String>
+    <sys:String x:Key="StrNcDescEnOutput">GPIO-Pin-Nummer des Ausgangssignals (z. B. 13 für eingebaute LED).</sys:String>
+    <sys:String x:Key="StrNcDescEnOutputMs">Dauer eines Signals in Millisekunden. Standard: 1000 ms (1 Sekunde).</sys:String>
+    <sys:String x:Key="StrNcDescEnActive">Aktiv-High = Pin auf HIGH zum Einschalten. Aktiv-Low = Pin auf LOW (für viele LEDs nötig).</sys:String>
+    <sys:String x:Key="StrNcDescEnBell">Bell = ASCII-Zeichen 0x07, das gezielt von anderen Nodes gesendet werden kann, um eine Benachrichtigung auszulösen.</sys:String>
+    <sys:String x:Key="StrNcDescCmEnabled">Ermöglicht das Senden vorgespeicherter Nachrichten direkt am Gerät über Drehencoder oder Auf/Ab-Tasten – ohne Smartphone.</sys:String>
+    <sys:String x:Key="StrNcDescCmSendBell">Fügt jeder gesendeten Nachricht ein Bell-Zeichen (0x07) bei – löst externe Benachrichtigungen beim Empfänger aus.</sys:String>
+    <sys:String x:Key="StrNcDescCmInput">Leer = alle Eingabequellen erlaubt. Mögliche Werte: rotary1, updown1, cardkb, serial (je nach Hardware).</sys:String>
+    <sys:String x:Key="StrNcDescCmRotary">Aktiviert Drehencoder 1 als Eingabe (KY-040 o. Ä., angeschlossen an die konfigurierten GPIO-Pins).</sys:String>
+    <sys:String x:Key="StrNcDescCmUpdown">Aktiviert Auf/Ab/Bestätigen-Tasten als Eingabe (3 separate GPIO-Pins).</sys:String>
+    <sys:String x:Key="StrNcDescRtEnabled">Sendet oder empfängt Testpakete zur Reichweitenmessung. Ein Node sendet (Intervall &gt; 0), alle anderen empfangen und loggen. ⚠ Bitte nach dem Test wieder deaktivieren – der Sender belastet den Kanal dauerhaft!</sys:String>
+    <sys:String x:Key="StrNcDescRtSender">Sendeintervall in Sekunden. 0 = Empfänger-Modus (kein Senden). Typischer Wert: 60 s. Nach Abschluss des Tests unbedingt auf 0 zurücksetzen und speichern!</sys:String>
+    <sys:String x:Key="StrNcDescRtSave">Speichert Testergebnisse als CSV-Datei auf der SD-Karte (nur ESP32 mit SD-Karten-Slot).</sys:String>
+    <sys:String x:Key="StrNcDescSerEnabled">Datenaustausch über serielle UART-Schnittstelle (zusätzlich zur USB-Verbindung), für Integration mit externen Systemen (Arduino, Raspberry Pi usw.).</sys:String>
+    <sys:String x:Key="StrNcDescSerEcho">Empfangene Daten werden direkt zurückgesendet (Echo-Modus zur Diagnose).</sys:String>
+    <sys:String x:Key="StrNcDescSerPins">GPIO-Pinnummern für den UART-Anschluss. 0 = Hardware-Standard des jeweiligen Boards.</sys:String>
+    <sys:String x:Key="StrNcDescSerTimeout">Wartezeit in Millisekunden, bis ein unvollständiges Paket als abgeschlossen gilt.</sys:String>
+    <sys:String x:Key="StrNcDescSerMode">DEFAULT = Textnachrichten · NMEA = GPS-Koordinaten als NMEA-Sätze ausgeben · PROTO = rohe Protobuf-Pakete (Entwickler).</sys:String>
 
     <!-- DirectMessages window -->
     <sys:String x:Key="StrDmWindowTitle">Direktnachrichten</sys:String>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -406,6 +406,8 @@
     <sys:String x:Key="StrNcDescFixedCoords">Dezimalgrad, z.B. 50.123456 / 8.654321. Wird beim Speichern an den Node übertragen.</sys:String>
     <sys:String x:Key="StrNcPickFromMap">Von Karte übernehmen</sys:String>
     <sys:String x:Key="StrNcPickFromMapTip">Aktuellen Kartenmittelpunkt als feste Position übernehmen</sys:String>
+    <sys:String x:Key="StrNcPickFromMapHint">Navigiere die Karte auf den gewünschten Standort, dann diesen Button klicken.</sys:String>
+    <sys:String x:Key="StrNcMapCenterLabel">Aktueller Kartenmittelpunkt:</sys:String>
     <sys:String x:Key="StrNcMinIntervalSecs">Mindestintervall Smart-Broadcast (s)</sys:String>
     <sys:String x:Key="StrNcDescMinIntervalSecs">Minimale Wartezeit in Sekunden zwischen zwei Smart-Positionssendungen.</sys:String>
     <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -397,8 +397,15 @@
     <sys:String x:Key="StrNcOverrideFreq">Override Frequenz (MHz)</sys:String>
     <sys:String x:Key="StrNcDescOverrideFreq">Überschreibt die berechnete Kanalfrequenz. Nur für lizenzierte Funkamateure oder Entwickler. 0 = automatisch.</sys:String>
     <!-- Node config: Position extras -->
-    <sys:String x:Key="StrNcFixedPosition">Feste Position</sys:String>
+    <sys:String x:Key="StrNcFixedPosition">Feste Position aktivieren</sys:String>
     <sys:String x:Key="StrNcDescFixedPosition">Der Node sendet immer die gleiche (manuelle) Position, unabhängig vom GPS-Empfang.</sys:String>
+    <sys:String x:Key="StrNcFixedPosGroupHeader">Koordinaten der festen Position</sys:String>
+    <sys:String x:Key="StrNcFixedLat">Breitengrad (Latitude)</sys:String>
+    <sys:String x:Key="StrNcFixedLon">Längengrad (Longitude)</sys:String>
+    <sys:String x:Key="StrNcFixedAlt">Höhe (m)</sys:String>
+    <sys:String x:Key="StrNcDescFixedCoords">Dezimalgrad, z.B. 50.123456 / 8.654321. Wird beim Speichern an den Node übertragen.</sys:String>
+    <sys:String x:Key="StrNcPickFromMap">Von Karte übernehmen</sys:String>
+    <sys:String x:Key="StrNcPickFromMapTip">Aktuellen Kartenmittelpunkt als feste Position übernehmen</sys:String>
     <sys:String x:Key="StrNcMinIntervalSecs">Mindestintervall Smart-Broadcast (s)</sys:String>
     <sys:String x:Key="StrNcDescMinIntervalSecs">Minimale Wartezeit in Sekunden zwischen zwei Smart-Positionssendungen.</sys:String>
     <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>
@@ -450,8 +457,16 @@
     <sys:String x:Key="StrNcDescSecIsManaged">Gerät wird durch einen Mesh-Administrator via Admin-Schlüssel verwaltet. Einige UI-Optionen werden eingeschränkt.</sys:String>
     <sys:String x:Key="StrNcSecAdminChannel">Legacy Admin Channel</sys:String>
     <sys:String x:Key="StrNcDescSecAdminChannel">Erlaubt Admin-Zugriff über den unverschlüsselten Legacy-Admin-Kanal. Nur für Abwärtskompatibilität.</sys:String>
+    <sys:String x:Key="StrNcSecPrivateKey">Private Key</sys:String>
+    <sys:String x:Key="StrNcDescSecPrivateKey">Privater X25519-Schlüssel für PKI-Entschlüsselung. Ändere ihn nur, wenn du weißt, was du tust — damit verlierst du alle verschlüsselten Direktnachrichten.</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey1">Admin Key 1</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey2">Admin Key 2</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey3">Admin Key 3</sys:String>
+    <sys:String x:Key="StrNcDescSecAdminKeys">Öffentliche Schlüssel von Admin-Geräten (Base64). Leeres Feld = nicht gesetzt.</sys:String>
     <!-- Node config: Channels panel -->
     <sys:String x:Key="StrNcNavChannels">Kanäle</sys:String>
+    <sys:String x:Key="StrNcChannelPosPrecision">Genauigkeit</sys:String>
+    <sys:String x:Key="StrNcDescChannelPosPrecision">Positions-Genauigkeit für diesen Kanal (0=aus, 10≈23km, 13≈2.8km, 16≈350m, 19≈44m, 32=exakt)</sys:String>
     <sys:String x:Key="StrNcChannelUplink">Uplink</sys:String>
     <sys:String x:Key="StrNcChannelDownlink">Downlink</sys:String>
     <sys:String x:Key="StrNcDescChannelUplink">Uplink: Empfangene LoRa-Pakete dieses Kanals werden an den MQTT-Broker weitergeleitet.</sys:String>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -377,6 +377,88 @@
     <sys:String x:Key="StrNcDescSerTimeout">Wartezeit in Millisekunden, bis ein unvollständiges Paket als abgeschlossen gilt.</sys:String>
     <sys:String x:Key="StrNcDescSerMode">DEFAULT = Textnachrichten · NMEA = GPS-Koordinaten als NMEA-Sätze ausgeben · PROTO = rohe Protobuf-Pakete (Entwickler).</sys:String>
 
+    <!-- Node config: User extras -->
+    <sys:String x:Key="StrNcIsLicensed">Amateurfunk-lizensiert (HAM)</sys:String>
+    <sys:String x:Key="StrNcDescIsLicensed">Aktivieren wenn du eine gültige Amateurfunklizenz besitzt. Long Name sollte dann das Rufzeichen sein. Ermöglicht größere Bandbreite in manchen Regionen.</sys:String>
+    <sys:String x:Key="StrNcIsUnmessagable">Nicht erreichbar (unmessagable)</sys:String>
+    <sys:String x:Key="StrNcDescIsUnmessagable">Wenn aktiv, akzeptiert dieser Node keine eingehenden Direktnachrichten.</sys:String>
+    <!-- Node config: Device GPIO -->
+    <sys:String x:Key="StrNcButtonGpio">Button GPIO Pin</sys:String>
+    <sys:String x:Key="StrNcDescButtonGpio">GPIO-Pinnummer für einen externen Taster. 0 = Board-Standard.</sys:String>
+    <sys:String x:Key="StrNcBuzzerGpio">Buzzer GPIO Pin</sys:String>
+    <sys:String x:Key="StrNcDescBuzzerGpio">GPIO-Pinnummer für einen externen Buzzer. 0 = Board-Standard.</sys:String>
+    <sys:String x:Key="StrNcDisableTripleClick">Dreifachklick deaktivieren</sys:String>
+    <sys:String x:Key="StrNcDescDisableTripleClick">Deaktiviert die Funktion "Dreifachklick = GPS ein/aus".</sys:String>
+    <!-- Node config: LoRa extras -->
+    <sys:String x:Key="StrNcIgnoreMqtt">Ignore MQTT</sys:String>
+    <sys:String x:Key="StrNcDescIgnoreMqtt">Pakete, die über MQTT weitergeleitet wurden, werden ignoriert (nicht erneut rebroadcastet). Reduziert Schleifen im Mesh.</sys:String>
+    <sys:String x:Key="StrNcOkToMqtt">OK to MQTT</sys:String>
+    <sys:String x:Key="StrNcDescOkToMqtt">Setzt das ok_to_mqtt-Bit in ausgehenden Paketen. Erlaubt MQTT-Gateways dieses Paket weiterzuleiten.</sys:String>
+    <sys:String x:Key="StrNcOverrideFreq">Override Frequenz (MHz)</sys:String>
+    <sys:String x:Key="StrNcDescOverrideFreq">Überschreibt die berechnete Kanalfrequenz. Nur für lizenzierte Funkamateure oder Entwickler. 0 = automatisch.</sys:String>
+    <!-- Node config: Position extras -->
+    <sys:String x:Key="StrNcFixedPosition">Feste Position</sys:String>
+    <sys:String x:Key="StrNcDescFixedPosition">Der Node sendet immer die gleiche (manuelle) Position, unabhängig vom GPS-Empfang.</sys:String>
+    <sys:String x:Key="StrNcMinIntervalSecs">Mindestintervall Smart-Broadcast (s)</sys:String>
+    <sys:String x:Key="StrNcDescMinIntervalSecs">Minimale Wartezeit in Sekunden zwischen zwei Smart-Positionssendungen.</sys:String>
+    <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>
+    <sys:String x:Key="StrNcDescRxGpio">GPIO-Pinnummer für GPS RX. 0 = Board-Standard.</sys:String>
+    <sys:String x:Key="StrNcTxGpioPos">GPS TX GPIO</sys:String>
+    <sys:String x:Key="StrNcDescTxGpioPos">GPIO-Pinnummer für GPS TX. 0 = Board-Standard.</sys:String>
+    <sys:String x:Key="StrNcGpsEnGpio">GPS Enable GPIO</sys:String>
+    <sys:String x:Key="StrNcDescGpsEnGpio">GPIO-Pinnummer zum Ein-/Ausschalten des GPS-Moduls. 0 = Board-Standard.</sys:String>
+    <!-- Node config: Power extras -->
+    <sys:String x:Key="StrNcAdcMult">ADC Multiplikator Override</sys:String>
+    <sys:String x:Key="StrNcDescAdcMult">Korrekturfaktor für die Batteriespannungsmessung (z. B. 3.20). 0 = Board-Standard. Typischer Bereich: 2–6.</sys:String>
+    <sys:String x:Key="StrNcBatteryInaAddr">INA Akku-I²C-Adresse</sys:String>
+    <sys:String x:Key="StrNcDescBatteryInaAddr">I²C-Adresse des INA2xx-Chips für Batteriespannungsmessung (hex, z. B. 0x40). 0 = deaktiviert.</sys:String>
+    <!-- Node config: Network extras -->
+    <sys:String x:Key="StrNcEthEnabled">Ethernet aktiviert</sys:String>
+    <sys:String x:Key="StrNcDescEthEnabled">Ethernet-Verbindung aktivieren (nur für Boards mit Ethernet-Port, z. B. T-ETH-Elite).</sys:String>
+    <sys:String x:Key="StrNcAddressMode">IP-Adressmodus</sys:String>
+    <sys:String x:Key="StrNcDescAddressMode">DHCP = automatische IP-Adresse vom Router. STATIC = feste IP-Adresse.</sys:String>
+    <sys:String x:Key="StrNcRsyslogServer">Rsyslog-Server</sys:String>
+    <sys:String x:Key="StrNcDescRsyslogServer">Adresse eines Rsyslog-Servers (IP:Port) für Remote-Logging. Leer = deaktiviert.</sys:String>
+    <!-- Node config: Display extras -->
+    <sys:String x:Key="StrNcDisplayUnits">Einheiten</sys:String>
+    <sys:String x:Key="StrNcDescDisplayUnits">Metrisch (km, m) oder Imperial (mi, ft) für Entfernungsanzeigen.</sys:String>
+    <sys:String x:Key="StrNcMetric">Metrisch</sys:String>
+    <sys:String x:Key="StrNcImperial">Imperial</sys:String>
+    <sys:String x:Key="StrNcOledType">OLED-Typ</sys:String>
+    <sys:String x:Key="StrNcDescOledType">Override für die automatische OLED-Erkennung. AUTO = Autoerkennung.</sys:String>
+    <sys:String x:Key="StrNcDisplayMode">Display-Modus</sys:String>
+    <sys:String x:Key="StrNcDescDisplayMode">DEFAULT = klassisch 128×64 · TWOCOLOR = für zweifarbige OLEDs · INVERTED = invertierte Titelleiste · COLOR = TFT-Farbe.</sys:String>
+    <sys:String x:Key="StrNcHeadingBold">Titelzeile fett</sys:String>
+    <sys:String x:Key="StrNcDescHeadingBold">Erste Zeile des Displays in Pseudo-Fettschrift darstellen.</sys:String>
+    <sys:String x:Key="StrNcWakeOnTap">Aufwachen bei Bewegung/Tap</sys:String>
+    <sys:String x:Key="StrNcDescWakeOnTap">Display bei erkannter Bewegung oder Tap durch den Beschleunigungssensor einschalten.</sys:String>
+    <sys:String x:Key="StrNcCompassOrientation">Kompass-Ausrichtung</sys:String>
+    <sys:String x:Key="StrNcDescCompassOrientation">Rotation des Kompass-Outputs falls das Board gedreht montiert ist.</sys:String>
+    <sys:String x:Key="StrNcUse12hClock">12-Stunden-Uhr</sys:String>
+    <sys:String x:Key="StrNcDescUse12hClock">Uhrzeit im 12-Stunden-Format (AM/PM) statt 24-Stunden anzeigen.</sys:String>
+    <!-- Node config: Security panel -->
+    <sys:String x:Key="StrNcNavSecurity">Sicherheit</sys:String>
+    <sys:String x:Key="StrNcSecPublicKey">Öffentlicher Schlüssel (Base64, read-only)</sys:String>
+    <sys:String x:Key="StrNcDescSecPublicKey">Der öffentliche X25519-Schlüssel dieses Nodes. Wird an andere Nodes übermittelt für PKI-Direktnachrichten. Nur lesbar.</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey">Admin-Schlüssel (Base64, einer pro Zeile)</sys:String>
+    <sys:String x:Key="StrNcDescSecAdminKey">Öffentliche Schlüssel, die Admin-Nachrichten an diesen Node senden dürfen. Max. 3 Einträge, je Zeile einer.</sys:String>
+    <sys:String x:Key="StrNcSecSerialEnabled">Serial Console aktiviert</sys:String>
+    <sys:String x:Key="StrNcDescSecSerialEnabled">Aktiviert die serielle Konsole (Stream API). Deaktivieren reduziert die CPU-Last.</sys:String>
+    <sys:String x:Key="StrNcSecDebugLog">Debug-Log API aktiviert</sys:String>
+    <sys:String x:Key="StrNcDescSecDebugLog">Live-Debug-Ausgabe über seriell oder Bluetooth. Wird beim API-Connect normalerweise deaktiviert.</sys:String>
+    <sys:String x:Key="StrNcSecIsManaged">Managed Mode</sys:String>
+    <sys:String x:Key="StrNcDescSecIsManaged">Gerät wird durch einen Mesh-Administrator via Admin-Schlüssel verwaltet. Einige UI-Optionen werden eingeschränkt.</sys:String>
+    <sys:String x:Key="StrNcSecAdminChannel">Legacy Admin Channel</sys:String>
+    <sys:String x:Key="StrNcDescSecAdminChannel">Erlaubt Admin-Zugriff über den unverschlüsselten Legacy-Admin-Kanal. Nur für Abwärtskompatibilität.</sys:String>
+    <!-- Node config: Channels panel -->
+    <sys:String x:Key="StrNcNavChannels">Kanäle</sys:String>
+    <sys:String x:Key="StrNcChannelUplink">Uplink</sys:String>
+    <sys:String x:Key="StrNcChannelDownlink">Downlink</sys:String>
+    <sys:String x:Key="StrNcDescChannelUplink">Uplink: Empfangene LoRa-Pakete dieses Kanals werden an den MQTT-Broker weitergeleitet.</sys:String>
+    <sys:String x:Key="StrNcDescChannelDownlink">Downlink: Vom MQTT-Broker empfangene Nachrichten werden über diesen Kanal ins Mesh gesendet.</sys:String>
+    <sys:String x:Key="StrNcLoadingProgress">Lade Konfiguration ({0}/{1})…</sys:String>
+    <sys:String x:Key="StrNcLoadingTimeout">Nicht alle Antworten empfangen — Speichern trotzdem freigegeben.</sys:String>
+
     <!-- DirectMessages window -->
     <sys:String x:Key="StrDmWindowTitle">Direktnachrichten</sys:String>
     <sys:String x:Key="StrNoActiveChats">Keine aktiven Chats</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -377,6 +377,88 @@
     <sys:String x:Key="StrNcDescSerTimeout">Wait time in milliseconds until an incomplete packet is considered complete.</sys:String>
     <sys:String x:Key="StrNcDescSerMode">DEFAULT = text messages · NMEA = GPS coordinates as NMEA sentences · PROTO = raw protobuf packets (developer).</sys:String>
 
+    <!-- Node config: User extras -->
+    <sys:String x:Key="StrNcIsLicensed">Licensed Amateur Radio (HAM)</sys:String>
+    <sys:String x:Key="StrNcDescIsLicensed">Enable if you hold a valid amateur radio license. Long Name should then be your callsign. Allows wider bandwidth in some regions.</sys:String>
+    <sys:String x:Key="StrNcIsUnmessagable">Unmessagable</sys:String>
+    <sys:String x:Key="StrNcDescIsUnmessagable">When enabled, this node does not accept incoming direct messages.</sys:String>
+    <!-- Node config: Device GPIO -->
+    <sys:String x:Key="StrNcButtonGpio">Button GPIO Pin</sys:String>
+    <sys:String x:Key="StrNcDescButtonGpio">GPIO pin number for an external button. 0 = board default.</sys:String>
+    <sys:String x:Key="StrNcBuzzerGpio">Buzzer GPIO Pin</sys:String>
+    <sys:String x:Key="StrNcDescBuzzerGpio">GPIO pin number for an external buzzer. 0 = board default.</sys:String>
+    <sys:String x:Key="StrNcDisableTripleClick">Disable Triple Click</sys:String>
+    <sys:String x:Key="StrNcDescDisableTripleClick">Disables the triple-press user button function (GPS toggle).</sys:String>
+    <!-- Node config: LoRa extras -->
+    <sys:String x:Key="StrNcIgnoreMqtt">Ignore MQTT</sys:String>
+    <sys:String x:Key="StrNcDescIgnoreMqtt">Packets relayed via MQTT are ignored (not rebroadcast). Reduces mesh loops.</sys:String>
+    <sys:String x:Key="StrNcOkToMqtt">OK to MQTT</sys:String>
+    <sys:String x:Key="StrNcDescOkToMqtt">Sets the ok_to_mqtt bit on outgoing packets. Allows MQTT gateways to forward this packet.</sys:String>
+    <sys:String x:Key="StrNcOverrideFreq">Override Frequency (MHz)</sys:String>
+    <sys:String x:Key="StrNcDescOverrideFreq">Overrides the calculated channel frequency. For licensed HAM operators or developers only. 0 = automatic.</sys:String>
+    <!-- Node config: Position extras -->
+    <sys:String x:Key="StrNcFixedPosition">Fixed Position</sys:String>
+    <sys:String x:Key="StrNcDescFixedPosition">Node always broadcasts the same (manually set) position regardless of GPS.</sys:String>
+    <sys:String x:Key="StrNcMinIntervalSecs">Smart Broadcast Min. Interval (s)</sys:String>
+    <sys:String x:Key="StrNcDescMinIntervalSecs">Minimum wait time in seconds between two smart position broadcasts.</sys:String>
+    <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>
+    <sys:String x:Key="StrNcDescRxGpio">GPIO pin number for GPS RX. 0 = board default.</sys:String>
+    <sys:String x:Key="StrNcTxGpioPos">GPS TX GPIO</sys:String>
+    <sys:String x:Key="StrNcDescTxGpioPos">GPIO pin number for GPS TX. 0 = board default.</sys:String>
+    <sys:String x:Key="StrNcGpsEnGpio">GPS Enable GPIO</sys:String>
+    <sys:String x:Key="StrNcDescGpsEnGpio">GPIO pin to power the GPS module on/off. 0 = board default.</sys:String>
+    <!-- Node config: Power extras -->
+    <sys:String x:Key="StrNcAdcMult">ADC Multiplier Override</sys:String>
+    <sys:String x:Key="StrNcDescAdcMult">Correction factor for battery voltage measurement (e.g. 3.20). 0 = board default. Typical range: 2–6.</sys:String>
+    <sys:String x:Key="StrNcBatteryInaAddr">INA Battery I²C Address</sys:String>
+    <sys:String x:Key="StrNcDescBatteryInaAddr">I²C address of the INA2xx chip for battery voltage measurement (hex, e.g. 0x40). 0 = disabled.</sys:String>
+    <!-- Node config: Network extras -->
+    <sys:String x:Key="StrNcEthEnabled">Ethernet Enabled</sys:String>
+    <sys:String x:Key="StrNcDescEthEnabled">Enable Ethernet connection (only for boards with Ethernet port, e.g. T-ETH-Elite).</sys:String>
+    <sys:String x:Key="StrNcAddressMode">IP Address Mode</sys:String>
+    <sys:String x:Key="StrNcDescAddressMode">DHCP = automatic IP address from router. STATIC = fixed IP address.</sys:String>
+    <sys:String x:Key="StrNcRsyslogServer">Rsyslog Server</sys:String>
+    <sys:String x:Key="StrNcDescRsyslogServer">Address of a rsyslog server (IP:Port) for remote logging. Empty = disabled.</sys:String>
+    <!-- Node config: Display extras -->
+    <sys:String x:Key="StrNcDisplayUnits">Units</sys:String>
+    <sys:String x:Key="StrNcDescDisplayUnits">Metric (km, m) or Imperial (mi, ft) for distance displays.</sys:String>
+    <sys:String x:Key="StrNcMetric">Metric</sys:String>
+    <sys:String x:Key="StrNcImperial">Imperial</sys:String>
+    <sys:String x:Key="StrNcOledType">OLED Type</sys:String>
+    <sys:String x:Key="StrNcDescOledType">Override for automatic OLED detection. AUTO = autodetect.</sys:String>
+    <sys:String x:Key="StrNcDisplayMode">Display Mode</sys:String>
+    <sys:String x:Key="StrNcDescDisplayMode">DEFAULT = classic 128×64 · TWOCOLOR = for bicolor OLEDs · INVERTED = inverted title bar · COLOR = TFT color.</sys:String>
+    <sys:String x:Key="StrNcHeadingBold">Bold Heading</sys:String>
+    <sys:String x:Key="StrNcDescHeadingBold">Display first line of screen in pseudo-bold style.</sys:String>
+    <sys:String x:Key="StrNcWakeOnTap">Wake on Tap/Motion</sys:String>
+    <sys:String x:Key="StrNcDescWakeOnTap">Wake the display when motion or tap is detected by the accelerometer.</sys:String>
+    <sys:String x:Key="StrNcCompassOrientation">Compass Orientation</sys:String>
+    <sys:String x:Key="StrNcDescCompassOrientation">Rotation of compass output if the board is mounted at an angle.</sys:String>
+    <sys:String x:Key="StrNcUse12hClock">12-Hour Clock</sys:String>
+    <sys:String x:Key="StrNcDescUse12hClock">Display time in 12-hour (AM/PM) format instead of 24-hour.</sys:String>
+    <!-- Node config: Security panel -->
+    <sys:String x:Key="StrNcNavSecurity">Security</sys:String>
+    <sys:String x:Key="StrNcSecPublicKey">Public Key (Base64, read-only)</sys:String>
+    <sys:String x:Key="StrNcDescSecPublicKey">The node's public X25519 key. Sent to other nodes for PKI direct messages. Read-only.</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey">Admin Keys (Base64, one per line)</sys:String>
+    <sys:String x:Key="StrNcDescSecAdminKey">Public keys authorized to send admin messages to this node. Max 3 entries, one per line.</sys:String>
+    <sys:String x:Key="StrNcSecSerialEnabled">Serial Console Enabled</sys:String>
+    <sys:String x:Key="StrNcDescSecSerialEnabled">Enables the serial console (Stream API). Disabling reduces CPU load.</sys:String>
+    <sys:String x:Key="StrNcSecDebugLog">Debug Log API Enabled</sys:String>
+    <sys:String x:Key="StrNcDescSecDebugLog">Live debug output over serial or Bluetooth. Normally disabled when an API client connects.</sys:String>
+    <sys:String x:Key="StrNcSecIsManaged">Managed Mode</sys:String>
+    <sys:String x:Key="StrNcDescSecIsManaged">Device is managed by a mesh administrator via admin keys. Some UI options will be restricted.</sys:String>
+    <sys:String x:Key="StrNcSecAdminChannel">Legacy Admin Channel</sys:String>
+    <sys:String x:Key="StrNcDescSecAdminChannel">Allow admin access via the unencrypted legacy admin channel. Enable only for backwards compatibility.</sys:String>
+    <!-- Node config: Channels panel -->
+    <sys:String x:Key="StrNcNavChannels">Channels</sys:String>
+    <sys:String x:Key="StrNcChannelUplink">Uplink</sys:String>
+    <sys:String x:Key="StrNcChannelDownlink">Downlink</sys:String>
+    <sys:String x:Key="StrNcDescChannelUplink">Uplink: received LoRa packets on this channel are forwarded to the MQTT broker.</sys:String>
+    <sys:String x:Key="StrNcDescChannelDownlink">Downlink: messages from the MQTT broker are sent into the mesh via this channel.</sys:String>
+    <sys:String x:Key="StrNcLoadingProgress">Loading configuration ({0}/{1})…</sys:String>
+    <sys:String x:Key="StrNcLoadingTimeout">Not all responses received — saving enabled anyway.</sys:String>
+
     <!-- DirectMessages window -->
     <sys:String x:Key="StrDmWindowTitle">Direct Messages</sys:String>
     <sys:String x:Key="StrNoActiveChats">No active chats</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -49,6 +49,10 @@
 
     <!-- Node config window -->
     <sys:String x:Key="StrLoadingConfig">Loading configuration...</sys:String>
+    <sys:String x:Key="StrNcConfigLoaded">Configuration loaded. Note: The device will restart after saving.</sys:String>
+    <sys:String x:Key="StrNcShowPassword">Show password</sys:String>
+    <sys:String x:Key="StrNcHidePassword">Hide password</sys:String>
+    <sys:String x:Key="StrNcWifiPskHint">— click 👁 to enter password (leave empty = unchanged) —</sys:String>
     <sys:String x:Key="StrConfigSaved">Saved!</sys:String>
 
     <!-- Messages -->
@@ -211,6 +215,167 @@
     <sys:String x:Key="StrNcBtRebootHint">Note: The device will restart after changing Bluetooth settings.</sys:String>
     <sys:String x:Key="StrNcNodeDbReset">Reset NodeDB...</sys:String>
     <sys:String x:Key="StrNcNodeDbResetTip">Clears the known nodes on the device (no factory reset)</sys:String>
+    <sys:String x:Key="StrNcSaveRebootHint">Note: The device will restart after saving.</sys:String>
+    <sys:String x:Key="StrNcSaveRebootWarning">Configuration will be saved and the device will restart. Continue?</sys:String>
+    <sys:String x:Key="StrNcSaveRebootTitle">Restart device?</sys:String>
+    <!-- Nav sections -->
+    <sys:String x:Key="StrNcSectionNode">NODE</sys:String>
+    <sys:String x:Key="StrNcSectionConfig">CONFIGURATION</sys:String>
+    <sys:String x:Key="StrNcSectionModules">MODULES</sys:String>
+    <!-- Nav items -->
+    <sys:String x:Key="StrNcNavUser">User</sys:String>
+    <sys:String x:Key="StrNcNavDevice">Device</sys:String>
+    <sys:String x:Key="StrNcNavLora">LoRa</sys:String>
+    <sys:String x:Key="StrNcNavPosition">Position</sys:String>
+    <sys:String x:Key="StrNcNavPower">Power</sys:String>
+    <sys:String x:Key="StrNcNavNetwork">Network</sys:String>
+    <sys:String x:Key="StrNcNavDisplay">Display</sys:String>
+    <sys:String x:Key="StrNcNavBluetooth">Bluetooth</sys:String>
+    <sys:String x:Key="StrNcNavMqtt">MQTT</sys:String>
+    <sys:String x:Key="StrNcNavTelemetry">Telemetry</sys:String>
+    <sys:String x:Key="StrNcNavNeighborInfo">Neighbor Info</sys:String>
+    <sys:String x:Key="StrNcNavStoreForward">Store &amp; Forward</sys:String>
+    <sys:String x:Key="StrNcNavExtNotif">Ext. Notification</sys:String>
+    <sys:String x:Key="StrNcNavCannedMsg">Canned Messages</sys:String>
+    <sys:String x:Key="StrNcNavRangeTest">Range Test</sys:String>
+    <sys:String x:Key="StrNcNavSerial">Serial</sys:String>
+    <!-- Power config -->
+    <sys:String x:Key="StrNcPowerSaving">Power saving mode</sys:String>
+    <sys:String x:Key="StrNcPowerSavingTip">Disables everything possible to conserve power</sys:String>
+    <sys:String x:Key="StrNcShutdownAfterSecs">Shutdown after (seconds, 0=never)</sys:String>
+    <sys:String x:Key="StrNcWaitBtSecs">Bluetooth off after (seconds, 0=never)</sys:String>
+    <sys:String x:Key="StrNcSdsSecs">Super deep sleep after (seconds, 0=never)</sys:String>
+    <sys:String x:Key="StrNcLsSecs">Light sleep after (seconds, 0=never)</sys:String>
+    <sys:String x:Key="StrNcMinWakeSecs">Min. wake time after packet (seconds)</sys:String>
+    <!-- Network config -->
+    <sys:String x:Key="StrNcWifiEnabled">Enable WiFi</sys:String>
+    <sys:String x:Key="StrNcWifiSsid">WiFi network name (SSID)</sys:String>
+    <sys:String x:Key="StrNcWifiPsk">WiFi password</sys:String>
+    <sys:String x:Key="StrNcNtpServer">NTP server</sys:String>
+    <!-- Display config -->
+    <sys:String x:Key="StrNcScreenOnSecs">Display timeout (e.g. 1m, 30s, 0=always on)</sys:String>
+    <sys:String x:Key="StrNcAutoCarousel">Enable auto screen carousel</sys:String>
+    <sys:String x:Key="StrNcCompassNorthTop">Compass always points north</sys:String>
+    <sys:String x:Key="StrNcFlipScreen">Flip screen</sys:String>
+    <sys:String x:Key="StrNcGpsFormat">GPS coordinate format</sys:String>
+    <!-- Neighbor Info module -->
+    <sys:String x:Key="StrNcNiEnabled">Enable neighbor info module</sys:String>
+    <sys:String x:Key="StrNcNiInterval">Update interval (e.g. 4h, 6h)</sys:String>
+    <!-- Store & Forward module -->
+    <sys:String x:Key="StrNcSfEnabled">Enable store &amp; forward</sys:String>
+    <sys:String x:Key="StrNcSfHeartbeat">Send heartbeat</sys:String>
+    <sys:String x:Key="StrNcSfRecords">Max. stored messages</sys:String>
+    <sys:String x:Key="StrNcSfHistoryMax">Max. messages in history reply</sys:String>
+    <sys:String x:Key="StrNcSfHistoryWindow">History time window (seconds)</sys:String>
+    <!-- External Notification module -->
+    <sys:String x:Key="StrNcEnEnabled">Enable ext. notification</sys:String>
+    <sys:String x:Key="StrNcEnOutputMs">Pulse duration (ms)</sys:String>
+    <sys:String x:Key="StrNcEnOutput">Output GPIO pin</sys:String>
+    <sys:String x:Key="StrNcEnActiveHigh">Active high (else active low)</sys:String>
+    <sys:String x:Key="StrNcEnAlertMessage">Alert on text message</sys:String>
+    <sys:String x:Key="StrNcEnAlertBell">Alert on bell character</sys:String>
+    <!-- Canned Messages module -->
+    <sys:String x:Key="StrNcCmEnabled">Enable module</sys:String>
+    <sys:String x:Key="StrNcCmSendBell">Send bell character</sys:String>
+    <sys:String x:Key="StrNcCmAllowInputSource">Allowed input source (empty=all)</sys:String>
+    <sys:String x:Key="StrNcCmRotary1">Enable rotary encoder 1</sys:String>
+    <sys:String x:Key="StrNcCmUpdown1">Enable up/down encoder 1</sys:String>
+    <!-- Range Test module -->
+    <sys:String x:Key="StrNcRtEnabled">Enable range test</sys:String>
+    <sys:String x:Key="StrNcRtSender">Sender interval (seconds, 0=no sender)</sys:String>
+    <sys:String x:Key="StrNcRtSave">Save results to SD card</sys:String>
+    <!-- Serial module -->
+    <sys:String x:Key="StrNcSerEnabled">Enable serial module</sys:String>
+    <sys:String x:Key="StrNcSerEcho">Echo</sys:String>
+    <sys:String x:Key="StrNcSerRxd">RX pin (GPIO)</sys:String>
+    <sys:String x:Key="StrNcSerTxd">TX pin (GPIO)</sys:String>
+    <sys:String x:Key="StrNcSerBaud">Baud rate</sys:String>
+    <sys:String x:Key="StrNcSerTimeout">Timeout (ms)</sys:String>
+    <sys:String x:Key="StrNcSerMode">Mode</sys:String>
+    <!-- Telemetry additions -->
+    <sys:String x:Key="StrNcPowerMeasurement">Enable power measurement</sys:String>
+
+    <!-- NodeConfig: new label strings (previously hardcoded) -->
+    <sys:String x:Key="StrNcDoubleTap">Double-tap as button press</sys:String>
+    <sys:String x:Key="StrNcDutyCycle">Override duty-cycle limit</sys:String>
+    <sys:String x:Key="StrNcChannelNum">Channel Number</sys:String>
+    <sys:String x:Key="StrNcGpsUpdateInterval">GPS update interval (s, 0=default)</sys:String>
+    <sys:String x:Key="StrNcMqttProxy">Proxy to Client</sys:String>
+    <sys:String x:Key="StrNcAutoCarouselSecs">Auto-carousel (sec, 0=off)</sys:String>
+
+    <!-- NodeConfig: description strings -->
+    <sys:String x:Key="StrNcDescLongName">Full name shown to other users (max. 39 characters).</sys:String>
+    <sys:String x:Key="StrNcDescShortName">Short name for device display (max. 4 characters, e.g. initials).</sys:String>
+    <sys:String x:Key="StrNcDescRebroadcast">Controls which received packets are rebroadcast. ALL = everything · LOCAL_ONLY = own channel only · NONE = no rebroadcast.</sys:String>
+    <sys:String x:Key="StrNcDescNodeInfo">How often the device sends its name/status into the mesh (seconds). Default: 900 s. 0 = firmware default.</sys:String>
+    <sys:String x:Key="StrNcDescTimezone">POSIX timezone string for the device's internal clock (e.g. for date/time display).</sys:String>
+    <sys:String x:Key="StrNcDescDoubleTap">Accelerometer: double-tapping the case triggers the button press (e.g. for GPS toggle).</sys:String>
+    <sys:String x:Key="StrNcDescLoraRegion">Legal frequency region. In Europe/Germany: EU_868 (868 MHz band).</sys:String>
+    <sys:String x:Key="StrNcDescUsePreset">Recommended: use preset. Only disable for manual bandwidth/spreading-factor configuration.</sys:String>
+    <sys:String x:Key="StrNcDescModemPreset">Higher Spreading Factor (SF) = better sensitivity and range, but lower throughput. · VERY_LONG_SLOW (SF12, 62.5 kHz) = maximum range, ~90 bps · LONG_SLOW (SF12, 125 kHz) = very long range, ~180 bps · LONG_FAST (SF11, 250 kHz) = good range, ~1 kbit/s – Meshtastic default · SHORT_SLOW (SF8, 250 kHz) = significantly shorter range, ~8 kbit/s – Mesh Hessen standard for dense networks · SHORT_FAST (SF7) = shortest range, ~17 kbit/s. All nodes in the mesh must use the same preset.</sys:String>
+    <sys:String x:Key="StrNcDescHopLimit">Max. number of rebroadcasts (hops) per packet. Default: 3. Higher values significantly increase network load.</sys:String>
+    <sys:String x:Key="StrNcDescTxPower">TX power in dBm. 0 = maximum power allowed for the selected region (recommended).</sys:String>
+    <sys:String x:Key="StrNcDescChannelNum">Frequency slot within the region. 0 = automatically derived from the channel name (hash) – default for all normal setups. Set manually only when targeting a specific frequency slot (advanced).</sys:String>
+    <sys:String x:Key="StrNcDescDutyCycle">⚠ Warning: Most radio regions enforce a legal duty-cycle limit for LoRa transmitters. Exceeding this limit may violate local radio regulations.</sys:String>
+    <sys:String x:Key="StrNcDescSx126x">Higher receive sensitivity (~1–2 dB gain) at the cost of ~2 mA extra current. Recommended for stationary nodes.</sys:String>
+    <sys:String x:Key="StrNcDescGpsMode">DISABLED = GPS off (saves power) · ENABLED = GPS active · NOT_PRESENT = no GPS module installed.</sys:String>
+    <sys:String x:Key="StrNcDescPosBroadcast">Maximum interval between position broadcasts (seconds). 0 = smart broadcast controls the interval.</sys:String>
+    <sys:String x:Key="StrNcDescSmartBroadcast">Sends position only when the device has moved far enough (minimum distance + minimum speed).</sys:String>
+    <sys:String x:Key="StrNcDescMinDistance">Minimum distance in metres the device must travel before sending a new position.</sys:String>
+    <sys:String x:Key="StrNcDescMinSpeed">Minimum speed in cm/s. When stationary below this speed, no new position is sent.</sys:String>
+    <sys:String x:Key="StrNcDescGpsInterval">How often the GPS module polls for new coordinates. 0 = firmware default (~30 s).</sys:String>
+    <sys:String x:Key="StrNcDescPowerSaving">Sleeps as much as possible: display, GPS, and Bluetooth are switched off; CPU enters deep/light sleep. The device only wakes when a LoRa packet is received or a sleep cycle expires. Do not enable if the device should remain connected via Bluetooth or USB at all times.</sys:String>
+    <sys:String x:Key="StrNcDescShutdownAfter">Device shuts down automatically after running on battery for this long (no USB). 0 = never.</sys:String>
+    <sys:String x:Key="StrNcDescWaitBt">Bluetooth switches off after this many seconds without a connection. 0 = Bluetooth always on.</sys:String>
+    <sys:String x:Key="StrNcDescSds">Super Deep Sleep: extreme power-save mode – only a physical reset button press wakes the device (seconds). 0 = disabled.</sys:String>
+    <sys:String x:Key="StrNcDescLs">Light Sleep: device remains receive-ready (LoRa on), but CPU and other consumers sleep (seconds). 0 = disabled.</sys:String>
+    <sys:String x:Key="StrNcDescMinWake">How long the device stays awake after receiving a packet before returning to sleep (seconds).</sys:String>
+    <sys:String x:Key="StrNcDescWifiEnabled">ESP32-based devices only (e.g. T-Beam, Heltec). nRF52 devices (RAK, T-Echo) have no Wi-Fi.</sys:String>
+    <sys:String x:Key="StrNcDescWifiSsid">Name of the Wi-Fi network (SSID) the device should connect to (max. 32 characters).</sys:String>
+    <sys:String x:Key="StrNcDescWifiPsk">Wi-Fi password. The device returns this field empty for security – leave blank to keep the current password unchanged.</sys:String>
+    <sys:String x:Key="StrNcDescNtpServer">Time server for automatic time synchronisation. Default: meshtastic.pool.ntp.org</sys:String>
+    <sys:String x:Key="StrNcDescScreenOn">How long the display stays on after the last action (seconds). 0 = always on.</sys:String>
+    <sys:String x:Key="StrNcDescAutoCarousel">Automatically cycles through display pages. Value in seconds. 0 = disabled.</sys:String>
+    <sys:String x:Key="StrNcDescCompassNorth">Compass display always shows geographic north at the top (instead of heading).</sys:String>
+    <sys:String x:Key="StrNcDescFlipScreen">Rotates the display 180° (for upside-down mounted enclosures).</sys:String>
+    <sys:String x:Key="StrNcDescBtEnabled">Disabling saves power – connection is then only possible via USB/serial.</sys:String>
+    <sys:String x:Key="StrNcDescBtPairing">RANDOM = new PIN each pairing (secure) · FIXED = same PIN always · NO_PIN = no PIN required (insecure).</sys:String>
+    <sys:String x:Key="StrNcDescMqttEnabled">Connects the device as a gateway between the LoRa mesh and an MQTT broker (internet bridge for messages and telemetry).</sys:String>
+    <sys:String x:Key="StrNcDescMqttServer">Hostname or IP of the MQTT broker. Default: mqtt.meshtastic.org</sys:String>
+    <sys:String x:Key="StrNcDescMqttEncryption">Packets are transmitted encrypted via MQTT (LoRa key stays in the packet).</sys:String>
+    <sys:String x:Key="StrNcDescMqttJson">Also publishes decrypted packets as JSON (e.g. for Home Assistant, Node-RED, Grafana).</sys:String>
+    <sys:String x:Key="StrNcDescMqttRootTopic">Base MQTT topic for all messages from this device. Default: msh</sys:String>
+    <sys:String x:Key="StrNcDescMqttProxy">The connected app (phone/PC) forwards MQTT messages for the device – no direct Wi-Fi on the device needed. Note: This Windows client does not actively implement the proxy mode.</sys:String>
+    <sys:String x:Key="StrNcDescMqttMapReport">Publishes the device's position to the public Meshtastic world map (map.meshtastic.org).</sys:String>
+    <sys:String x:Key="StrNcDescDeviceTelemetry">Device metrics: battery %, voltage, channel utilisation, TX airtime. Visible in the client's telemetry window.</sys:String>
+    <sys:String x:Key="StrNcDescEnvTelemetry">Environmental sensors (temperature, humidity, pressure) – requires connected I²C sensor (e.g. BME280).</sys:String>
+    <sys:String x:Key="StrNcDescAirQuality">Air quality sensor (PM2.5 etc.) – requires connected sensor (e.g. PMSA003I).</sys:String>
+    <sys:String x:Key="StrNcDescPowerTelemetry">Power measurement (voltage/current) – requires INA2xx sensor.</sys:String>
+    <sys:String x:Key="StrNcDescNiEnabled">Device periodically broadcasts a list of all directly reachable neighbour nodes (with SNR values). Useful for network analysis.</sys:String>
+    <sys:String x:Key="StrNcDescNiInterval">Minimum interval per spec: 4 h (14400 seconds). Smaller values are ignored by the firmware.</sys:String>
+    <sys:String x:Key="StrNcDescSfEnabled">Stores messages for temporarily offline nodes and delivers them on next contact. Requires a dedicated server node (ESP32 with sufficient storage).</sys:String>
+    <sys:String x:Key="StrNcDescSfHeartbeat">Sends a regular heartbeat so clients know the store-and-forward server is reachable.</sys:String>
+    <sys:String x:Key="StrNcDescSfRecords">Maximum number of messages stored on the server node. 0 = firmware limit.</sys:String>
+    <sys:String x:Key="StrNcDescSfHistoryMax">Maximum number of messages sent in response to a single history request.</sys:String>
+    <sys:String x:Key="StrNcDescSfHistoryWindow">Time window in seconds from which messages are returned for a history request.</sys:String>
+    <sys:String x:Key="StrNcDescEnEnabled">Controls an external GPIO output (LED, buzzer, vibration motor) on incoming messages.</sys:String>
+    <sys:String x:Key="StrNcDescEnOutput">GPIO pin number for the output signal (e.g. 13 for built-in LED).</sys:String>
+    <sys:String x:Key="StrNcDescEnOutputMs">Signal duration in milliseconds. Default: 1000 ms (1 second).</sys:String>
+    <sys:String x:Key="StrNcDescEnActive">Active-High = set pin HIGH to activate. Active-Low = set pin LOW (required for many LEDs).</sys:String>
+    <sys:String x:Key="StrNcDescEnBell">Bell = ASCII character 0x07, which can be sent deliberately by other nodes to trigger a notification.</sys:String>
+    <sys:String x:Key="StrNcDescCmEnabled">Enables sending pre-stored messages directly on the device using a rotary encoder or up/down buttons – no smartphone needed.</sys:String>
+    <sys:String x:Key="StrNcDescCmSendBell">Appends a Bell character (0x07) to every sent message – triggers external notifications at the recipient.</sys:String>
+    <sys:String x:Key="StrNcDescCmInput">Empty = all input sources allowed. Possible values: rotary1, updown1, cardkb, serial (hardware-dependent).</sys:String>
+    <sys:String x:Key="StrNcDescCmRotary">Enables rotary encoder 1 as input (KY-040 or similar, connected to configured GPIO pins).</sys:String>
+    <sys:String x:Key="StrNcDescCmUpdown">Enables up/down/confirm buttons as input (3 separate GPIO pins).</sys:String>
+    <sys:String x:Key="StrNcDescRtEnabled">Sends or receives test packets for range measurement. One node sends (interval &gt; 0), others receive and log. ⚠ Remember to disable after the test – the sender continuously occupies the channel!</sys:String>
+    <sys:String x:Key="StrNcDescRtSender">Send interval in seconds. 0 = receiver mode (no transmitting). Typical value: 60 s. Make sure to reset to 0 and save after completing the test!</sys:String>
+    <sys:String x:Key="StrNcDescRtSave">Saves test results as a CSV file on the SD card (ESP32 with SD slot only).</sys:String>
+    <sys:String x:Key="StrNcDescSerEnabled">Data exchange over a serial UART interface (in addition to USB), for integration with external systems (Arduino, Raspberry Pi, etc.).</sys:String>
+    <sys:String x:Key="StrNcDescSerEcho">Received data is immediately echoed back (for diagnostics).</sys:String>
+    <sys:String x:Key="StrNcDescSerPins">GPIO pin numbers for the UART connection. 0 = board hardware default.</sys:String>
+    <sys:String x:Key="StrNcDescSerTimeout">Wait time in milliseconds until an incomplete packet is considered complete.</sys:String>
+    <sys:String x:Key="StrNcDescSerMode">DEFAULT = text messages · NMEA = GPS coordinates as NMEA sentences · PROTO = raw protobuf packets (developer).</sys:String>
 
     <!-- DirectMessages window -->
     <sys:String x:Key="StrDmWindowTitle">Direct Messages</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -406,6 +406,8 @@
     <sys:String x:Key="StrNcDescFixedCoords">Decimal degrees, e.g. 50.123456 / 8.654321. Sent to node on save.</sys:String>
     <sys:String x:Key="StrNcPickFromMap">Pick from Map</sys:String>
     <sys:String x:Key="StrNcPickFromMapTip">Use current map center as fixed position</sys:String>
+    <sys:String x:Key="StrNcPickFromMapHint">Navigate the map to the desired location, then click this button.</sys:String>
+    <sys:String x:Key="StrNcMapCenterLabel">Current map center:</sys:String>
     <sys:String x:Key="StrNcMinIntervalSecs">Smart Broadcast Min. Interval (s)</sys:String>
     <sys:String x:Key="StrNcDescMinIntervalSecs">Minimum wait time in seconds between two smart position broadcasts.</sys:String>
     <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -346,7 +346,9 @@
     <sys:String x:Key="StrNcDescMqttJson">Also publishes decrypted packets as JSON (e.g. for Home Assistant, Node-RED, Grafana).</sys:String>
     <sys:String x:Key="StrNcDescMqttRootTopic">Base MQTT topic for all messages from this device. Default: msh</sys:String>
     <sys:String x:Key="StrNcDescMqttProxy">The connected app (phone/PC) forwards MQTT messages for the device – no direct Wi-Fi on the device needed. Note: This Windows client does not actively implement the proxy mode.</sys:String>
-    <sys:String x:Key="StrNcDescMqttMapReport">Publishes the device's position to the public Meshtastic world map (map.meshtastic.org).</sys:String>
+    <sys:String x:Key="StrNcDescMqttMapReport">Publishes the device's position to the public Meshtastic world map (map.meshtastic.org) and to map.meshhessen.de.</sys:String>
+    <sys:String x:Key="StrNcMqttMapReportPrecision">Map Report Precision</sys:String>
+    <sys:String x:Key="StrNcDescMqttMapReportPrecision">Position precision for map report packets. Recommended: ~370m or higher for public maps.</sys:String>
     <sys:String x:Key="StrNcDescDeviceTelemetry">Device metrics: battery %, voltage, channel utilisation, TX airtime. Visible in the client's telemetry window.</sys:String>
     <sys:String x:Key="StrNcDescEnvTelemetry">Environmental sensors (temperature, humidity, pressure) – requires connected I²C sensor (e.g. BME280).</sys:String>
     <sys:String x:Key="StrNcDescAirQuality">Air quality sensor (PM2.5 etc.) – requires connected sensor (e.g. PMSA003I).</sys:String>
@@ -405,9 +407,15 @@
     <sys:String x:Key="StrNcFixedAlt">Altitude (m)</sys:String>
     <sys:String x:Key="StrNcDescFixedCoords">Decimal degrees, e.g. 50.123456 / 8.654321. Sent to node on save.</sys:String>
     <sys:String x:Key="StrNcPickFromMap">Pick from Map</sys:String>
-    <sys:String x:Key="StrNcPickFromMapTip">Use current map center as fixed position</sys:String>
-    <sys:String x:Key="StrNcPickFromMapHint">Navigate the map to the desired location, then click this button.</sys:String>
+    <sys:String x:Key="StrNcPickFromMapTip">Opens a map window — click the desired location there</sys:String>
+    <sys:String x:Key="StrNcPickFromMapHint">Click "Pick from Map" to open a map window and select the location there.</sys:String>
     <sys:String x:Key="StrNcMapCenterLabel">Current map center:</sys:String>
+    <sys:String x:Key="StrNcUseCurrentPos">Own Map Pin</sys:String>
+    <sys:String x:Key="StrNcUseCurrentPosTip">Uses your own position (set via right-click → "Set My Position" on the map)</sys:String>
+    <sys:String x:Key="StrMapPickerTitle">Pick Location</sys:String>
+    <sys:String x:Key="StrMapPickerHint">Click on the map to select a point, then click "Accept".</sys:String>
+    <sys:String x:Key="StrMapPickerAccept">Accept</sys:String>
+    <sys:String x:Key="StrMapPickerCancel">Cancel</sys:String>
     <sys:String x:Key="StrNcMinIntervalSecs">Smart Broadcast Min. Interval (s)</sys:String>
     <sys:String x:Key="StrNcDescMinIntervalSecs">Minimum wait time in seconds between two smart position broadcasts.</sys:String>
     <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>
@@ -467,10 +475,14 @@
     <sys:String x:Key="StrNcDescSecAdminKeys">Public keys of admin devices (Base64). Leave blank = not set.</sys:String>
     <!-- Node config: Channels panel -->
     <sys:String x:Key="StrNcNavChannels">Channels</sys:String>
+    <sys:String x:Key="StrNcChannelRole">Role</sys:String>
+    <sys:String x:Key="StrNcChannelName">Name</sys:String>
     <sys:String x:Key="StrNcChannelPosPrecision">Precision</sys:String>
-    <sys:String x:Key="StrNcDescChannelPosPrecision">Position precision for this channel (0=off, 10≈23km, 13≈2.8km, 16≈350m, 19≈44m, 32=exact)</sys:String>
+    <sys:String x:Key="StrNcDescChannelPosPrecision">Position precision for this channel. Bits 10–19: from ~23km down to ~45m. 0=off, 32=exact.</sys:String>
     <sys:String x:Key="StrNcChannelUplink">Uplink</sys:String>
     <sys:String x:Key="StrNcChannelDownlink">Downlink</sys:String>
+    <sys:String x:Key="StrNcPrecNone">No Location</sys:String>
+    <sys:String x:Key="StrNcPrecExact">Exact</sys:String>
     <sys:String x:Key="StrNcDescChannelUplink">Uplink: received LoRa packets on this channel are forwarded to the MQTT broker.</sys:String>
     <sys:String x:Key="StrNcDescChannelDownlink">Downlink: messages from the MQTT broker are sent into the mesh via this channel.</sys:String>
     <sys:String x:Key="StrNcLoadingProgress">Loading configuration ({0}/{1})…</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -397,8 +397,15 @@
     <sys:String x:Key="StrNcOverrideFreq">Override Frequency (MHz)</sys:String>
     <sys:String x:Key="StrNcDescOverrideFreq">Overrides the calculated channel frequency. For licensed HAM operators or developers only. 0 = automatic.</sys:String>
     <!-- Node config: Position extras -->
-    <sys:String x:Key="StrNcFixedPosition">Fixed Position</sys:String>
+    <sys:String x:Key="StrNcFixedPosition">Enable Fixed Position</sys:String>
     <sys:String x:Key="StrNcDescFixedPosition">Node always broadcasts the same (manually set) position regardless of GPS.</sys:String>
+    <sys:String x:Key="StrNcFixedPosGroupHeader">Fixed Position Coordinates</sys:String>
+    <sys:String x:Key="StrNcFixedLat">Latitude</sys:String>
+    <sys:String x:Key="StrNcFixedLon">Longitude</sys:String>
+    <sys:String x:Key="StrNcFixedAlt">Altitude (m)</sys:String>
+    <sys:String x:Key="StrNcDescFixedCoords">Decimal degrees, e.g. 50.123456 / 8.654321. Sent to node on save.</sys:String>
+    <sys:String x:Key="StrNcPickFromMap">Pick from Map</sys:String>
+    <sys:String x:Key="StrNcPickFromMapTip">Use current map center as fixed position</sys:String>
     <sys:String x:Key="StrNcMinIntervalSecs">Smart Broadcast Min. Interval (s)</sys:String>
     <sys:String x:Key="StrNcDescMinIntervalSecs">Minimum wait time in seconds between two smart position broadcasts.</sys:String>
     <sys:String x:Key="StrNcRxGpio">GPS RX GPIO</sys:String>
@@ -450,8 +457,16 @@
     <sys:String x:Key="StrNcDescSecIsManaged">Device is managed by a mesh administrator via admin keys. Some UI options will be restricted.</sys:String>
     <sys:String x:Key="StrNcSecAdminChannel">Legacy Admin Channel</sys:String>
     <sys:String x:Key="StrNcDescSecAdminChannel">Allow admin access via the unencrypted legacy admin channel. Enable only for backwards compatibility.</sys:String>
+    <sys:String x:Key="StrNcSecPrivateKey">Private Key</sys:String>
+    <sys:String x:Key="StrNcDescSecPrivateKey">X25519 private key used for PKI decryption. Only change if you know what you're doing — you will lose access to all encrypted direct messages.</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey1">Admin Key 1</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey2">Admin Key 2</sys:String>
+    <sys:String x:Key="StrNcSecAdminKey3">Admin Key 3</sys:String>
+    <sys:String x:Key="StrNcDescSecAdminKeys">Public keys of admin devices (Base64). Leave blank = not set.</sys:String>
     <!-- Node config: Channels panel -->
     <sys:String x:Key="StrNcNavChannels">Channels</sys:String>
+    <sys:String x:Key="StrNcChannelPosPrecision">Precision</sys:String>
+    <sys:String x:Key="StrNcDescChannelPosPrecision">Position precision for this channel (0=off, 10≈23km, 13≈2.8km, 16≈350m, 19≈44m, 32=exact)</sys:String>
     <sys:String x:Key="StrNcChannelUplink">Uplink</sys:String>
     <sys:String x:Key="StrNcChannelDownlink">Downlink</sys:String>
     <sys:String x:Key="StrNcDescChannelUplink">Uplink: received LoRa packets on this channel are forwarded to the MQTT broker.</sys:String>

--- a/MeshhessenClient/Services/LocalFileTileProvider.cs
+++ b/MeshhessenClient/Services/LocalFileTileProvider.cs
@@ -1,0 +1,33 @@
+using BruTile;
+
+namespace MeshhessenClient.Services;
+
+/// <summary>
+/// Serves pre-downloaded map tiles from the local file system.
+/// Tile storage format: maptiles/{source}/{z}/{x}/{yOsm}.png  (OSM/XYZ scheme)
+/// </summary>
+internal class LocalFileTileProvider : ITileProvider
+{
+    private readonly string _baseDir;
+    private readonly string _sourceFolder;
+
+    public LocalFileTileProvider(string baseDir, string sourceFolder)
+    {
+        _baseDir = baseDir;
+        _sourceFolder = sourceFolder;
+    }
+
+    public Task<byte[]?> GetTileAsync(TileInfo tileInfo)
+    {
+        var z = tileInfo.Index.Level;
+        var x = tileInfo.Index.Col;
+        // BruTile TMS has Row 0 in the south, OSM files have Y=0 in the north → convert
+        var yOsm = (1 << z) - 1 - tileInfo.Index.Row;
+        var path = System.IO.Path.Combine(_baseDir, _sourceFolder, z.ToString(), x.ToString(), $"{yOsm}.png");
+        if (System.IO.File.Exists(path))
+        {
+            try { return Task.FromResult<byte[]?>(System.IO.File.ReadAllBytes(path)); } catch { }
+        }
+        return Task.FromResult<byte[]?>(null);
+    }
+}

--- a/MeshhessenClient/Services/MeshtasticProtocolService.cs
+++ b/MeshhessenClient/Services/MeshtasticProtocolService.cs
@@ -40,9 +40,18 @@ public class MeshtasticProtocolService
     public event EventHandler<LoRaConfig>? LoRaConfigReceived;
     public event EventHandler<DeviceConfig>? DeviceConfigReceived;
     public event EventHandler<PositionConfig>? PositionConfigReceived;
+    public event EventHandler<PowerConfig>? PowerConfigReceived;
+    public event EventHandler<NetworkConfig>? NetworkConfigReceived;
+    public event EventHandler<DisplayConfig>? DisplayConfigReceived;
     public event EventHandler<MQTTConfig>? MqttConfigReceived;
     public event EventHandler<TelemetryConfig>? TelemetryConfigReceived;
     public event EventHandler<BluetoothConfig>? BluetoothConfigReceived;
+    public event EventHandler<NeighborInfoConfig>? NeighborInfoConfigReceived;
+    public event EventHandler<StoreForwardConfig>? StoreForwardConfigReceived;
+    public event EventHandler<ExternalNotificationConfig>? ExternalNotificationConfigReceived;
+    public event EventHandler<CannedMessageConfig>? CannedMessageConfigReceived;
+    public event EventHandler<RangeTestConfig>? RangeTestConfigReceived;
+    public event EventHandler<SerialConfig>? SerialConfigReceived;
     public event EventHandler<User>? OwnerReceived;
     public event EventHandler<DeviceInfo>? DeviceInfoReceived;
     public event EventHandler<int>? PacketCountChanged;
@@ -1862,6 +1871,60 @@ public class MeshtasticProtocolService
         await SendAdminMessageAsync(adminMsg);
     }
 
+    public async Task RequestPowerConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetConfigRequest = 2 }; // POWER = 2
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestNetworkConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetConfigRequest = 3 }; // NETWORK = 3
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestDisplayConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetConfigRequest = 4 }; // DISPLAY = 4
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestSerialConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetModuleConfigRequest = 1 }; // SERIAL = 1
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestExternalNotificationConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetModuleConfigRequest = 2 }; // EXT_NOTIF = 2
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestStoreForwardConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetModuleConfigRequest = 3 }; // STORE_FORWARD = 3
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestRangeTestConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetModuleConfigRequest = 4 }; // RANGE_TEST = 4
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestCannedMessageConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetModuleConfigRequest = 6 }; // CANNED_MSG = 6
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestNeighborInfoConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetModuleConfigRequest = 9 }; // NEIGHBOR_INFO = 9
+        await SendAdminMessageAsync(adminMsg);
+    }
+
     // ========== Config Set Methods ==========
 
     public async Task SetOwnerAsync(User user)
@@ -1910,6 +1973,90 @@ public class MeshtasticProtocolService
     {
         await EnsureSessionKeyAsync();
         var adminMsg = new AdminMessage { SetConfig = new Config { Bluetooth = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetPowerConfigAsync(PowerConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetConfig = new Config { Power = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetNetworkConfigAsync(NetworkConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetConfig = new Config { Network = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetDisplayConfigAsync(DisplayConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetConfig = new Config { Display = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetSerialConfigAsync(SerialConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetModuleConfig = new ModuleConfig { Serial = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetExternalNotificationConfigAsync(ExternalNotificationConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetModuleConfig = new ModuleConfig { ExternalNotification = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetStoreForwardConfigAsync(StoreForwardConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetModuleConfig = new ModuleConfig { StoreForward = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetRangeTestConfigAsync(RangeTestConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetModuleConfig = new ModuleConfig { RangeTest = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetCannedMessageConfigAsync(CannedMessageConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetModuleConfig = new ModuleConfig { CannedMessage = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetNeighborInfoConfigAsync(NeighborInfoConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetModuleConfig = new ModuleConfig { NeighborInfo = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task BeginEditSettingsAsync()
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { BeginEditSettings = true };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task CommitEditSettingsAsync()
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { CommitEditSettings = true };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RebootAsync(int delaySecs = 3)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { RebootSeconds = delaySecs };
         await SendAdminMessageAsync(adminMsg);
     }
 
@@ -2044,6 +2191,18 @@ public class MeshtasticProtocolService
                             BluetoothConfigReceived?.Invoke(this, config.Bluetooth);
                             break;
 
+                        case Config.PayloadVariantOneofCase.Power:
+                            PowerConfigReceived?.Invoke(this, config.Power);
+                            break;
+
+                        case Config.PayloadVariantOneofCase.Network:
+                            NetworkConfigReceived?.Invoke(this, config.Network);
+                            break;
+
+                        case Config.PayloadVariantOneofCase.Display:
+                            DisplayConfigReceived?.Invoke(this, config.Display);
+                            break;
+
                         case Config.PayloadVariantOneofCase.Security:
                             var sec = config.Security;
                             if (sec.PrivateKey != null && sec.PrivateKey.Length == 32)
@@ -2087,6 +2246,30 @@ public class MeshtasticProtocolService
 
                         case ModuleConfig.PayloadVariantOneofCase.Telemetry:
                             TelemetryConfigReceived?.Invoke(this, moduleConfig.Telemetry);
+                            break;
+
+                        case ModuleConfig.PayloadVariantOneofCase.Serial:
+                            SerialConfigReceived?.Invoke(this, moduleConfig.Serial);
+                            break;
+
+                        case ModuleConfig.PayloadVariantOneofCase.ExternalNotification:
+                            ExternalNotificationConfigReceived?.Invoke(this, moduleConfig.ExternalNotification);
+                            break;
+
+                        case ModuleConfig.PayloadVariantOneofCase.StoreForward:
+                            StoreForwardConfigReceived?.Invoke(this, moduleConfig.StoreForward);
+                            break;
+
+                        case ModuleConfig.PayloadVariantOneofCase.RangeTest:
+                            RangeTestConfigReceived?.Invoke(this, moduleConfig.RangeTest);
+                            break;
+
+                        case ModuleConfig.PayloadVariantOneofCase.CannedMessage:
+                            CannedMessageConfigReceived?.Invoke(this, moduleConfig.CannedMessage);
+                            break;
+
+                        case ModuleConfig.PayloadVariantOneofCase.NeighborInfo:
+                            NeighborInfoConfigReceived?.Invoke(this, moduleConfig.NeighborInfo);
                             break;
                     }
                     break;

--- a/MeshhessenClient/Services/MeshtasticProtocolService.cs
+++ b/MeshhessenClient/Services/MeshtasticProtocolService.cs
@@ -52,6 +52,7 @@ public class MeshtasticProtocolService
     public event EventHandler<CannedMessageConfig>? CannedMessageConfigReceived;
     public event EventHandler<RangeTestConfig>? RangeTestConfigReceived;
     public event EventHandler<SerialConfig>? SerialConfigReceived;
+    public event EventHandler<SecurityConfig>? SecurityConfigReceived;
     public event EventHandler<User>? OwnerReceived;
     public event EventHandler<DeviceInfo>? DeviceInfoReceived;
     public event EventHandler<int>? PacketCountChanged;
@@ -62,6 +63,8 @@ public class MeshtasticProtocolService
     public event EventHandler<int>? TimeDriftDetected;  // arg: observed drift in seconds
     public event EventHandler<TelemetryDatabaseService.WaypointEntry>? WaypointReceived;
     public event EventHandler<uint>? WaypointDeleted;
+    /// <summary>Raised when the radio sends an MqttClientProxyMessage (device→broker direction).</summary>
+    public event EventHandler<MqttClientProxyMessage>? MqttProxyMessageReceived;
     public int TimeDriftThresholdSeconds { get; set; } = 300; // 5 minutes
 
     private DateTime _lastDriftCheck = DateTime.MinValue;
@@ -785,6 +788,10 @@ public class MeshtasticProtocolService
                 break;
 
             case FromRadio.PayloadVariantOneofCase.ModuleConfig:
+                break;
+
+            case FromRadio.PayloadVariantOneofCase.MqttClientProxyMessage:
+                MqttProxyMessageReceived?.Invoke(this, fromRadio.MqttClientProxyMessage);
                 break;
         }
     }
@@ -1997,6 +2004,31 @@ public class MeshtasticProtocolService
         await SendAdminMessageAsync(adminMsg);
     }
 
+    public async Task RequestSecurityConfigAsync()
+    {
+        var adminMsg = new AdminMessage { GetConfigRequest = (uint)AdminMessage.Types.ConfigType.SecurityConfig };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task SetSecurityConfigAsync(SecurityConfig config)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetConfig = new Config { Security = config } };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
+    public async Task RequestChannelConfigAsync(int channelIndex)
+    {
+        await RequestChannelAsync(channelIndex);
+    }
+
+    public async Task UpdateChannelUplinkDownlinkAsync(Channel channel)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { SetChannel = channel };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
     public async Task SetSerialConfigAsync(SerialConfig config)
     {
         await EnsureSessionKeyAsync();
@@ -2037,6 +2069,16 @@ public class MeshtasticProtocolService
         await EnsureSessionKeyAsync();
         var adminMsg = new AdminMessage { SetModuleConfig = new ModuleConfig { NeighborInfo = config } };
         await SendAdminMessageAsync(adminMsg);
+    }
+
+    /// <summary>
+    /// Sends an MqttClientProxyMessage to the radio (broker→device direction).
+    /// Called by MqttProxyService when a message arrives from the MQTT broker.
+    /// </summary>
+    public async Task SendMqttProxyMessageAsync(MqttClientProxyMessage msg)
+    {
+        var toRadio = new ToRadio { MqttClientProxyMessage = msg };
+        await SendToRadioAsync(toRadio);
     }
 
     public async Task BeginEditSettingsAsync()
@@ -2214,6 +2256,7 @@ public class MeshtasticProtocolService
                             {
                                 Logger.WriteLine("SecurityConfig received but private key missing/invalid");
                             }
+                            SecurityConfigReceived?.Invoke(this, sec);
                             break;
                     }
                     break;

--- a/MeshhessenClient/Services/MeshtasticProtocolService.cs
+++ b/MeshhessenClient/Services/MeshtasticProtocolService.cs
@@ -308,14 +308,14 @@ public class MeshtasticProtocolService
 
             var channelInfo = new ChannelInfo
             {
-                Index = channel.Index,
-                Name = ExtractChannelName(channel),
-                Role = channel.Role.ToString(),
-                Psk = channel.Settings?.Psk != null && channel.Settings.Psk.Length > 0
-                    ? Convert.ToBase64String(channel.Settings.Psk.ToByteArray())
-                    : "",
-                Uplink = channel.Settings?.UplinkEnabled ?? false,
-                Downlink = channel.Settings?.DownlinkEnabled ?? false
+                Index             = channel.Index,
+                Name              = ExtractChannelName(channel),
+                Role              = channel.Role.ToString(),
+                Psk               = channel.Settings?.Psk != null && channel.Settings.Psk.Length > 0
+                    ? Convert.ToBase64String(channel.Settings.Psk.ToByteArray()) : "",
+                Uplink            = channel.Settings?.UplinkEnabled ?? false,
+                Downlink          = channel.Settings?.DownlinkEnabled ?? false,
+                PositionPrecision = channel.Settings?.ModuleSettings?.PositionPrecision ?? 0
             };
             ChannelInfoReceived?.Invoke(this, channelInfo);
             await Task.Delay(50);
@@ -1548,14 +1548,14 @@ public class MeshtasticProtocolService
 
                     var channelInfo = new ChannelInfo
                     {
-                        Index = channel.Index,
-                        Name = channelName,
-                        Role = channel.Role.ToString(),
-                        Psk = channel.Settings?.Psk != null && channel.Settings.Psk.Length > 0
-                            ? Convert.ToBase64String(channel.Settings.Psk.ToByteArray())
-                            : "",
-                        Uplink = channel.Settings?.UplinkEnabled ?? false,
-                        Downlink = channel.Settings?.DownlinkEnabled ?? false
+                        Index             = channel.Index,
+                        Name              = channelName,
+                        Role              = channel.Role.ToString(),
+                        Psk               = channel.Settings?.Psk != null && channel.Settings.Psk.Length > 0
+                            ? Convert.ToBase64String(channel.Settings.Psk.ToByteArray()) : "",
+                        Uplink            = channel.Settings?.UplinkEnabled ?? false,
+                        Downlink          = channel.Settings?.DownlinkEnabled ?? false,
+                        PositionPrecision = channel.Settings?.ModuleSettings?.PositionPrecision ?? 0
                     };
                     ChannelInfoReceived?.Invoke(this, channelInfo);
                 }
@@ -1955,6 +1955,20 @@ public class MeshtasticProtocolService
         await SendAdminMessageAsync(adminMsg);
     }
 
+    public async Task SetFixedPositionAsync(double latDeg, double lonDeg, int altitudeM)
+    {
+        await EnsureSessionKeyAsync();
+        var position = new Position
+        {
+            LatitudeI  = (int)(latDeg  * 1e7),
+            LongitudeI = (int)(lonDeg  * 1e7),
+            Altitude   = altitudeM,
+            Time       = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+        };
+        var adminMsg = new AdminMessage { SetPosition = position };
+        await SendAdminMessageAsync(adminMsg);
+    }
+
     public async Task SetLoRaConfigAsync(LoRaConfig config)
     {
         await EnsureSessionKeyAsync();
@@ -2184,16 +2198,18 @@ public class MeshtasticProtocolService
                         shouldFireChannelEvent = !_isInitializing;
                     }
 
-                    if (shouldFireChannelEvent && channel.Role != ChannelRole.Disabled)
+                    if (shouldFireChannelEvent)
                     {
                         var channelInfo = new ChannelInfo
                         {
-                            Index = channel.Index,
-                            Name = channelName,
-                            Role = channel.Role.ToString(),
-                            Psk = channel.Settings?.Psk != null && channel.Settings.Psk.Length > 0
-                                ? Convert.ToBase64String(channel.Settings.Psk.ToByteArray())
-                                : ""
+                            Index             = channel.Index,
+                            Name              = channelName,
+                            Role              = channel.Role.ToString(),
+                            Psk               = channel.Settings?.Psk != null && channel.Settings.Psk.Length > 0
+                                ? Convert.ToBase64String(channel.Settings.Psk.ToByteArray()) : "",
+                            Uplink            = channel.Settings?.UplinkEnabled ?? false,
+                            Downlink          = channel.Settings?.DownlinkEnabled ?? false,
+                            PositionPrecision = channel.Settings?.ModuleSettings?.PositionPrecision ?? 0
                         };
                         ChannelInfoReceived?.Invoke(this, channelInfo);
                     }

--- a/MeshhessenClient/Services/MqttProxyService.cs
+++ b/MeshhessenClient/Services/MqttProxyService.cs
@@ -1,0 +1,234 @@
+using System.Reflection;
+using Meshtastic.Protobufs;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Packets;
+
+namespace MeshhessenClient.Services;
+
+/// <summary>
+/// Bidirectional MQTT proxy: forwards MqttClientProxyMessage packets between the
+/// Meshtastic radio (serial/USB) and a real MQTT broker — exactly as the Android
+/// app does when proxy_to_client_enabled = true.
+/// </summary>
+public sealed class MqttProxyService : IDisposable
+{
+    // ─── state ────────────────────────────────────────────────────────────────
+    private readonly MeshtasticProtocolService _protocol;
+    private IMqttClient?   _mqtt;
+    private MQTTConfig?    _config;
+    private string?        _rootTopic;
+    private bool           _running;
+    private bool           _disposed;
+
+    // ─── events ───────────────────────────────────────────────────────────────
+    /// <summary>Raised on the calling thread when connection state changes.</summary>
+    public event EventHandler<string>? StatusChanged;
+
+    // ─── version / node-id ────────────────────────────────────────────────────
+    private static readonly string _appVersion =
+        Assembly.GetExecutingAssembly()
+                .GetCustomAttribute<AssemblyFileVersionAttribute>()
+                ?.Version?.Split('.') is { } parts && parts.Length >= 3
+                    ? $"{parts[0]}.{parts[1]}.{parts[2]}"
+                    : "0.0.0";
+
+    public MqttProxyService(MeshtasticProtocolService protocol)
+    {
+        _protocol = protocol;
+    }
+
+    // ─── public API ──────────────────────────────────────────────────────────
+
+    public bool IsRunning => _running;
+
+    /// <summary>
+    /// Start the proxy. Idempotent — does nothing if already running with the
+    /// same config.
+    /// </summary>
+    public async Task StartAsync(MQTTConfig mqttConfig, uint myNodeId)
+    {
+        if (_running) await StopAsync();          // restart on config change
+
+        if (!mqttConfig.Enabled || !mqttConfig.ProxyToClientEnabled)
+            return;
+
+        _config = mqttConfig;
+        _rootTopic = string.IsNullOrWhiteSpace(mqttConfig.Root) ? "msh" : mqttConfig.Root.TrimEnd('/');
+
+        // ── parse broker address ──────────────────────────────────────────────
+        var address = string.IsNullOrWhiteSpace(mqttConfig.Address)
+            ? "mqtt.meshtastic.org"
+            : mqttConfig.Address.Trim();
+
+        string host;
+        int    port;
+
+        if (address.Contains(':'))
+        {
+            var idx = address.LastIndexOf(':');
+            host = address[..idx];
+            port = int.TryParse(address[(idx + 1)..], out var p) ? p
+                   : (mqttConfig.TlsEnabled ? 8883 : 1883);
+        }
+        else
+        {
+            host = address;
+            port = mqttConfig.TlsEnabled ? 8883 : 1883;
+        }
+
+        // ── build client options ──────────────────────────────────────────────
+        var nodeIdHex  = $"{myNodeId:x8}";
+        var clientId   = $"meshhessenclient-{_appVersion}-!{nodeIdHex}";
+
+        var optBuilder = new MqttClientOptionsBuilder()
+            .WithClientId(clientId)
+            .WithTcpServer(host, port)
+            .WithCleanSession(true)
+            .WithKeepAlivePeriod(TimeSpan.FromSeconds(60));
+
+        if (mqttConfig.TlsEnabled)
+            optBuilder = optBuilder.WithTls();
+
+        if (!string.IsNullOrEmpty(mqttConfig.Username))
+            optBuilder = optBuilder.WithCredentials(mqttConfig.Username, mqttConfig.Password);
+
+        // ── create + connect ──────────────────────────────────────────────────
+        var factory = new MqttFactory();
+        _mqtt = factory.CreateMqttClient();
+
+        _mqtt.ApplicationMessageReceivedAsync += OnBrokerMessageAsync;
+        _mqtt.DisconnectedAsync               += OnDisconnectedAsync;
+
+        try
+        {
+            await _mqtt.ConnectAsync(optBuilder.Build(), CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            RaiseStatus($"MQTT Proxy: Verbindungsfehler – {ex.Message}");
+            _mqtt.Dispose();
+            _mqtt = null;
+            return;
+        }
+
+        // ── subscribe to root topic ───────────────────────────────────────────
+        var subOpts = new MqttClientSubscribeOptionsBuilder()
+            .WithTopicFilter(f => f.WithTopic($"{_rootTopic}/#"))
+            .Build();
+
+        await _mqtt.SubscribeAsync(subOpts);
+
+        // ── hook radio → broker ───────────────────────────────────────────────
+        _protocol.MqttProxyMessageReceived += OnRadioMqttMessage;
+
+        _running = true;
+        RaiseStatus($"MQTT Proxy aktiv — {host}:{port} als {clientId}");
+    }
+
+    public async Task StopAsync()
+    {
+        _protocol.MqttProxyMessageReceived -= OnRadioMqttMessage;
+        _running = false;
+
+        if (_mqtt is { IsConnected: true })
+        {
+            try { await _mqtt.DisconnectAsync(); } catch { /* best-effort */ }
+        }
+
+        _mqtt?.Dispose();
+        _mqtt = null;
+        RaiseStatus("MQTT Proxy gestoppt.");
+    }
+
+    // ─── broker → radio ──────────────────────────────────────────────────────
+
+    private async Task OnBrokerMessageAsync(MqttApplicationMessageReceivedEventArgs e)
+    {
+        if (!_running) return;
+
+        var msg = new MqttClientProxyMessage
+        {
+            Topic    = e.ApplicationMessage.Topic,
+            Retained = e.ApplicationMessage.Retain,
+            Data     = Google.Protobuf.ByteString.CopyFrom(
+                           e.ApplicationMessage.PayloadSegment.ToArray()),
+        };
+
+        try
+        {
+            await _protocol.SendMqttProxyMessageAsync(msg);
+        }
+        catch (Exception ex)
+        {
+            RaiseStatus($"MQTT Proxy: Weiterleitungsfehler Broker→Radio: {ex.Message}");
+        }
+    }
+
+    // ─── radio → broker ──────────────────────────────────────────────────────
+
+    private async void OnRadioMqttMessage(object? sender, MqttClientProxyMessage msg)
+    {
+        if (_mqtt is not { IsConnected: true }) return;
+
+        try
+        {
+            byte[] payload = msg.PayloadVariantCase switch
+            {
+                MqttClientProxyMessage.PayloadVariantOneofCase.Data =>
+                    msg.Data.ToByteArray(),
+                MqttClientProxyMessage.PayloadVariantOneofCase.Text =>
+                    System.Text.Encoding.UTF8.GetBytes(msg.Text),
+                _ => Array.Empty<byte>(),
+            };
+
+            var appMsg = new MqttApplicationMessageBuilder()
+                .WithTopic(msg.Topic)
+                .WithPayload(payload)
+                .WithRetainFlag(msg.Retained)
+                .Build();
+
+            await _mqtt.PublishAsync(appMsg, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            RaiseStatus($"MQTT Proxy: Weiterleitungsfehler Radio→Broker: {ex.Message}");
+        }
+    }
+
+    // ─── reconnect on unexpected disconnect ──────────────────────────────────
+
+    private async Task OnDisconnectedAsync(MqttClientDisconnectedEventArgs e)
+    {
+        if (!_running || _config == null) return;
+
+        RaiseStatus("MQTT Proxy: Verbindung verloren, versuche Reconnect in 5 s …");
+        await Task.Delay(5_000);
+
+        if (!_running || _mqtt == null) return;
+
+        try
+        {
+            var host = _mqtt.Options.ChannelOptions is MqttClientTcpOptions tcp
+                       ? tcp.RemoteEndpoint?.ToString() ?? "?" : "?";
+            await _mqtt.ReconnectAsync();
+            RaiseStatus($"MQTT Proxy: Reconnect erfolgreich ({host})");
+        }
+        catch (Exception ex)
+        {
+            RaiseStatus($"MQTT Proxy: Reconnect fehlgeschlagen – {ex.Message}");
+        }
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private void RaiseStatus(string msg) =>
+        StatusChanged?.Invoke(this, msg);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _ = StopAsync();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 
 ![Windows](https://img.shields.io/badge/Windows-10%2F11-blue)
 ![.NET](https://img.shields.io/badge/.NET-8.0-purple)
-![Status](https://img.shields.io/badge/Status-v1.5.8-yellow)
+![Status](https://img.shields.io/badge/Status-v1.5.9-yellow)
 ![License](https://img.shields.io/github/license/SMLunchen/mh_windowsclient)
 ![Stars](https://img.shields.io/github/stars/SMLunchen/mh_windowsclient)
 
@@ -107,7 +107,9 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 * **Node-Farben** – Nodes individuell einfärben (Karte + Listen)
 * **Node-Notizen** – Freitext-Notizen pro Node
 * **Nodes anpinnen** – Nodes in der Liste oben fixieren (unabhängig von Sortierung)
-* **Node-Konfiguration** – Einstellungen des verbundenen Geräts anpassen
+* **Node-Konfiguration** – vollständige Gerätekonfiguration direkt aus dem Client (Device, LoRa, Position, Power, Network, Display, Bluetooth, Security, MQTT, Telemetrie, Kanäle u.v.m.)
+  * **Feste Position (Fixed Position)** – Breitengrad, Längengrad und Höhe manuell eingeben und an den Node übertragen; Koordinaten mit einem Klick vom aktuellen Kartenmittelpunkt übernehmen
+  * **Kanal-Konfiguration** – MQTT-Uplink/Downlink und Positions-Präzision pro Kanal direkt einstellen (wie Android-App)
 * **BT-PIN ändern** – Bluetooth-PIN direkt aus dem Client setzen
 
 ### ⚙️ Verbindung & System
@@ -328,7 +330,7 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 
  ![Windows](https://img.shields.io/badge/Windows-10%2F11-blue)
  ![.NET](https://img.shields.io/badge/.NET-8.0-purple)
- ![Status](https://img.shields.io/badge/Status-v1.5.8-yellow)
+ ![Status](https://img.shields.io/badge/Status-v1.5.9-yellow)
  ![License](https://img.shields.io/github/license/SMLunchen/mh_windowsclient)
  ![Stars](https://img.shields.io/github/stars/SMLunchen/mh_windowsclient)
 
@@ -429,7 +431,9 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 * **Node colors** – color-code nodes individually (map + lists)
 * **Node notes** – free-text annotations per node
 * **Pin nodes** – pin nodes to the top of the list (independent of sorting)
-* **Node configuration** – adjust settings of the connected device
+* **Node configuration** – full device configuration directly from the client (device, LoRa, position, power, network, display, Bluetooth, security, MQTT, telemetry, channels, and more)
+  * **Fixed Position** – enter latitude, longitude, and altitude manually and transmit to the node; pick coordinates from the current map center with one click
+  * **Channel configuration** – set MQTT uplink/downlink and position precision per channel directly (like the Android app)
 * **Change BT PIN** – set Bluetooth PIN directly from the client
 
 ### ⚙️ Connection & System

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
     "url": "https://smlunchen.github.io/mh_windowsclient/",
     "downloadUrl": "https://github.com/SMLunchen/mh_windowsclient/releases/latest",
     "author": { "@type": "Organization", "name": "Meshhessen Community", "url": "https://www.meshhessen.de" },
-    "softwareVersion": "1.5.8",
+    "softwareVersion": "1.5.9",
     "screenshot": "https://raw.githubusercontent.com/SMLunchen/mh_windowsclient/master/img/map.png",
     "keywords": "Meshtastic, Windows, LoRa, Mesh, Telemetrie, Traceroute, Offline-Karte, PKI"
   }
@@ -312,8 +312,8 @@
 <main>
 
   <div class="whats-new">
-    <span class="vbadge">v1.5.8</span>
-    <span class="summary">Persistente Nachrichten-DB, DM-History, Online-Karten, HTTP/3 und mehr.</span>
+    <span class="vbadge">v1.5.9</span>
+    <span class="summary">Feste Position via Karte, Kanal-Uplink/Downlink, Kanalverwaltung-Fix und mehr.</span>
     <a href="changelog.html">Changelog ansehen →</a>
   </div>
 
@@ -384,13 +384,16 @@
       </ul>
     </div>
     <div class="card" style="--card-accent:#56d364">
-      <h3>🔧 Node-Verwaltung</h3>
+      <span class="badge-new">NEU</span>
+      <h3>🔧 Node-Verwaltung &amp; Konfiguration</h3>
       <ul>
         <li>Node-Farben individuell wählbar (Karte + Liste)</li>
         <li>Freitext-Notizen pro Node</li>
         <li>Nodes anpinnen (oben fixieren, unabhängig von Sortierung)</li>
         <li>Schnellfilter für die Node-Liste</li>
-        <li>Node-Konfiguration direkt aus dem Client</li>
+        <li><strong>Vollständige Node-Konfiguration</strong> (Device, LoRa, Position, Power, Network, Display, BT, Security, MQTT, Telemetrie, Kanäle)</li>
+        <li><strong>Feste Position</strong> – Lat/Lon/Höhe eingeben oder direkt vom Kartenmittelpunkt übernehmen</li>
+        <li><strong>Kanal-Konfiguration</strong> – MQTT-Uplink/Downlink &amp; Positions-Präzision pro Kanal</li>
         <li>Bluetooth-PIN direkt ändern</li>
         <li>Meshhessen-Schnellkonfiguration (One-Click Short Slow + EU868)</li>
       </ul>
@@ -693,8 +696,8 @@
 <main>
 
   <div class="whats-new">
-    <span class="vbadge">NEW</span>
-    <span class="summary">Persistent message DB, DM history, online maps, HTTP/3 and more.</span>
+    <span class="vbadge">v1.5.9</span>
+    <span class="summary">Fixed position via map, channel uplink/downlink, channel management fix and more.</span>
     <a href="changelog.html">View changelog →</a>
   </div>
 
@@ -765,13 +768,16 @@
       </ul>
     </div>
     <div class="card" style="--card-accent:#56d364">
-      <h3>🔧 Node Management</h3>
+      <span class="badge-new">NEW</span>
+      <h3>🔧 Node Management &amp; Config</h3>
       <ul>
         <li>Individual node colors (map + list)</li>
         <li>Free-text notes per node</li>
         <li>Pin nodes to top (independent of sort order)</li>
         <li>Quick filter for the node list</li>
-        <li>Node configuration directly from the client</li>
+        <li><strong>Full node configuration</strong> (device, LoRa, position, power, network, display, BT, security, MQTT, telemetry, channels)</li>
+        <li><strong>Fixed position</strong> – enter lat/lon/altitude or pick from current map center</li>
+        <li><strong>Channel config</strong> – MQTT uplink/downlink &amp; position precision per channel</li>
         <li>Change Bluetooth PIN directly</li>
         <li>Meshhessen quick-config (one-click Short Slow + EU868)</li>
       </ul>


### PR DESCRIPTION
Complete Node Configuration Window (rebuilt from scratch)
The NodeConfigWindow was fully redesigned and now covers the entire Meshtastic firmware configuration:

Device & LoRa

Region, modem preset (or manual LoRa parameters: bandwidth, spreading factor, coding rate), TX power, hop limit, rebroadcast mode
Device role, serial console, debug log, double-tap action, LED heartbeat
Position

GPS mode (enabled / disabled / not present), GPS update interval, baud rate, RX/TX GPIO
Fixed position with coordinate input (lat/lon/alt)
"Pick from Map": dedicated map picker window (MapPickerWindow) that honours the current map settings (offline / online-own / online-osm)
"Own Map Pin": copies the position set via right-click directly into the fields
Smart broadcast, min distance, min interval, position broadcast interval
Network / Wi-Fi

SSID/PSK, DHCP/static IP (IP, gateway, subnet, DNS), Ethernet, NTP server, syslog
Display

Screen timeout, carousel interval, compass orientation, 12h clock, units (metric/imperial), display mode, OLED type, flip, bold heading, wake-on-tap
MQTT

Server, username, password, encryption, JSON mode, TLS, root topic, proxy mode
Map reporting enable + precision level (bits 10–19 + exact); description includes map.meshhessen.de
MQTT proxy client (MqttProxyService): the Windows client can act as an MQTT proxy for the connected node
Telemetry

Device, environment, air quality and power intervals; measurement checkboxes; Fahrenheit option
Bluetooth

Enable/disable, pairing mode (RANDOM / FIXED / NO_PIN), fixed PIN
Neighbor Info, Store & Forward, External Notification, Canned Messages, Range Test, Serial

All modules fully configurable
Security

Public key (display), private key (generate / import, masked), admin channel override, managed mode, serial console, debug log; admin keys 1–3
Channel Management

All 8 channels: role, name, uplink, downlink, position precision
Precision with all bits 10–19 (~23 km down to ~45 m) + 0 = no location + 32 = exact
Column headers and dropdown options fully i18n (DE + EN); combobox column widened to prevent clipping
Map & UI
Map right-click context menu

"Telemetry" added as a new entry for all nodes (after Traceroute)
OpenTelemetryForNode() extracted as a shared helper — also used by the node list context menu
MapPickerWindow

Standalone map window for position selection; click places a red marker, "Accept" returns the coordinates
Uses the same tile source as the main map (LocalFileTileProvider moved to Services/)
Infrastructure
Proto extensions: many new config fields across all config types; new: map_report_precision = 11 in MQTTConfig, admin.proto additions
MqttProxyService: new service that handles the MQTT broker connection on behalf of the node
LocalFileTileProvider extracted from MainWindow into Services/LocalFileTileProvider.cs
i18n: all new strings fully covered in Strings.de.xaml + Strings.en.xaml
