### PR TITLE
Remote admin gauges favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ### ✨ Hinzugefügt
 
+#### Remote-Verwaltung – Sicherheits-Tab
+- **Neuer „Sicherheit"-Reiter** in der Fernverwaltung (Remote Admin) für `Config.SecurityConfig`
+  - **Öffentlicher Schlüssel** (Public Key) read-only als Hex-Darstellung (Consolas)
+  - **Admin-Schlüssel 1–3** (Base64) editierbar — autorisierte Admin-Geräte
+  - **Flags:** Legacy Admin Channel, Managed Mode, Serial Console, Debug Log API
+  - Wird automatisch beim Öffnen mit geladen (GetConfigRequest = SecurityConfig)
+  - Wird mit „Speichern" an das Remote-Gerät übertragen
+- **Favoriten auf Remote-Knoten verwalten** – neuer Abschnitt im Steuerung-Reiter:
+  - ComboBox mit allen bekannten Knoten
+  - „Als Favorit setzen" / „Favorit entfernen" – sendet `add_favorite_node` / `remove_favorite_node` an den Remote-Node
+  - Bestätigung per MessageBox nach erfolgtem Senden
+
+#### Telemetrie-Dashboard
+- **Dashboard-Button in der Hauptleiste** (📊 Toolbar) – Dashboard direkt ohne Umweg über das Telemetrie-Kontextmenü öffnen
+- **Dashboard ist jetzt ein unabhängiges Fenster** – schließt sich nicht mehr mit dem Telemetrie-Fenster; kann auf einem zweiten Monitor platziert werden
+
 #### Persistente Nachrichten-Datenbank
 - **SQLite-Nachrichtenspeicher** für Kanal- und DM-Nachrichten (optional, in Einstellungen aktivierbar)
   - Je Kanal eine eigene DB-Datei (`messages/channel_{index}_{name}.db`), DMs in `messages/dm.db`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ### ✨ Hinzugefügt
 
+#### 🔧 Remote Admin – Lazy Loading & Tab-Reload
+- **Lade-Modus-Dialog** beim Öffnen des Remote-Admin-Fensters: Benutzer wählt ob alle Einstellungen sofort geladen werden sollen (~30–60 s) oder seitenweise
+  - **Seitenweise-Modus:** Jeder Reiter wird erst beim ersten Anklicken geladen (kein unnötiger Funkverkehr)
+  - Bereits geladene Reiter werden nicht erneut abgerufen
+- **Neuer Button „↻ Tab neu laden"** in der Buttonleiste – lädt nur den aktuell sichtbaren Reiter komplett neu (ohne den Rest anzufassen)
+
+#### 🔧 Lokaler Admin – Sequentielles Laden
+- **Echtes sequentielles Config-Loading** in der Node-Konfiguration (lokaler Admin):
+  - Bisher: alle 17 Konfigurations-Requests feuern und auf Events warten (fire-and-forget)
+  - Jetzt: senden → auf Antwort-Event warten → nächste senden; 8 s Timeout pro Konfiguration
+  - Verhindert Queue-Overflow auf langsamen Boards (z.B. Heltec) – vorher Abbruch bei 4–5/17
+  - Falls eine Konfiguration nicht antwortet (z.B. nicht unterstütztes Modul), wird nach 8 s automatisch weitergemacht; fehlende Configs werden am Ende angezeigt
+
 #### 🖧 Virtual Node (Tools-Tab)
 - **Virtual Node TCP-Proxy-Server** – wandelt den Meshhessen Client in einen Meshtastic-kompatiblen TCP-Server um
   - Meshtastic-Apps (Android, iOS, andere Clients) können sich mit dem Client verbinden, als wäre er ein echtes Gerät
@@ -117,6 +130,29 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ### 🐛 Behoben
 
+#### 🔧 Remote Admin – Channel-Ladefehler
+- **`GetChannelRequest` ist 1-basiert** (1 = Kanal 0, 2 = Kanal 1 …): War 0-basiert → Kanal 0 lud nie (Timeout), alle anderen Kanäle um eins verschoben
+- **Channel-Reihenfolge:** Stale-Response-Validierung via `ch.Index` entfernt – Firmware setzt das Feld oft nicht (Protobuf-Default 0), was alle Kanäle außer 0 als "falsche Antwort" klassifizierte und dreifach neu anforderte
+
+#### 🔧 Remote Admin – Favoriten (Proto-Feldnummern falsch)
+- `add_favorite_node = 36` war veraltet; aktuelle Firmware erwartet `set_favorite_node = 39`
+  - Feld 36 ist in aktueller Firmware `set_canned_message_module_messages` → Favorites-Anfragen landeten still beim falschen Handler
+- `remove_favorite_node` korrigiert von Feld 37 auf Feld 40
+- `admin.proto` im Projekt auf aktuelle Feldnummern aktualisiert; alle C#-Referenzen auf `SetFavoriteNode` umgestellt
+- **FavoriteButton Fire-and-forget behoben:** Fehler beim Setzen/Entfernen wurden still ignoriert; jetzt proper `async void` mit Fehlermeldung und UI-Revert bei Fehler
+
+#### 🔧 Admin – Key-Anzeige
+- **Public Key und Private Key** wurden als Hex angezeigt; Meshtastic-App und Firmware nutzen Base64 → beide Admin-Fenster (lokal & remote) zeigen Keys jetzt in Base64
+
+#### 🗺️ Karte – Emoji-Node-Namen
+- **Emoji-Kurzname (z.B. 🔥, 📶)** wurden auf der Karte als □ angezeigt, weil SkiaSharp/Mapsui kein Emoji-Fallback hat
+- Alle vier `LabelStyle`-Stellen in MainWindow auf `Font { FontFamily = "Segoe UI Emoji" }` gesetzt
+
+#### 🖧 Virtual Node – Traceroute-Telemetrie
+- **Traceroute-Requests des VNode-Clients** wurden fälschlicherweise in die eigene Telemetrie eingespeist: Android-App löst Traceroute aus → Request-Paket (`WantResponse=true`, Portnum=70) wurde als Traceroute-Ergebnis mit `DestinationNodeId = myNodeId` gespeichert
+- Fix: `ProcessExternalPacket` filtert ausgehende Traceroute-Requests heraus; die Antwort kommt ohnehin über den physischen Funkweg
+
+#### ⚙️ Sonstige Bugfixes
 - **Zombie-Prozess beim Beenden**: App beendet sich jetzt sauber mit `Application.Current.Shutdown()`
   - Synchroner Disconnect statt asynchron
   - Keine hängenden Prozesse mehr nach Fenster-Schließen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ### ✨ Hinzugefügt
 
+#### 🖧 Virtual Node (Tools-Tab)
+- **Virtual Node TCP-Proxy-Server** – wandelt den Meshhessen Client in einen Meshtastic-kompatiblen TCP-Server um
+  - Meshtastic-Apps (Android, iOS, andere Clients) können sich mit dem Client verbinden, als wäre er ein echtes Gerät
+  - Konfigurierbar in **Tools → Virtual Node**: Port (Standard: 4404), aktivieren/deaktivieren, Admin-Befehle blockieren (optional)
+  - Startet automatisch beim Verbinden mit dem physischen Node (wenn aktiviert); stoppt bei Disconnect
+  - **Config-Replay**: Verbindende Apps erhalten sofort MyNodeInfo, alle Kanäle, Gerätekonfig und bekannte Nodes
+  - **Bidirektionale Nachrichtenweiterleitung**: In der App geschriebene Nachrichten erscheinen in den verbundenen Apps und umgekehrt (über den physischen Node)
+  - **Multi-Client-Support**: Beliebig viele Clients gleichzeitig verbindbar
+  - Message-Queue mit 10 ms Delay zwischen Paketen schützt den physischen Node vor Überflutung
+  - Status-Anzeige im Tools-Tab: läuft/gestoppt, Client-Anzahl, verbundene IPs
+  - Einstellungen werden sofort in INI gespeichert
+  - Neue INI-Keys: `VirtualNodeEnabled`, `VirtualNodePort`, `VirtualNodeBlockAdmin`
+
 #### 🔧 T-Deck Karten-Assistent (neuer Tools-Tab)
 - **Neuer Reiter „Tools"** im Hauptfenster mit zwei Funktionen:
   - **T-Deck Karten-Assistent** – geführter 6-Schritt-Wizard zur Vorbereitung einer SD-Karte mit Offline-Karten

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
 
 ### ✨ Hinzugefügt
 
+#### 🔧 T-Deck Karten-Assistent (neuer Tools-Tab)
+- **Neuer Reiter „Tools"** im Hauptfenster mit zwei Funktionen:
+  - **T-Deck Karten-Assistent** – geführter 6-Schritt-Wizard zur Vorbereitung einer SD-Karte mit Offline-Karten
+  - **Tile-Export** – lokale Tiles als ZIP exportieren (je nach Kartentyp oder alle)
+- **Schritt 1 – Willkommen:** Erklärung des Workflows, Hinweis dass nur Deutschland abgedeckt ist
+- **Schritt 2 – SD-Karte wählen:** Listet nur Wechseldatenträger auf, zeigt Gesamtgröße, freier Speicher und Dateisystem
+- **Schritt 3 – Formatierung prüfen:**
+  - Prüft ob das Laufwerk exFAT oder FAT32 ist
+  - Empfiehlt exFAT mit 4096-Byte-Zuordnungseinheiten (erklärt warum: kleine Tiles ~100 Bytes, große AU = Platzverschwendung)
+  - Bietet Formatierung per PowerShell `Format-Volume` mit UAC-Elevation an
+  - Doppelte Bestätigungsdialoge vor dem unwiderruflichen Formatieren
+  - Auswahl: exFAT 4096 Bytes (Standard/empfohlen) oder FAT32 512 Bytes (Ältere Geräte)
+  - Formatierung kann übersprungen werden
+- **Schritt 4 – Bereich auswählen** (drei Modi):
+  - **Nach Bundesland:** alle 16 Bundesländer als Checkboxen mit Alles/Keine-Schnellauswahl; kombinierte BBox wird berechnet
+  - **Ganz Deutschland:** feste BBox N 55.10° S 47.27° W 5.87° E 15.04°
+  - **Freestyle:** Mapsui-Kartenfenster, Klicken-und-Ziehen zum Zeichnen eines Rechteck-Auswahlbereichs
+- **Schritt 5 – Zoom & Kartentyp:**
+  - Maximale Zoom-Stufe: 8 / 10 / 12 / 14 (empfohlen) / 16 / 17 (Maximum)
+  - Warnhinweise bei Zoom ≥ 14 und ≥ 16 (Laufzeit, Speicherplatz)
+  - Kartentyp: OSM Standard / OSM Dark / OpenTopoMap
+  - Live-Schätzung: Tile-Anzahl und Speicherplatzbedarf; Warnung wenn SD-Speicher knapp
+- **Schritt 6 – Download & Übertragung:**
+  - Zusammenfassung aller Einstellungen
+  - **Additiver Transfer:** SD-Tile vorhanden → überspringen; lokal vorhanden → kopieren; sonst → herunterladen vom Tile-Server und gleichzeitig lokal cachen
+  - Fortschrittsbalken mit Tile-Zähler und aktueller Zoom/X/Y-Angabe
+  - Abbrechen jederzeit möglich
+- **SD-Karten-Verzeichnisstruktur:** `{Laufwerk}:\maps\OSM\{z}\{x}\{y}.png` (bzw. `OpenTopo`, `OSMDark`)
+- **Tile-Export-Dialog:** Exportiert lokale Tiles (alle oder gefiltert nach Kartentyp) als ZIP
+- Vollständig mehrsprachig (Deutsch / Englisch) über bestehende i18n-Infrastruktur
+
 #### Remote-Verwaltung – Sicherheits-Tab
 - **Neuer „Sicherheit"-Reiter** in der Fernverwaltung (Remote Admin) für `Config.SecurityConfig`
   - **Öffentlicher Schlüssel** (Public Key) read-only als Hex-Darstellung (Consolas)

--- a/MeshhessenClient/AddWidgetDialog.xaml.cs
+++ b/MeshhessenClient/AddWidgetDialog.xaml.cs
@@ -27,7 +27,10 @@ public class AddWidgetDialog : Window
     private readonly TextBox    _thresholdBox;
     private readonly CheckBox   _maCheckBox;
     private readonly Dictionary<uint, string> _nodeNames;
-    private readonly List<(uint id, string label)> _allNodes;
+    private readonly Dictionary<uint, string> _nodeShortNames;
+    private readonly List<(uint id, string label, string shortName)> _allNodes;
+    private readonly HashSet<uint> _selectedNodeIds = new();
+    private bool _suppressSelectionTracking;
 
     private static readonly (string key, string label)[] Metrics =
     {
@@ -61,12 +64,18 @@ public class AddWidgetDialog : Window
         ("clock",       "StrWidgetTypeClock",       false),
     };
 
-    public AddWidgetDialog(Dictionary<uint, string> nodeNames, DashboardWidget? existing = null)
+    public AddWidgetDialog(Dictionary<uint, string> nodeNames, Dictionary<uint, string>? nodeShortNames = null, DashboardWidget? existing = null)
     {
-        _nodeNames = nodeNames;
-        _allNodes  = nodeNames.OrderBy(kv => kv.Value)
-                              .Select(kv => (kv.Key, kv.Value))
-                              .ToList();
+        _nodeNames      = nodeNames;
+        _nodeShortNames = nodeShortNames ?? new Dictionary<uint, string>();
+        _allNodes = nodeNames.OrderBy(kv => kv.Value)
+                             .Select(kv =>
+                             {
+                                 string sn = _nodeShortNames.TryGetValue(kv.Key, out var s) && !string.IsNullOrWhiteSpace(s) ? s : string.Empty;
+                                 string label = sn.Length > 0 ? $"{sn} | {kv.Value}" : kv.Value;
+                                 return (kv.Key, label, sn);
+                             })
+                             .ToList();
 
         bool isDark = ThemeManager.Current.ActualApplicationTheme == ApplicationTheme.Dark;
         Color bgColor    = isDark ? Color.FromRgb(22, 27, 34)   : Color.FromRgb(250, 251, 253);
@@ -170,6 +179,8 @@ public class AddWidgetDialog : Window
             Height        = 130,
             Margin        = new Thickness(0, 0, 0, 12),
         };
+        ScrollViewer.SetCanContentScroll(_nodeListBox, false);
+        _nodeListBox.SelectionChanged += NodeList_SelectionChanged;
         PopulateNodeList(null);
         _nodeSection.Children.Add(_nodeListBox);
         outerStack.Children.Add(_nodeSection);
@@ -182,7 +193,11 @@ public class AddWidgetDialog : Window
         // ── Chart options (threshold + MA) — only for line/area ──
         _chartOptionsSection = new StackPanel { Margin = new Thickness(0, 0, 0, 6) };
         _chartOptionsSection.Children.Add(MakeLabel(Loc("StrDashboardThreshold") + " (leer = aus):", fgSubColor));
-        _thresholdBox = new TextBox { Margin = new Thickness(0, 0, 0, 8) };
+        _thresholdBox = new TextBox
+        {
+            Margin  = new Thickness(0, 0, 0, 8),
+            ToolTip = Loc("StrDashboardThresholdTip"),
+        };
         _chartOptionsSection.Children.Add(_thresholdBox);
         _maCheckBox = new CheckBox
         {
@@ -234,11 +249,16 @@ public class AddWidgetDialog : Window
         _thresholdBox.Text    = double.IsNaN(existing.Threshold) ? "" : existing.Threshold.ToString("G4");
         _maCheckBox.IsChecked = existing.ShowMovingAverage;
 
-        // Must match SelectionMode: Add() throws on Single; use SelectedItem instead
-        _nodeListBox.SelectedItems.Clear();
+        // Pre-seed _selectedNodeIds so filter changes preserve selection
+        _selectedNodeIds.Clear();
+        foreach (var id in existing.NodeIds) _selectedNodeIds.Add(id);
+
+        // Apply to listbox (UnselectAll works in both Single and Multiple mode)
+        _suppressSelectionTracking = true;
+        _nodeListBox.UnselectAll();
         foreach (ListBoxItem item in _nodeListBox.Items)
         {
-            if (item.Tag is not uint id || !existing.NodeIds.Contains(id)) continue;
+            if (item.Tag is not uint id || !_selectedNodeIds.Contains(id)) continue;
             if (_nodeListBox.SelectionMode == SelectionMode.Single)
             {
                 _nodeListBox.SelectedItem = item;
@@ -246,6 +266,7 @@ public class AddWidgetDialog : Window
             }
             _nodeListBox.SelectedItems.Add(item);
         }
+        _suppressSelectionTracking = false;
     }
 
     // ── Filtering ────────────────────────────────────────────────────────────
@@ -255,30 +276,58 @@ public class AddWidgetDialog : Window
         PopulateNodeList(_nodeSearchBox.Text);
     }
 
-    private static bool MatchesNode(string needle, (uint id, string label) n)
+    private static bool MatchesNode(string needle, (uint id, string label, string shortName) n)
     {
         if (n.label.Contains(needle, StringComparison.OrdinalIgnoreCase)) return true;
+        if (n.shortName.Contains(needle, StringComparison.OrdinalIgnoreCase)) return true;
         string hex = $"{n.id:x8}";
         if (hex.Contains(needle, StringComparison.OrdinalIgnoreCase)) return true;
         if ($"!{hex}".Contains(needle, StringComparison.OrdinalIgnoreCase)) return true;
         if (n.id.ToString().Contains(needle)) return true;
-        // Last-4 short id convention some people use
         if (hex.EndsWith(needle, StringComparison.OrdinalIgnoreCase)) return true;
         return false;
     }
 
+    private void NodeList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressSelectionTracking) return;
+        foreach (ListBoxItem item in e.AddedItems.OfType<ListBoxItem>())
+            if (item.Tag is uint id) _selectedNodeIds.Add(id);
+        foreach (ListBoxItem item in e.RemovedItems.OfType<ListBoxItem>())
+            if (item.Tag is uint id) _selectedNodeIds.Remove(id);
+    }
+
     private void PopulateNodeList(string? filter)
     {
+        _suppressSelectionTracking = true;
         _nodeListBox.Items.Clear();
-        IEnumerable<(uint id, string label)> query = string.IsNullOrWhiteSpace(filter)
+
+        IEnumerable<(uint id, string label, string shortName)> query = string.IsNullOrWhiteSpace(filter)
             ? _allNodes
             : _allNodes.Where(n => MatchesNode(filter, n));
 
-        foreach (var (id, label) in query)
+        foreach (var (id, label, _) in query)
             _nodeListBox.Items.Add(new ListBoxItem { Tag = id, Content = label });
 
-        if (_nodeListBox.Items.Count > 0 && _nodeListBox.SelectedItems.Count == 0)
+        // Restore previously-selected nodes; only auto-select first if nothing was selected before
+        bool anyRestored = false;
+        foreach (ListBoxItem item in _nodeListBox.Items)
+        {
+            if (item.Tag is not uint id || !_selectedNodeIds.Contains(id)) continue;
+            if (_nodeListBox.SelectionMode == SelectionMode.Single)
+            {
+                _nodeListBox.SelectedItem = item;
+                anyRestored = true;
+                break;
+            }
+            _nodeListBox.SelectedItems.Add(item);
+            anyRestored = true;
+        }
+
+        if (!anyRestored && _nodeListBox.Items.Count > 0 && _selectedNodeIds.Count == 0)
             _nodeListBox.SelectedIndex = 0;
+
+        _suppressSelectionTracking = false;
     }
 
     // ── Widget type changed ───────────────────────────────────────────────────

--- a/MeshhessenClient/AddWidgetDialog.xaml.cs
+++ b/MeshhessenClient/AddWidgetDialog.xaml.cs
@@ -1,0 +1,361 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using MeshhessenClient.Models;
+using ModernWpf;
+
+namespace MeshhessenClient;
+
+public class AddWidgetDialog : Window
+{
+    private static string Loc(string key) =>
+        Application.Current?.Resources[key] as string ?? key;
+
+    public DashboardWidget? Result { get; private set; }
+
+    private readonly ComboBox   _widgetTypeCombo;
+    private readonly ComboBox   _metricCombo;
+    private readonly ComboBox   _daysCombo;
+    private readonly TextBox    _titleBox;
+    private readonly TextBox    _nodeSearchBox;
+    private readonly ListBox    _nodeListBox;
+    private readonly TextBlock  _nodeHintText;
+    private readonly StackPanel _metricSection;
+    private readonly StackPanel _daysSection;
+    private readonly StackPanel _nodeSection;
+    private readonly Dictionary<uint, string> _nodeNames;
+    private readonly List<(uint id, string label)> _allNodes;
+
+    private static readonly (string key, string label)[] Metrics =
+    {
+        ("snr",          "SNR (dB)"),
+        ("rssi",         "RSSI (dBm)"),
+        ("battery",      "Batterie (%)"),
+        ("voltage",      "Spannung (V)"),
+        ("channel_util", "Kanal-Auslastung (%)"),
+        ("air_tx_util",  "TX-Auslastung (%)"),
+        ("temperature",  "Temperatur (°C)"),
+        ("humidity",     "Luftfeuchtigkeit (%)"),
+        ("pressure",     "Luftdruck (hPa)"),
+        ("packet_count", "Pakete pro Stunde"),
+    };
+
+    private static readonly (string key, string labelKey, bool multiNode)[] WidgetTypes =
+    {
+        ("line",        "StrWidgetTypeLine",        true),
+        ("area",        "StrWidgetTypeArea",        true),
+        ("bar",         "StrWidgetTypeBar",         true),
+        ("scatter",     "StrWidgetTypeScatter",     true),
+        ("gauge",       "StrWidgetTypeGauge",       false),
+        ("stat",        "StrWidgetTypeStat",        false),
+        ("heatmap",     "StrWidgetTypeHeatmap",     false),
+        ("histogram",   "StrWidgetTypeHistogram",   false),
+        ("candlestick", "StrWidgetTypeCandlestick", false),
+        ("stateline",   "StrWidgetTypeStateline",   false),
+        ("clock",       "StrWidgetTypeClock",       false),
+    };
+
+    public AddWidgetDialog(Dictionary<uint, string> nodeNames, DashboardWidget? existing = null)
+    {
+        _nodeNames = nodeNames;
+        _allNodes  = nodeNames.OrderBy(kv => kv.Value)
+                              .Select(kv => (kv.Key, kv.Value))
+                              .ToList();
+
+        bool isDark = ThemeManager.Current.ActualApplicationTheme == ApplicationTheme.Dark;
+        Color bgColor    = isDark ? Color.FromRgb(22, 27, 34)   : Color.FromRgb(250, 251, 253);
+        Color fgSubColor = isDark ? Color.FromRgb(139, 148, 158) : Color.FromRgb(96, 105, 115);
+        Color hintColor  = isDark ? Color.FromRgb(72, 79, 88)    : Color.FromRgb(170, 175, 183);
+
+        Title  = existing != null ? Loc("StrDashboardEditWidget") : Loc("StrAddWidgetTitle");
+        Width  = 460;
+        Height = 640;
+        ResizeMode = ResizeMode.NoResize;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        Background = new SolidColorBrush(bgColor);
+
+        var outerStack = new StackPanel { Margin = new Thickness(18, 14, 18, 14) };
+
+        // ── Widget type ──
+        outerStack.Children.Add(MakeLabel(Loc("StrAddWidgetType"), fgSubColor));
+        _widgetTypeCombo = new ComboBox { Margin = new Thickness(0, 0, 0, 12) };
+        foreach (var (key, labelKey, _) in WidgetTypes)
+            _widgetTypeCombo.Items.Add(new ComboBoxItem { Tag = key, Content = Loc(labelKey) });
+        _widgetTypeCombo.SelectedIndex = 0;
+        _widgetTypeCombo.SelectionChanged += WidgetType_SelectionChanged;
+        outerStack.Children.Add(_widgetTypeCombo);
+
+        // ── Metric section ──
+        _metricSection = new StackPanel();
+        _metricSection.Children.Add(MakeLabel(Loc("StrAddWidgetMetric"), fgSubColor));
+        _metricCombo = new ComboBox { Margin = new Thickness(0, 0, 0, 12) };
+        foreach (var (key, label) in Metrics)
+            _metricCombo.Items.Add(new ComboBoxItem { Tag = key, Content = label });
+        _metricCombo.SelectedIndex = 0;
+        _metricSection.Children.Add(_metricCombo);
+        outerStack.Children.Add(_metricSection);
+
+        // ── Days section ──
+        _daysSection = new StackPanel();
+        _daysSection.Children.Add(MakeLabel(Loc("StrAddWidgetDays"), fgSubColor));
+        _daysCombo = new ComboBox { Margin = new Thickness(0, 0, 0, 12) };
+        foreach (var (days, label) in new[]
+        {
+            (1,  Loc("StrDays1")),
+            (7,  Loc("StrDays7")),
+            (14, Loc("StrDays14")),
+            (30, Loc("StrDays30")),
+            (0,  Loc("StrDaysAll")),
+        })
+            _daysCombo.Items.Add(new ComboBoxItem { Tag = days, Content = label });
+        _daysCombo.SelectedIndex = 1; // default 7 days
+        _daysSection.Children.Add(_daysCombo);
+        outerStack.Children.Add(_daysSection);
+
+        // ── Node section ──
+        _nodeSection = new StackPanel();
+
+        var nodeLabelRow = new DockPanel { Margin = new Thickness(0, 0, 0, 4) };
+        var nodeLabel    = MakeLabel(Loc("StrAddWidgetNodes"), fgSubColor);
+        DockPanel.SetDock(nodeLabel, Dock.Left);
+        _nodeHintText = new TextBlock
+        {
+            Text       = Loc("StrAddWidgetSingleNodeHint"),
+            FontSize   = 10,
+            Foreground = new SolidColorBrush(Color.FromRgb(240, 76, 76)),
+            VerticalAlignment   = VerticalAlignment.Bottom,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Visibility = Visibility.Collapsed,
+            Margin     = new Thickness(6, 0, 0, 0),
+        };
+        DockPanel.SetDock(_nodeHintText, Dock.Right);
+        nodeLabelRow.Children.Add(_nodeHintText);
+        nodeLabelRow.Children.Add(nodeLabel);
+        _nodeSection.Children.Add(nodeLabelRow);
+
+        _nodeSearchBox = new TextBox
+        {
+            Padding  = new Thickness(6, 4, 6, 4),
+            FontSize = 11,
+        };
+        _nodeSearchBox.TextChanged += NodeSearch_TextChanged;
+
+        var searchHint = new TextBlock
+        {
+            Text       = Loc("StrAddWidgetNodeSearch"),
+            FontSize   = 11,
+            Foreground = new SolidColorBrush(hintColor),
+            IsHitTestVisible = false,
+            Margin     = new Thickness(8, 5, 0, 0),
+        };
+        var searchGrid = new Grid { Margin = new Thickness(0, 0, 0, 4) };
+        searchGrid.Children.Add(_nodeSearchBox);
+        searchGrid.Children.Add(searchHint);
+        _nodeSearchBox.TextChanged += (_, _) =>
+        {
+            searchHint.Visibility = string.IsNullOrEmpty(_nodeSearchBox.Text)
+                ? Visibility.Visible : Visibility.Collapsed;
+        };
+        _nodeSection.Children.Add(searchGrid);
+
+        _nodeListBox = new ListBox
+        {
+            SelectionMode = SelectionMode.Multiple,
+            Height        = 130,
+            Margin        = new Thickness(0, 0, 0, 12),
+        };
+        PopulateNodeList(null);
+        _nodeSection.Children.Add(_nodeListBox);
+        outerStack.Children.Add(_nodeSection);
+
+        // ── Title ──
+        outerStack.Children.Add(MakeLabel(Loc("StrAddWidgetCustomTitle"), fgSubColor));
+        _titleBox = new TextBox { Margin = new Thickness(0, 0, 0, 18) };
+        outerStack.Children.Add(_titleBox);
+
+        // ── Buttons ──
+        var btnRow = new StackPanel
+        {
+            Orientation         = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+        };
+        var ok     = new Button { Content = "OK", Width = 80, IsDefault = true, Margin = new Thickness(0, 0, 8, 0) };
+        var cancel = new Button { Content = Loc("StrCancel"), Width = 90, IsCancel = true };
+        ok.Click += Ok_Click;
+        btnRow.Children.Add(ok);
+        btnRow.Children.Add(cancel);
+        outerStack.Children.Add(btnRow);
+
+        Content = new ScrollViewer
+        {
+            Content = outerStack,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+        };
+
+        UpdateSectionVisibility();
+        UpdateNodeSelectionMode();
+
+        // Pre-fill if editing existing widget
+        if (existing != null)
+            PrefillFrom(existing);
+    }
+
+    private void PrefillFrom(DashboardWidget existing)
+    {
+        foreach (ComboBoxItem item in _widgetTypeCombo.Items)
+            if (item.Tag is string t && t == existing.Type) { _widgetTypeCombo.SelectedItem = item; break; }
+
+        foreach (ComboBoxItem item in _metricCombo.Items)
+            if (item.Tag is string m && m == existing.Metric) { _metricCombo.SelectedItem = item; break; }
+
+        foreach (ComboBoxItem item in _daysCombo.Items)
+            if (item.Tag is int d && d == existing.Days) { _daysCombo.SelectedItem = item; break; }
+
+        _titleBox.Text = existing.Title;
+
+        _nodeListBox.SelectedItems.Clear();
+        foreach (ListBoxItem item in _nodeListBox.Items)
+            if (item.Tag is uint id && existing.NodeIds.Contains(id))
+                _nodeListBox.SelectedItems.Add(item);
+    }
+
+    // ── Filtering ────────────────────────────────────────────────────────────
+
+    private void NodeSearch_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        PopulateNodeList(_nodeSearchBox.Text);
+    }
+
+    private static bool MatchesNode(string needle, (uint id, string label) n)
+    {
+        if (n.label.Contains(needle, StringComparison.OrdinalIgnoreCase)) return true;
+        string hex = $"{n.id:x8}";
+        if (hex.Contains(needle, StringComparison.OrdinalIgnoreCase)) return true;
+        if ($"!{hex}".Contains(needle, StringComparison.OrdinalIgnoreCase)) return true;
+        if (n.id.ToString().Contains(needle)) return true;
+        // Last-4 short id convention some people use
+        if (hex.EndsWith(needle, StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    private void PopulateNodeList(string? filter)
+    {
+        _nodeListBox.Items.Clear();
+        IEnumerable<(uint id, string label)> query = string.IsNullOrWhiteSpace(filter)
+            ? _allNodes
+            : _allNodes.Where(n => MatchesNode(filter, n));
+
+        foreach (var (id, label) in query)
+            _nodeListBox.Items.Add(new ListBoxItem { Tag = id, Content = label });
+
+        if (_nodeListBox.Items.Count > 0 && _nodeListBox.SelectedItems.Count == 0)
+            _nodeListBox.SelectedIndex = 0;
+    }
+
+    // ── Widget type changed ───────────────────────────────────────────────────
+
+    private void WidgetType_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        UpdateSectionVisibility();
+        UpdateNodeSelectionMode();
+    }
+
+    private string CurrentType =>
+        (_widgetTypeCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "line";
+
+    private void UpdateSectionVisibility()
+    {
+        string type = CurrentType;
+        bool isClock = type == "clock";
+        _metricSection.Visibility = isClock ? Visibility.Collapsed : Visibility.Visible;
+        _daysSection.Visibility   = isClock ? Visibility.Collapsed : Visibility.Visible;
+        _nodeSection.Visibility   = isClock ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    private void UpdateNodeSelectionMode()
+    {
+        bool allowMulti = WidgetTypes.FirstOrDefault(t => t.key == CurrentType).multiNode;
+
+        if (allowMulti)
+        {
+            _nodeListBox.SelectionMode = SelectionMode.Multiple;
+            _nodeHintText.Visibility   = Visibility.Collapsed;
+        }
+        else
+        {
+            _nodeListBox.SelectionMode = SelectionMode.Single;
+            _nodeHintText.Visibility   = Visibility.Visible;
+            if (_nodeListBox.SelectedItems.Count > 1)
+            {
+                var first = _nodeListBox.SelectedItem;
+                _nodeListBox.UnselectAll();
+                _nodeListBox.SelectedItem = first;
+            }
+        }
+    }
+
+    // ── OK handler ───────────────────────────────────────────────────────────
+
+    private void Ok_Click(object sender, RoutedEventArgs e)
+    {
+        string type = CurrentType;
+
+        if (type == "clock")
+        {
+            string clockTitle = string.IsNullOrWhiteSpace(_titleBox.Text)
+                ? Loc("StrWidgetTypeClock")
+                : _titleBox.Text.Trim();
+            Result = new DashboardWidget(
+                Id:      Guid.NewGuid().ToString("N")[..8],
+                Type:    "clock",
+                Metric:  "none",
+                NodeIds: new List<uint>(),
+                Days:    0,
+                Title:   clockTitle);
+            DialogResult = true;
+            Close();
+            return;
+        }
+
+        var nodeIds = _nodeListBox.SelectedItems.OfType<ListBoxItem>()
+                                  .Select(i => (uint)(i.Tag ?? 0u))
+                                  .Where(id => id != 0)
+                                  .ToList();
+        if (nodeIds.Count == 0)
+        {
+            MessageBox.Show(Loc("StrAddWidgetNoNode"), Title,
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        string metric = (_metricCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "snr";
+        int    days   = (_daysCombo.SelectedItem   as ComboBoxItem)?.Tag is int d ? d : 7;
+
+        string metricLabel = (_metricCombo.SelectedItem as ComboBoxItem)?.Content as string ?? metric;
+        string title = string.IsNullOrWhiteSpace(_titleBox.Text)
+            ? metricLabel
+            : _titleBox.Text.Trim();
+
+        bool singleOnly = WidgetTypes.FirstOrDefault(t => t.key == type).multiNode == false;
+        if (singleOnly && nodeIds.Count > 1)
+            nodeIds = nodeIds.Take(1).ToList();
+
+        Result = new DashboardWidget(
+            Id:      Guid.NewGuid().ToString("N")[..8],
+            Type:    type,
+            Metric:  metric,
+            NodeIds: nodeIds,
+            Days:    days,
+            Title:   title);
+        DialogResult = true;
+        Close();
+    }
+
+    private static TextBlock MakeLabel(string text, Color color) => new()
+    {
+        Text       = text,
+        FontSize   = 11,
+        Margin     = new Thickness(0, 0, 0, 3),
+        Foreground = new SolidColorBrush(color),
+    };
+}

--- a/MeshhessenClient/AddWidgetDialog.xaml.cs
+++ b/MeshhessenClient/AddWidgetDialog.xaml.cs
@@ -23,6 +23,9 @@ public class AddWidgetDialog : Window
     private readonly StackPanel _metricSection;
     private readonly StackPanel _daysSection;
     private readonly StackPanel _nodeSection;
+    private readonly StackPanel _chartOptionsSection;
+    private readonly TextBox    _thresholdBox;
+    private readonly CheckBox   _maCheckBox;
     private readonly Dictionary<uint, string> _nodeNames;
     private readonly List<(uint id, string label)> _allNodes;
 
@@ -52,6 +55,9 @@ public class AddWidgetDialog : Window
         ("histogram",   "StrWidgetTypeHistogram",   false),
         ("candlestick", "StrWidgetTypeCandlestick", false),
         ("stateline",   "StrWidgetTypeStateline",   false),
+        ("ranking",     "StrWidgetTypeRanking",     true),
+        ("multistat",   "StrWidgetTypeMultiStat",   true),
+        ("meshhealth",  "StrWidgetTypeMeshHealth",  true),
         ("clock",       "StrWidgetTypeClock",       false),
     };
 
@@ -170,8 +176,21 @@ public class AddWidgetDialog : Window
 
         // ── Title ──
         outerStack.Children.Add(MakeLabel(Loc("StrAddWidgetCustomTitle"), fgSubColor));
-        _titleBox = new TextBox { Margin = new Thickness(0, 0, 0, 18) };
+        _titleBox = new TextBox { Margin = new Thickness(0, 0, 0, 12) };
         outerStack.Children.Add(_titleBox);
+
+        // ── Chart options (threshold + MA) — only for line/area ──
+        _chartOptionsSection = new StackPanel { Margin = new Thickness(0, 0, 0, 6) };
+        _chartOptionsSection.Children.Add(MakeLabel(Loc("StrDashboardThreshold") + " (leer = aus):", fgSubColor));
+        _thresholdBox = new TextBox { Margin = new Thickness(0, 0, 0, 8) };
+        _chartOptionsSection.Children.Add(_thresholdBox);
+        _maCheckBox = new CheckBox
+        {
+            Content = Loc("StrDashboardMovingAvg"),
+            Margin  = new Thickness(0, 0, 0, 12),
+        };
+        _chartOptionsSection.Children.Add(_maCheckBox);
+        outerStack.Children.Add(_chartOptionsSection);
 
         // ── Buttons ──
         var btnRow = new StackPanel
@@ -211,12 +230,22 @@ public class AddWidgetDialog : Window
         foreach (ComboBoxItem item in _daysCombo.Items)
             if (item.Tag is int d && d == existing.Days) { _daysCombo.SelectedItem = item; break; }
 
-        _titleBox.Text = existing.Title;
+        _titleBox.Text        = existing.Title;
+        _thresholdBox.Text    = double.IsNaN(existing.Threshold) ? "" : existing.Threshold.ToString("G4");
+        _maCheckBox.IsChecked = existing.ShowMovingAverage;
 
+        // Must match SelectionMode: Add() throws on Single; use SelectedItem instead
         _nodeListBox.SelectedItems.Clear();
         foreach (ListBoxItem item in _nodeListBox.Items)
-            if (item.Tag is uint id && existing.NodeIds.Contains(id))
-                _nodeListBox.SelectedItems.Add(item);
+        {
+            if (item.Tag is not uint id || !existing.NodeIds.Contains(id)) continue;
+            if (_nodeListBox.SelectionMode == SelectionMode.Single)
+            {
+                _nodeListBox.SelectedItem = item;
+                break;
+            }
+            _nodeListBox.SelectedItems.Add(item);
+        }
     }
 
     // ── Filtering ────────────────────────────────────────────────────────────
@@ -266,10 +295,12 @@ public class AddWidgetDialog : Window
     private void UpdateSectionVisibility()
     {
         string type = CurrentType;
-        bool isClock = type == "clock";
-        _metricSection.Visibility = isClock ? Visibility.Collapsed : Visibility.Visible;
-        _daysSection.Visibility   = isClock ? Visibility.Collapsed : Visibility.Visible;
-        _nodeSection.Visibility   = isClock ? Visibility.Collapsed : Visibility.Visible;
+        bool isClock   = type == "clock";
+        bool showChart = type is "line" or "area";
+        _metricSection.Visibility       = isClock ? Visibility.Collapsed : Visibility.Visible;
+        _daysSection.Visibility         = isClock ? Visibility.Collapsed : Visibility.Visible;
+        _nodeSection.Visibility         = isClock ? Visibility.Collapsed : Visibility.Visible;
+        _chartOptionsSection.Visibility = showChart ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void UpdateNodeSelectionMode()
@@ -340,13 +371,22 @@ public class AddWidgetDialog : Window
         if (singleOnly && nodeIds.Count > 1)
             nodeIds = nodeIds.Take(1).ToList();
 
+        double threshold = double.TryParse(
+            _thresholdBox.Text.Replace(",", "."),
+            System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out double tv)
+            ? tv : double.NaN;
+        bool showMA = _maCheckBox.IsChecked == true;
+
         Result = new DashboardWidget(
-            Id:      Guid.NewGuid().ToString("N")[..8],
-            Type:    type,
-            Metric:  metric,
-            NodeIds: nodeIds,
-            Days:    days,
-            Title:   title);
+            Id:                Guid.NewGuid().ToString("N")[..8],
+            Type:              type,
+            Metric:            metric,
+            NodeIds:           nodeIds,
+            Days:              days,
+            Title:             title,
+            Threshold:         threshold,
+            ShowMovingAverage: showMA);
         DialogResult = true;
         Close();
     }

--- a/MeshhessenClient/MainWindow.xaml
+++ b/MeshhessenClient/MainWindow.xaml
@@ -781,9 +781,32 @@
                              TextChanged="NodeFilterTextBox_TextChanged"
                              Tag="🔍 Filter nach Name, ID, SNR, Batterie..."/>
 
-                    <ListView x:Name="NodesListView" Grid.Row="1">
+                    <ListView x:Name="NodesListView" Grid.Row="1"
+                              ContextMenuOpening="NodesListView_ContextMenuOpening">
                         <ListView.View>
                             <GridView x:Name="NodesGridView">
+                                <GridViewColumn Width="24">
+                                    <GridViewColumn.Header>
+                                        <GridViewColumnHeader Content="★" ToolTip="{DynamicResource StrFavoriteColTooltip}"/>
+                                    </GridViewColumn.Header>
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="★" FontSize="13" Foreground="#FFC107"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsFavorite}" Value="True">
+                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
                                 <GridViewColumn Width="30">
                                     <GridViewColumn.Header>
                                         <GridViewColumnHeader Content="🎨"/>
@@ -945,6 +968,7 @@
                                 </MenuItem>
                                 <MenuItem Header="{DynamicResource StrEditNote}" Click="EditNodeNote_Click"/>
                                 <Separator/>
+                                <MenuItem x:Name="FavoriteNodeMenuItem" Header="{DynamicResource StrFavorite}" Click="NodeContextMenu_Favorite_Click"/>
                                 <MenuItem x:Name="PinNodeMenuItem" Header="{DynamicResource StrPin}" Click="NodeContextMenu_Pin_Click"/>
                                 <MenuItem x:Name="ShowPathNodeMenuItem" Header="{DynamicResource StrShowPath}" Click="NodeContextMenu_ShowPath_Click"/>
                                 <MenuItem x:Name="HidePathMenuItem" Header="{DynamicResource StrHidePath}" Click="NodeContextMenu_HidePath_Click" Visibility="Collapsed"/>
@@ -1345,6 +1369,17 @@
                                 </StackPanel>
                             </GroupBox>
 
+                            <!-- Remote Admin -->
+                            <GroupBox Header="{DynamicResource StrRemoteAdminGroup}" Margin="0,0,0,16">
+                                <StackPanel Margin="10">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <TextBlock Text="{DynamicResource StrRemoteAdminTimeoutLabel}" VerticalAlignment="Center" Margin="0,0,8,0" FontSize="11"/>
+                                        <TextBox x:Name="RemoteAdminTimeoutTextBox" Width="50" Text="30" FontSize="11"/>
+                                        <TextBlock Text="s" VerticalAlignment="Center" Margin="4,0,0,0" FontSize="11" Foreground="Gray"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </GroupBox>
+
                             <!-- f) Verschlüsselte Nachrichten -->
                             <GroupBox Header="{DynamicResource StrMessagesGroup}" Margin="0,0,0,16">
                                 <StackPanel Margin="10">
@@ -1441,6 +1476,12 @@
                                                   FontSize="11" Margin="0,0,0,10"/>
                                         <Button x:Name="NodeConfigButton" Content="{DynamicResource StrNodeConfig}"
                                                IsEnabled="False" Click="NodeConfig_Click"/>
+                                        <Separator Margin="0,10,0,10"/>
+                                        <TextBlock Text="{DynamicResource StrRemoteAdminHint}"
+                                                  FontStyle="Italic" Foreground="Gray" TextWrapping="Wrap"
+                                                  FontSize="11" Margin="0,0,0,10"/>
+                                        <Button x:Name="RemoteAdminButton" Content="{DynamicResource StrRemoteAdmin}"
+                                               IsEnabled="False" Click="RemoteAdmin_Click"/>
                                     </StackPanel>
                                 </GroupBox>
 

--- a/MeshhessenClient/MainWindow.xaml
+++ b/MeshhessenClient/MainWindow.xaml
@@ -1391,7 +1391,7 @@
                                 <StackPanel Margin="10">
                                     <CheckBox x:Name="ShowEncryptedMessagesCheckBox"
                                              Content="{DynamicResource StrShowEncrypted}"
-                                             IsChecked="True"/>
+                                             IsChecked="False"/>
                                     <TextBlock Text="{DynamicResource StrShowEncryptedHint}"
                                               FontStyle="Italic" Foreground="Gray" TextWrapping="Wrap" FontSize="11" Margin="0,4,0,0"/>
                                 </StackPanel>

--- a/MeshhessenClient/MainWindow.xaml
+++ b/MeshhessenClient/MainWindow.xaml
@@ -212,9 +212,15 @@
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <Button x:Name="OpenDmWindowButton"
                            Content="💬 DMs"
-                           Margin="0,0,10,0"
+                           Margin="0,0,8,0"
                            Click="OpenDmWindow_Click"
                            ToolTip="{DynamicResource StrOpenDms}"/>
+                    <Button x:Name="OpenDashboardButton"
+                           Content="📊"
+                           Margin="0,0,10,0"
+                           Width="40"
+                           Click="OpenDashboardMain_Click"
+                           ToolTip="{DynamicResource StrOpenDashboard}"/>
                     <Ellipse x:Name="StatusIndicator"
                             Width="12"
                             Height="12"

--- a/MeshhessenClient/MainWindow.xaml
+++ b/MeshhessenClient/MainWindow.xaml
@@ -1635,6 +1635,40 @@
                 </ScrollViewer>
             </TabItem>
 
+            <!-- Tools Tab -->
+            <TabItem Header="{DynamicResource StrTabTools}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="24">
+
+                        <!-- T-Deck Map Assistant -->
+                        <TextBlock Text="{DynamicResource StrToolsTDeckSection}"
+                                   FontSize="15" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource StrToolsTDeckDesc}"
+                                   TextWrapping="Wrap" Foreground="#555" Margin="0,0,0,10"/>
+                        <TextBlock Text="{DynamicResource StrTDeckGermanyOnly}"
+                                   TextWrapping="Wrap" Foreground="#1E6AB8" Margin="0,0,0,10"
+                                   FontStyle="Italic"/>
+                        <Button x:Name="TDeckMapBtn"
+                                Content="{DynamicResource StrToolsTDeckBtn}"
+                                HorizontalAlignment="Left" Padding="16,8"
+                                Click="TDeckMapBtn_Click"/>
+
+                        <Separator Margin="0,20"/>
+
+                        <!-- Tile Export -->
+                        <TextBlock Text="{DynamicResource StrToolsExportSection}"
+                                   FontSize="15" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource StrToolsExportDesc}"
+                                   TextWrapping="Wrap" Foreground="#555" Margin="0,0,0,10"/>
+                        <Button x:Name="TDeckExportBtn"
+                                Content="{DynamicResource StrToolsExportBtn}"
+                                HorizontalAlignment="Left" Padding="16,8"
+                                Click="TDeckExportBtn_Click"/>
+
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
             <!-- Debug Tab -->
             <TabItem Header="🐛 Debug">
                 <Grid Margin="10">

--- a/MeshhessenClient/MainWindow.xaml
+++ b/MeshhessenClient/MainWindow.xaml
@@ -1665,6 +1665,57 @@
                                 HorizontalAlignment="Left" Padding="16,8"
                                 Click="TDeckExportBtn_Click"/>
 
+                        <Separator Margin="0,20"/>
+
+                        <!-- Virtual Node -->
+                        <TextBlock Text="{DynamicResource StrVirtualNodeSection}"
+                                   FontSize="15" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource StrVirtualNodeDesc}"
+                                   TextWrapping="Wrap" Foreground="#555" Margin="0,0,0,10"/>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <CheckBox x:Name="VirtualNodeEnableCheckBox"
+                                      Content="{DynamicResource StrVirtualNodeEnable}"
+                                      VerticalAlignment="Center"
+                                      Checked="VirtualNodeSettings_Changed"
+                                      Unchecked="VirtualNodeSettings_Changed"/>
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8" VerticalAlignment="Center">
+                            <TextBlock Text="{DynamicResource StrVirtualNodePort}"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <TextBox x:Name="VirtualNodePortBox"
+                                     Width="80" Text="4404"
+                                     VerticalAlignment="Center"
+                                     LostFocus="VirtualNodeSettings_Changed"/>
+                        </StackPanel>
+
+                        <CheckBox x:Name="VirtualNodeBlockAdminCheckBox"
+                                  Content="{DynamicResource StrVirtualNodeBlockAdmin}"
+                                  Margin="0,0,0,12"
+                                  Checked="VirtualNodeSettings_Changed"
+                                  Unchecked="VirtualNodeSettings_Changed"/>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <TextBlock Text="{DynamicResource StrVirtualNodeStatus}"
+                                       VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock x:Name="VirtualNodeStatusText"
+                                       VerticalAlignment="Center" FontWeight="SemiBold"/>
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                            <TextBlock Text="{DynamicResource StrVirtualNodeClients}"
+                                       VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock x:Name="VirtualNodeClientCountText"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+
+                        <TextBlock x:Name="VirtualNodeClientListText"
+                                   Margin="0,4,0,0"
+                                   FontFamily="Consolas" FontSize="11"
+                                   Foreground="#555"
+                                   TextWrapping="Wrap"/>
+
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -87,7 +87,8 @@ public partial class MainWindow : Window
         true,
         "de",
         false,
-        new Dictionary<uint, bool>(),
+        new Dictionary<uint, bool>(),  // PinnedNodes
+        new Dictionary<uint, bool>(),  // FavoriteNodes
         90,
         Services.PskMismatchAction.Overwrite,
         6,    // SignalWeatherWindowHours
@@ -99,7 +100,8 @@ public partial class MainWindow : Window
         false,      // EnableMessageDb
         90,         // MessageDbRetentionDays
         "Serial",   // LastConnectionType
-        string.Empty); // LastBtDevice
+        string.Empty,  // LastBtDevice
+        30);           // RemoteAdminTimeoutSeconds
     private NodeInfo? _mapContextMenuNode;
     private uint? _alertNodeId;  // Stores the node ID for "Show on Map" button
 
@@ -409,6 +411,9 @@ public partial class MainWindow : Window
             // Time Sync
             if (AutoTimeSyncCheckBox != null) AutoTimeSyncCheckBox.IsChecked = settings.AutoTimeSyncOnConnect;
             if (TimeSyncDriftBox != null) TimeSyncDriftBox.Text = settings.TimeSyncDriftThresholdSeconds.ToString();
+
+            // Remote Admin
+            if (RemoteAdminTimeoutTextBox != null) RemoteAdminTimeoutTextBox.Text = settings.RemoteAdminTimeoutSeconds.ToString();
 
             // Message DB
             EnableMessageDbCheckBox.IsChecked = settings.EnableMessageDb;
@@ -1587,6 +1592,7 @@ public partial class MainWindow : Window
                             UpdateStatusBar(string.Format(Loc("StrConnectedReady"), displayName));
                             SetConnectionStatus(ConnectionStatus.Ready);
                             NodeConfigButton.IsEnabled = true;
+                            RemoteAdminButton.IsEnabled = true;
                         });
                     }
                     catch (Exception initEx)
@@ -2040,6 +2046,7 @@ public partial class MainWindow : Window
                 Language: (LanguageComboBox.SelectedItem as System.Windows.Controls.ComboBoxItem)?.Tag as string ?? "de",
                 EnableLocationLogging: EnableLocationLoggingCheckBox.IsChecked == true,
                 PinnedNodes: _currentSettings.PinnedNodes,
+                FavoriteNodes: _currentSettings.FavoriteNodes,
                 TelemetryRetentionDays: int.TryParse((TelemetryRetentionComboBox.SelectedItem as System.Windows.Controls.ComboBoxItem)?.Tag as string, out var ret) ? ret : 90,
                 NodeKeyMismatchAction: PskWarnRadio.IsChecked == true ? Services.PskMismatchAction.Warn
                                      : PskAskRadio.IsChecked  == true ? Services.PskMismatchAction.Ask
@@ -2053,7 +2060,8 @@ public partial class MainWindow : Window
                 EnableMessageDb: EnableMessageDbCheckBox.IsChecked == true,
                 MessageDbRetentionDays: int.TryParse((MessageDbRetentionComboBox.SelectedItem as System.Windows.Controls.ComboBoxItem)?.Tag as string, out var mdr) ? mdr : 90,
                 LastConnectionType: _currentSettings.LastConnectionType,
-                LastBtDevice: _currentSettings.LastBtDevice
+                LastBtDevice: _currentSettings.LastBtDevice,
+                RemoteAdminTimeoutSeconds: int.TryParse(RemoteAdminTimeoutTextBox.Text, out var rats) ? Math.Clamp(rats, 5, 120) : 30
             );
             _currentSettings = settings;
             SettingsService.Save(settings);
@@ -2127,6 +2135,7 @@ public partial class MainWindow : Window
                     _channels.Clear();
                     _currentLoRaConfig = null;
                     NodeConfigButton.IsEnabled = false;
+                    RemoteAdminButton.IsEnabled = false;
                     UpdateMeshHessenButtonState();
                     PacketCountText.Text = string.Format(Loc("StrPacketCount"), 0);
 
@@ -2238,6 +2247,7 @@ public partial class MainWindow : Window
                             UpdateStatusBar(Loc("StrConnectedReadySimple"));
                             SetConnectionStatus(ConnectionStatus.Ready);
                             NodeConfigButton.IsEnabled = true;
+                            RemoteAdminButton.IsEnabled = true;
                         });
                     }
                     catch (Exception initEx)
@@ -2471,8 +2481,12 @@ public partial class MainWindow : Window
                     node.Note = note;
                 }
 
-                // Apply pinned state
-                node.IsPinned = _currentSettings.PinnedNodes.ContainsKey(node.NodeId);
+                // Apply pinned and favorite state (local settings take precedence; proto value also accepted)
+                node.IsPinned    = _currentSettings.PinnedNodes.ContainsKey(node.NodeId);
+                node.IsFavorite  = _currentSettings.FavoriteNodes.ContainsKey(node.NodeId) || node.IsFavorite;
+                // Sync device-reported favorites into local settings cache
+                if (node.IsFavorite)
+                    _currentSettings.FavoriteNodes[node.NodeId] = true;
 
                 // Log location if enabled
                 if (_currentSettings.EnableLocationLogging)
@@ -3335,8 +3349,8 @@ public partial class MainWindow : Window
             };
         }
 
-        // Pinned nodes always first (stable sort preserves column order within groups)
-        filtered = filtered.OrderBy(n => n.IsPinned ? 0 : 1);
+        // Favorites first, then pinned, then rest
+        filtered = filtered.OrderBy(n => n.IsFavorite ? 0 : n.IsPinned ? 1 : 2);
 
         // Update UI
         _nodes.Clear();
@@ -3892,7 +3906,61 @@ public partial class MainWindow : Window
         SettingsService.Save(_currentSettings);
     }
 
-    // ========== Node Config Window ==========
+    // ========== Node Config + Remote Admin ==========
+
+    private void RemoteAdmin_Click(object sender, RoutedEventArgs e)
+    {
+        // Show node selector from favorites list
+        var favorites = _allNodes.Where(n => n.IsFavorite).ToList();
+        if (favorites.Count == 0)
+        {
+            MessageBox.Show(Loc("StrRemoteAdminNoFavorites"), Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        // Simple selection dialog using a standard ListBox in a window
+        var dialog = new Window
+        {
+            Title           = Loc("StrRemoteAdminSelectNode"),
+            Width           = 380,
+            Height          = 320,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Owner           = this,
+            ResizeMode      = ResizeMode.NoResize
+        };
+        var stack = new StackPanel { Margin = new Thickness(16) };
+        stack.Children.Add(new TextBlock
+        {
+            Text       = Loc("StrRemoteAdminSelectNode"),
+            FontWeight = FontWeights.SemiBold,
+            Margin     = new Thickness(0, 0, 0, 10)
+        });
+        var listBox = new ListBox { Height = 180 };
+        foreach (var n in favorites)
+            listBox.Items.Add(new ListBoxItem { Content = $"{n.Name} ({n.Id})", Tag = n });
+        listBox.SelectedIndex = 0;
+        stack.Children.Add(listBox);
+        var btnRow = new StackPanel { Orientation = System.Windows.Controls.Orientation.Horizontal,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Right, Margin = new Thickness(0, 12, 0, 0) };
+        var okBtn = new System.Windows.Controls.Button { Content = "OK", Width = 80, Margin = new Thickness(0, 0, 8, 0),
+            IsDefault = true };
+        var cancelBtn = new System.Windows.Controls.Button { Content = Loc("StrCancel"), Width = 80, IsCancel = true };
+        btnRow.Children.Add(okBtn);
+        btnRow.Children.Add(cancelBtn);
+        stack.Children.Add(btnRow);
+        dialog.Content = stack;
+        bool confirmed = false;
+        okBtn.Click    += (_, _) => { confirmed = true; dialog.Close(); };
+        cancelBtn.Click += (_, _) => dialog.Close();
+        dialog.ShowDialog();
+
+        if (!confirmed || listBox.SelectedItem is not ListBoxItem { Tag: NodeInfo selected }) return;
+
+        var timeout = _currentSettings.RemoteAdminTimeoutSeconds * 1000;
+        var win = new RemoteAdminWindow(_protocolService, selected, timeout, selected.IsFavorite) { Owner = this };
+        win.Show();
+    }
 
     private void NodeConfig_Click(object sender, RoutedEventArgs e)
     {
@@ -3949,7 +4017,8 @@ public partial class MainWindow : Window
     {
         if (NodesListView.SelectedItem is NodeInfo node)
         {
-            PinNodeMenuItem.Header = node.IsPinned ? Loc("StrUnpin") : Loc("StrPin");
+            PinNodeMenuItem.Header      = node.IsPinned    ? Loc("StrUnpin")       : Loc("StrPin");
+            FavoriteNodeMenuItem.Header = node.IsFavorite  ? Loc("StrUnfavorite")  : Loc("StrFavorite");
             bool pathActive = _pathLayers.ContainsKey(node.NodeId);
             ShowPathNodeMenuItem.Visibility = pathActive ? Visibility.Collapsed : Visibility.Visible;
             HidePathMenuItem.Visibility = pathActive ? Visibility.Visible : Visibility.Collapsed;
@@ -3971,6 +4040,36 @@ public partial class MainWindow : Window
 
         ApplyNodeSortAndFilter();
         Services.Logger.WriteLine($"Node {node.Name} ({node.Id}) {(node.IsPinned ? "pinned" : "unpinned")}");
+    }
+
+    private void ToggleFavoriteInternal(NodeInfo node)
+    {
+        node.IsFavorite = !node.IsFavorite;
+
+        var existing = _allNodes.FirstOrDefault(n => n.NodeId == node.NodeId);
+        if (existing != null) existing.IsFavorite = node.IsFavorite;
+
+        if (node.IsFavorite)
+            _currentSettings.FavoriteNodes[node.NodeId] = true;
+        else
+            _currentSettings.FavoriteNodes.Remove(node.NodeId);
+        SettingsService.Save(_currentSettings);
+
+        if (_protocolService != null)
+        {
+            _ = node.IsFavorite
+                ? _protocolService.AddFavoriteNodeAsync(node.NodeId)
+                : _protocolService.RemoveFavoriteNodeAsync(node.NodeId);
+        }
+
+        ApplyNodeSortAndFilter();
+        Services.Logger.WriteLine($"Node {node.Name} ({node.Id}) {(node.IsFavorite ? "favorited" : "unfavorited")}");
+    }
+
+    private void NodeContextMenu_Favorite_Click(object sender, RoutedEventArgs e)
+    {
+        if (NodesListView.SelectedItem is NodeInfo node)
+            ToggleFavoriteInternal(node);
     }
 
     private void NodeContextMenu_Pin_Click(object sender, RoutedEventArgs e)

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -5300,7 +5300,10 @@ public partial class MainWindow : Window
     {
         if (_db == null) return;
         var nodeNames = _allNodes.ToDictionary(n => n.NodeId, n => n.Name);
-        var dash = new TelemetryDashboardWindow(_db, nodeNames);
+        var nodeShortNames = _allNodes
+            .Where(n => !string.IsNullOrWhiteSpace(n.ShortName))
+            .ToDictionary(n => n.NodeId, n => n.ShortName);
+        var dash = new TelemetryDashboardWindow(_db, nodeNames, nodeShortNames);
         dash.Show();
         dash.Activate();
     }

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -5524,8 +5524,9 @@ public partial class MainWindow : Window
         var now = DateTime.Now;
         if (now.Hour == 0 && now.Minute == 0 && !_midnightFiredToday)
         {
-            _midnightFiredToday = true;
-            Dispatcher.BeginInvoke(ShowMidnightMesh);
+            _midnightFiredToday = true;  // always lock out further checks this midnight
+            if (_allNodes.Count > 0 && Random.Shared.Next(3) == 0)  // ~1 in 3 nights
+                Dispatcher.BeginInvoke(ShowMidnightMesh);
         }
         else if (now.Hour != 0)
         {
@@ -5541,15 +5542,17 @@ public partial class MainWindow : Window
         var lines = new[]
         {
             "- - - - - - - - - - - - - - - - - - - -",
-            $"SENDESTELLE {myShortName.ToUpper()}",
-            "SENDELEISTUNG WIRD JETZT REDUZIERT",
-            "NACHT-BETRIEB AKTIV — 73 DE MH",
+            $"SENDESTELLE {myShortName.ToUpper()} — OSTEREI",
+            "AM-SENDELEISTUNG WIRD JETZT REDUZIERT",
+            "Ionosphäre aktiv: AM-Signale reichen nachts",
+            "hunderte km weit (Skywave-Propagation).",
+            "FCC-Nachtpflicht seit 1934 · LoRa: unaffected",
             "- - - - - - - - - - - - - - - - - - - -"
         };
         var msg = new MessageItem
         {
             Time        = "00:00",
-            From        = "⚡ SENDESTELLE",
+            From        = "⚡ SENDESTELLE OSTEREI",
             Message     = string.Join("\n", lines),
             ChannelName = "SYSTEM",
             IsOwnMessage = false

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -48,7 +48,7 @@ public partial class MainWindow : Window
     private ObservableCollection<ChannelInfo> _channels = new();
     private ObservableCollection<Models.BluetoothDeviceInfo> _bluetoothDevices = new();
     private int _activeChannelIndex = 0;
-    private bool _showEncryptedMessages = true;
+    private bool _showEncryptedMessages = false;
     private ChannelInfo? _messageChannelFilter = null;
     private DirectMessagesWindow? _dmWindow = null;
     private uint _myNodeId = 0;
@@ -68,7 +68,7 @@ public partial class MainWindow : Window
     private AppSettings _currentSettings = new(
         false,
         string.Empty,
-        true,
+        false,
         50.9,
         9.5,
         string.Empty,
@@ -453,6 +453,7 @@ public partial class MainWindow : Window
         catch (Exception ex)
         {
             Services.Logger.WriteLine($"ERROR loading settings: {ex.Message}");
+            _showEncryptedMessages = false;
         }
     }
 
@@ -1002,6 +1003,7 @@ public partial class MainWindow : Window
                 _currentSettings.MyLatitude, _currentSettings.MyLongitude)
             { Owner = this };
             win.Show();
+            win.Activate();
         }
 
         MapStatusText.Text = sb.ToString();
@@ -3115,6 +3117,7 @@ public partial class MainWindow : Window
             else
             {
                 _dmWindow.Show();
+                _dmWindow.Activate();
             }
 
             // Reset Button-Hervorhebung

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -1034,6 +1034,7 @@ public partial class MainWindow : Window
             _dmWindow.SetMessageDbManager(_messageDbManager);
             _dmWindow.Show();
         }
+        _dmWindow.Activate();
         _dmWindow.OpenChatWithNode(node.NodeId, node.Name, node.ColorHex);
     }
 
@@ -3960,6 +3961,7 @@ public partial class MainWindow : Window
         var timeout = _currentSettings.RemoteAdminTimeoutSeconds * 1000;
         var win = new RemoteAdminWindow(_protocolService, selected, timeout, selected.IsFavorite) { Owner = this };
         win.Show();
+        win.Activate();
     }
 
     private void NodeConfig_Click(object sender, RoutedEventArgs e)
@@ -3968,6 +3970,7 @@ public partial class MainWindow : Window
         {
             var win = new NodeConfigWindow(_protocolService, GetMapCenter, GetMyPosition, BuildTileLayer) { Owner = this };
             win.Show();
+            win.Activate();
         }
         catch (Exception ex)
         {
@@ -5281,6 +5284,7 @@ public partial class MainWindow : Window
             Owner = this
         };
         win.Show();
+        win.Activate();
     }
 
     private void NodeContextMenu_Telemetry_Click(object sender, RoutedEventArgs e)
@@ -5293,7 +5297,9 @@ public partial class MainWindow : Window
     {
         if (_db == null) return;
         var nodeNames = _allNodes.ToDictionary(n => n.NodeId, n => n.Name);
-        new TelemetryDashboardWindow(_db, nodeNames).Show();
+        var dash = new TelemetryDashboardWindow(_db, nodeNames);
+        dash.Show();
+        dash.Activate();
     }
 
     // Context menu handlers for traceroute
@@ -5321,6 +5327,7 @@ public partial class MainWindow : Window
             Owner = this
         };
         win.Show();
+        win.Activate();
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -5289,6 +5289,13 @@ public partial class MainWindow : Window
         OpenTelemetryForNode(node);
     }
 
+    private void OpenDashboardMain_Click(object sender, RoutedEventArgs e)
+    {
+        if (_db == null) return;
+        var nodeNames = _allNodes.ToDictionary(n => n.NodeId, n => n.Name);
+        new TelemetryDashboardWindow(_db, nodeNames).Show();
+    }
+
     // Context menu handlers for traceroute
     private void NodeContextMenu_Traceroute_Click(object sender, RoutedEventArgs e)
     {

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -3330,6 +3330,15 @@ public partial class MainWindow : Window
                 }
             }
 
+            // Sync send-channel dropdown to the selected filter channel
+            // (skip "Alle Kanäle" sentinel with Index 999)
+            if (_messageChannelFilter != null && _messageChannelFilter.Index != 999)
+            {
+                var match = _channels.FirstOrDefault(c => c.Index == _messageChannelFilter.Index);
+                if (match != null && !Equals(ActiveChannelComboBox.SelectedItem, match))
+                    ActiveChannelComboBox.SelectedItem = match;
+            }
+
             Services.Logger.WriteLine($"Message filter changed to: {_messageChannelFilter?.Name ?? "Alle"} ({_messages.Count}/{_allMessages.Count} messages)");
         }
         catch (Exception ex)

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -575,6 +575,7 @@ public partial class MainWindow : Window
         feature.Styles.Add(new LabelStyle
         {
             Text = label,
+            Font = new Mapsui.Styles.Font { FontFamily = "Segoe UI Emoji" },
             ForeColor = Mapsui.Styles.Color.Blue,
             BackColor = new Mapsui.Styles.Brush(Mapsui.Styles.Color.White),
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
@@ -638,6 +639,7 @@ public partial class MainWindow : Window
         feature.Styles.Add(new LabelStyle
         {
             Text = labelText,
+            Font = new Mapsui.Styles.Font { FontFamily = "Segoe UI Emoji" },
             ForeColor = Mapsui.Styles.Color.Black,
             BackColor = new Mapsui.Styles.Brush(new Mapsui.Styles.Color(255, 255, 255, 180)),
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
@@ -4791,7 +4793,7 @@ public partial class MainWindow : Window
                 HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Left,
                 VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
                 Offset = new Offset(8, 0),
-                Font = new Font { Size = 9 },
+                Font = new Mapsui.Styles.Font { FontFamily = "Segoe UI Emoji", Size = 9 },
             });
             features.Add(pin);
         }
@@ -5132,7 +5134,7 @@ public partial class MainWindow : Window
             BackColor = new Mapsui.Styles.Brush(new Mapsui.Styles.Color(100, 100, 100, 200)),
             HorizontalAlignment = LabelStyle.HorizontalAlignmentEnum.Center,
             VerticalAlignment = LabelStyle.VerticalAlignmentEnum.Center,
-            Font = new Font { Size = 9 },
+            Font = new Mapsui.Styles.Font { FontFamily = "Segoe UI Emoji", Size = 9 },
         });
         return f;
     }

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -1185,6 +1185,18 @@ public partial class MainWindow : Window
         UpdateMapTileStatus();
     }
 
+    private void TDeckMapBtn_Click(object sender, RoutedEventArgs e)
+    {
+        var wizard = new TDeckWizardWindow { Owner = this };
+        wizard.ShowDialog();
+    }
+
+    private void TDeckExportBtn_Click(object sender, RoutedEventArgs e)
+    {
+        var exportWin = new TDeckExportWindow { Owner = this };
+        exportWin.ShowDialog();
+    }
+
     private void MapZoomIn_Click(object sender, RoutedEventArgs e)
     {
         if (_map != null)

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -101,7 +101,10 @@ public partial class MainWindow : Window
         90,         // MessageDbRetentionDays
         "Serial",   // LastConnectionType
         string.Empty,  // LastBtDevice
-        30);           // RemoteAdminTimeoutSeconds
+        30,            // RemoteAdminTimeoutSeconds
+        false,         // VirtualNodeEnabled
+        4404,          // VirtualNodePort
+        false);        // VirtualNodeBlockAdmin
     private NodeInfo? _mapContextMenuNode;
     private uint? _alertNodeId;  // Stores the node ID for "Show on Map" button
 
@@ -157,6 +160,9 @@ public partial class MainWindow : Window
 
     // MQTT Proxy
     private MqttProxyService? _mqttProxyService;
+
+    // Virtual Node
+    private Services.VirtualNodeService? _virtualNodeService;
 
     // Reconnect state
     private ConnectionParameters? _lastConnectionParams;
@@ -414,6 +420,12 @@ public partial class MainWindow : Window
 
             // Remote Admin
             if (RemoteAdminTimeoutTextBox != null) RemoteAdminTimeoutTextBox.Text = settings.RemoteAdminTimeoutSeconds.ToString();
+
+            // Virtual Node
+            if (VirtualNodeEnableCheckBox != null) VirtualNodeEnableCheckBox.IsChecked = settings.VirtualNodeEnabled;
+            if (VirtualNodePortBox != null) VirtualNodePortBox.Text = settings.VirtualNodePort.ToString();
+            if (VirtualNodeBlockAdminCheckBox != null) VirtualNodeBlockAdminCheckBox.IsChecked = settings.VirtualNodeBlockAdmin;
+            RefreshVirtualNodeStatus();
 
             // Message DB
             EnableMessageDbCheckBox.IsChecked = settings.EnableMessageDb;
@@ -1553,6 +1565,7 @@ public partial class MainWindow : Window
                 if (_nodeKeyService != null) _protocolService.SetNodeKeyService(_nodeKeyService);
                 _protocolService.SetPskMismatchAction(_currentSettings.NodeKeyMismatchAction);
                 _dmWindow?.UpdateProtocolService(_protocolService);
+                PrepareVirtualNode();
 
                 // Recreate proxy with new protocol service
                 _mqttProxyService?.Dispose();
@@ -1608,6 +1621,7 @@ public partial class MainWindow : Window
                             SetConnectionStatus(ConnectionStatus.Ready);
                             NodeConfigButton.IsEnabled = true;
                             RemoteAdminButton.IsEnabled = true;
+                            StartVirtualNodeIfEnabled();
                         });
                     }
                     catch (Exception initEx)
@@ -2076,10 +2090,14 @@ public partial class MainWindow : Window
                 MessageDbRetentionDays: int.TryParse((MessageDbRetentionComboBox.SelectedItem as System.Windows.Controls.ComboBoxItem)?.Tag as string, out var mdr) ? mdr : 90,
                 LastConnectionType: _currentSettings.LastConnectionType,
                 LastBtDevice: _currentSettings.LastBtDevice,
-                RemoteAdminTimeoutSeconds: int.TryParse(RemoteAdminTimeoutTextBox.Text, out var rats) ? Math.Clamp(rats, 5, 120) : 30
+                RemoteAdminTimeoutSeconds: int.TryParse(RemoteAdminTimeoutTextBox.Text, out var rats) ? Math.Clamp(rats, 5, 120) : 30,
+                VirtualNodeEnabled: VirtualNodeEnableCheckBox?.IsChecked == true,
+                VirtualNodePort: int.TryParse(VirtualNodePortBox?.Text, out var vnp) ? Math.Clamp(vnp, 1, 65535) : 4404,
+                VirtualNodeBlockAdmin: VirtualNodeBlockAdminCheckBox?.IsChecked == true
             );
             _currentSettings = settings;
             SettingsService.Save(settings);
+            ApplyVirtualNodeSettings();
 
             // Enable/disable message DB manager
             if (settings.EnableMessageDb && _messageDbManager == null)
@@ -2128,6 +2146,9 @@ public partial class MainWindow : Window
                     // Stop MQTT proxy on disconnect
                     if (_mqttProxyService != null)
                         _ = _mqttProxyService.StopAsync();
+
+                    // Stop Virtual Node on disconnect
+                    StopVirtualNode();
 
                     // Stop analysis timer on disconnect
                     _analysisTimer?.Dispose();
@@ -2224,6 +2245,7 @@ public partial class MainWindow : Window
                 if (_db != null) _protocolService.SetDatabase(_db);
                 if (_nodeKeyService != null) _protocolService.SetNodeKeyService(_nodeKeyService);
                 _protocolService.SetPskMismatchAction(_currentSettings.NodeKeyMismatchAction);
+                PrepareVirtualNode();
 
                 // Recreate proxy with new protocol service
                 _mqttProxyService?.Dispose();
@@ -2263,6 +2285,7 @@ public partial class MainWindow : Window
                             SetConnectionStatus(ConnectionStatus.Ready);
                             NodeConfigButton.IsEnabled = true;
                             RemoteAdminButton.IsEnabled = true;
+                            StartVirtualNodeIfEnabled();
                         });
                     }
                     catch (Exception initEx)
@@ -2679,6 +2702,139 @@ public partial class MainWindow : Window
         Services.Logger.WriteLine($"OnMqttConfigReceived: proxy={mqttConfig.ProxyToClientEnabled}, broker={mqttConfig.Address}");
         _ = _mqttProxyService.StartAsync(mqttConfig, _myNodeId);
     }
+
+    // ── Virtual Node ──────────────────────────────────────────────────────────
+
+    // Phase 1: called right after new MeshtasticProtocolService is created so that
+    // RawFrameReceived is wired before InitializeAsync runs — this way the VN cache
+    // fills naturally during init and needs no separate populate step.
+    private void PrepareVirtualNode()
+    {
+        if (!_currentSettings.VirtualNodeEnabled) return;
+
+        // Tear down any previous instance
+        if (_virtualNodeService != null)
+        {
+            _virtualNodeService.Stop();
+            _virtualNodeService.Dispose();
+            _virtualNodeService = null;
+        }
+        // Unsubscribe in case it was left wired to the old protocol service
+        // (safe no-op if already unsubscribed)
+        try { _protocolService.RawFrameReceived -= OnVnRawFrame; } catch { }
+
+        _virtualNodeService = new Services.VirtualNodeService(_connectionService!)
+        {
+            Port = _currentSettings.VirtualNodePort,
+            BlockAdminCommands = _currentSettings.VirtualNodeBlockAdmin
+        };
+        _virtualNodeService.ClientCountChanged += (_, _) => Dispatcher.BeginInvoke(RefreshVirtualNodeStatus);
+        _virtualNodeService.LogMessage += (_, msg) => Services.Logger.WriteLine($"[VN] {msg}");
+        _virtualNodeService.ClientPacketReceived += OnVnClientPacket;
+        _protocolService.RawFrameReceived += OnVnRawFrame;
+    }
+
+    // Phase 2: called after Ready — starts the TCP listener
+    private void StartVirtualNodeIfEnabled()
+    {
+        if (!_currentSettings.VirtualNodeEnabled) return;
+        if (_connectionService?.IsConnected != true) return;
+        if (_virtualNodeService?.IsRunning == true) return;
+
+        // If PrepareVirtualNode was never called (e.g. VN was enabled after connect)
+        // create the service now — cache will be partially filled but that is acceptable
+        if (_virtualNodeService == null)
+            PrepareVirtualNode();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _virtualNodeService!.StartAsync();
+                Dispatcher.BeginInvoke(RefreshVirtualNodeStatus);
+            }
+            catch (Exception ex)
+            {
+                Services.Logger.WriteLine($"Virtual Node start failed: {ex.Message}");
+                Dispatcher.BeginInvoke(RefreshVirtualNodeStatus);
+            }
+        });
+    }
+
+    private void StopVirtualNode()
+    {
+        if (_protocolService != null)
+            _protocolService.RawFrameReceived -= OnVnRawFrame;
+        if (_virtualNodeService != null)
+            _virtualNodeService.ClientPacketReceived -= OnVnClientPacket;
+        _virtualNodeService?.Stop();
+        _virtualNodeService?.Dispose();
+        _virtualNodeService = null;
+        Dispatcher.BeginInvoke(RefreshVirtualNodeStatus);
+    }
+
+    private void OnVnRawFrame(object? sender, byte[] frame)
+        => _virtualNodeService?.OnRawFrameFromPhysical(frame);
+
+    private void OnVnClientPacket(object? sender, byte[] fromRadioBytes)
+        => _protocolService?.ProcessExternalPacket(fromRadioBytes);
+
+    private void ApplyVirtualNodeSettings()
+    {
+        if (_virtualNodeService != null)
+            _virtualNodeService.BlockAdminCommands = _currentSettings.VirtualNodeBlockAdmin;
+
+        if (_currentSettings.VirtualNodeEnabled && _connectionService?.IsConnected == true)
+        {
+            // Restart if port changed or not running yet
+            bool portChanged = _virtualNodeService?.Port != _currentSettings.VirtualNodePort;
+            if (!(_virtualNodeService?.IsRunning == true) || portChanged)
+            {
+                StopVirtualNode();
+                StartVirtualNodeIfEnabled();
+            }
+        }
+        else if (!_currentSettings.VirtualNodeEnabled)
+        {
+            StopVirtualNode();
+        }
+        RefreshVirtualNodeStatus();
+    }
+
+    private void VirtualNodeSettings_Changed(object sender, RoutedEventArgs e)
+    {
+        // Immediate apply without full settings save (save happens via SaveSettings_Click)
+        var enabled = VirtualNodeEnableCheckBox?.IsChecked == true;
+        var blockAdmin = VirtualNodeBlockAdminCheckBox?.IsChecked == true;
+        int port = int.TryParse(VirtualNodePortBox?.Text, out var p) ? Math.Clamp(p, 1, 65535) : 4404;
+
+        _currentSettings = _currentSettings with
+        {
+            VirtualNodeEnabled = enabled,
+            VirtualNodePort = port,
+            VirtualNodeBlockAdmin = blockAdmin
+        };
+        SettingsService.Save(_currentSettings);
+        ApplyVirtualNodeSettings();
+    }
+
+    private void RefreshVirtualNodeStatus()
+    {
+        if (VirtualNodeStatusText == null) return;
+        var running = _virtualNodeService?.IsRunning == true;
+        VirtualNodeStatusText.Text = running ? Loc("StrVirtualNodeRunning") : Loc("StrVirtualNodeStopped");
+        VirtualNodeStatusText.Foreground = running
+            ? new SolidColorBrush(System.Windows.Media.Color.FromRgb(0x2E, 0x7D, 0x32))
+            : new SolidColorBrush(System.Windows.Media.Color.FromRgb(0x75, 0x75, 0x75));
+
+        var clients = _virtualNodeService?.GetConnectedClients() ?? [];
+        VirtualNodeClientCountText.Text = clients.Count.ToString();
+        VirtualNodeClientListText.Text = clients.Count > 0
+            ? string.Join("\n", clients.Select(c => $"{c.Id}  {c.Ip}"))
+            : Loc("StrVirtualNodeNoClients");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
 
     private void OnPacketCountChanged(object? sender, int count)
     {

--- a/MeshhessenClient/MainWindow.xaml.cs
+++ b/MeshhessenClient/MainWindow.xaml.cs
@@ -3280,7 +3280,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        MainTabs.SelectedIndex = 4;
+        MainTabs.SelectedIndex = 3;
         var nodePos = SphericalMercator.FromLonLat(node.Longitude.Value, node.Latitude.Value);
         if (_map != null)
         {
@@ -3497,7 +3497,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        MainTabs.SelectedIndex = 4;
+        MainTabs.SelectedIndex = 3;
         var nodePos = SphericalMercator.FromLonLat(node.Longitude.Value, node.Latitude.Value);
         if (_map != null)
         {
@@ -4231,7 +4231,7 @@ public partial class MainWindow : Window
             _map?.Layers.Add(pathLayer);
 
             // Zoom to fit
-            MainTabs.SelectedIndex = 4;
+            MainTabs.SelectedIndex = 3;
             var minX = coords.Min(c => c.X); var maxX = coords.Max(c => c.X);
             var minY = coords.Min(c => c.Y); var maxY = coords.Max(c => c.Y);
             var paddedSize = Math.Max(Math.Max(maxX - minX, maxY - minY) * 1.3, 1000.0);
@@ -4365,7 +4365,7 @@ public partial class MainWindow : Window
             }
 
             // Switch to Map tab
-            MainTabs.SelectedIndex = 4; // Map is tab index 4 (0=Messages, 1=Nodes, 2=Channels, 3=Settings, 4=Map)
+            MainTabs.SelectedIndex = 3; // Map is tab index 3 (0=Messages, 1=Nodes, 2=Channels, 3=Map, 4=Settings, ...)
 
             // Center map on node position with closer zoom
             var nodePos = SphericalMercator.FromLonLat(node.Longitude.Value, node.Latitude.Value);
@@ -4649,7 +4649,7 @@ public partial class MainWindow : Window
 
         if (zoomToFit)
         {
-            MainTabs.SelectedIndex = 4;
+            MainTabs.SelectedIndex = 3;
             var allPts = orderedIds
                 .Where(id => positions.ContainsKey(id))
                 .Select(id => { var p = SphericalMercator.FromLonLat(positions[id].Lon, positions[id].Lat); return new MPoint(p.x, p.y); })
@@ -4808,7 +4808,7 @@ public partial class MainWindow : Window
             MapStatusText.Text = "Alle DB-Traceroutes bereits auf der Karte.";
         else
         {
-            MainTabs.SelectedIndex = 4;
+            MainTabs.SelectedIndex = 3;
             MapStatusText.Text = $"{drawn} Traceroute(s) aus DB geladen ({days}d).";
         }
     }

--- a/MeshhessenClient/MeshhessenClient.csproj
+++ b/MeshhessenClient/MeshhessenClient.csproj
@@ -18,9 +18,9 @@
     <PublishDir>..\public\</PublishDir>
 
     <AssemblyName>MeshhessenClient</AssemblyName>
-    <Version>1.5.9</Version>
-    <AssemblyVersion>1.5.9.0</AssemblyVersion>
-    <FileVersion>1.5.9.0</FileVersion>
+    <Version>1.5.10</Version>
+    <AssemblyVersion>1.5.10.0</AssemblyVersion>
+    <FileVersion>1.5.10.0</FileVersion>
     <Company>Meshtastic Community</Company>
     <Product>Meshhessen Client</Product>
     <Description>Offline-fähiger Windows Client für Meshtastic Geräte</Description>

--- a/MeshhessenClient/MeshhessenClient.csproj
+++ b/MeshhessenClient/MeshhessenClient.csproj
@@ -18,9 +18,9 @@
     <PublishDir>..\public\</PublishDir>
 
     <AssemblyName>MeshhessenClient</AssemblyName>
-    <Version>1.5.10.2</Version>
-    <AssemblyVersion>1.5.10.2</AssemblyVersion>
-    <FileVersion>1.5.10.2</FileVersion>
+    <Version>1.5.11.0</Version>
+    <AssemblyVersion>1.5.11.0</AssemblyVersion>
+    <FileVersion>1.5.11.0</FileVersion>
     <Company>Meshtastic Community</Company>
     <Product>Meshhessen Client</Product>
     <Description>Offline-fähiger Windows Client für Meshtastic Geräte</Description>

--- a/MeshhessenClient/MeshhessenClient.csproj
+++ b/MeshhessenClient/MeshhessenClient.csproj
@@ -18,9 +18,9 @@
     <PublishDir>..\public\</PublishDir>
 
     <AssemblyName>MeshhessenClient</AssemblyName>
-    <Version>1.5.10</Version>
-    <AssemblyVersion>1.5.10.0</AssemblyVersion>
-    <FileVersion>1.5.10.0</FileVersion>
+    <Version>1.5.10.2</Version>
+    <AssemblyVersion>1.5.10.2</AssemblyVersion>
+    <FileVersion>1.5.10.2</FileVersion>
     <Company>Meshtastic Community</Company>
     <Product>Meshhessen Client</Product>
     <Description>Offline-fähiger Windows Client für Meshtastic Geräte</Description>

--- a/MeshhessenClient/MeshhessenClient.csproj.lscache
+++ b/MeshhessenClient/MeshhessenClient.csproj.lscache
@@ -1,0 +1,424 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=MeshhessenClient
+CommandLineArgsForDesignTimeEvaluation=-langversion:12.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=12.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=MeshhessenClient
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../MeshhessenClient.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net8.0-windows10.0.19041.0/win-x64/MeshhessenClient.dll
+TargetRefPath=<PATH>obj/Debug/net8.0-windows10.0.19041.0/win-x64/ref/MeshhessenClient.dll
+TemporaryDependencyNodeTargetIdentifier=net8.0-windows10.0.19041.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:1701,1702,1701,1702
+/fullpaths
+/nostdlib+
+/platform:x64
+/errorreport:prompt
+/warn:8
+/define:TRACE;DEBUG;NET;NET8_0;NETCOREAPP;WINDOWS;WINDOWS10_0_19041_0;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER;WINDOWS10_0_19041_0_OR_GREATER;WINDOWS10_0_18362_0_OR_GREATER;WINDOWS10_0_17763_0_OR_GREATER;WINDOWS8_0_OR_GREATER;WINDOWS7_0_OR_GREATER
+/highentropyva+
+/nullable:enable
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net8.0-windows10.0.19041.0\win-x64\MeshhessenClient.dll
+/refout:obj\Debug\net8.0-windows10.0.19041.0\win-x64\refint\MeshhessenClient.dll
+/target:winexe
+/warnaserror-
+/utf8output
+/win32icon:Resources\app.ico
+/win32manifest:app.manifest
+/deterministic+
+/langversion:12.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+AddChannelWindow.xaml.cs
+AddWidgetDialog.xaml.cs
+App.xaml.cs
+ChannelBrowserWindow.xaml.cs
+Converters/
+ AlertBellIconConverter.cs
+ ColorConverters.cs
+ MessageDocumentConverter.cs
+ MqttIconConverter.cs
+DirectMessagesWindow.xaml.cs
+Helpers/RichTextBoxHelper.cs
+MainWindow.xaml.cs
+MapPickerWindow.xaml.cs
+MigrationProgressWindow.xaml.cs
+Models/
+ BluetoothDeviceInfo.cs
+ ChannelInfo.cs
+ DashboardModels.cs
+ DirectMessageConversation.cs
+ MessageDbEntry.cs
+ MessageItem.cs
+ MyNodeInfo.cs
+ NodeInfo.cs
+ TelemetryStats.cs
+ TracerouteHopItem.cs
+ TracerouteResult.cs
+ TracerouteSaveData.cs
+NodeConfigWindow.xaml.cs
+NodeInfoWindow.xaml.cs
+NodeKeyMismatchDialog.xaml.cs
+obj/Debug/net8.0-windows10.0.19041.0/win-x64/
+ .NETCoreApp,Version=v8.0.AssemblyAttributes.cs
+ AddChannelWindow.g.cs
+ Admin.cs
+ App.g.cs
+ ChannelBrowserWindow.g.cs
+ DirectMessagesWindow.g.cs
+ GeneratedInternalTypeHelper.g.cs
+ MainWindow.g.cs
+ MapPickerWindow.g.cs
+ Mesh.cs
+ MeshhessenClient.AssemblyInfo.cs
+ MeshhessenClient.GlobalUsings.g.cs
+ MigrationProgressWindow.g.cs
+ NodeConfigWindow.g.cs
+ NodeInfoWindow.g.cs
+ NodeKeyMismatchDialog.g.cs
+ PlotWindow.g.cs
+ Portnums.cs
+ RemoteAdminWindow.g.cs
+ SegmentSnrWindow.g.cs
+ TDeckExportWindow.g.cs
+ TDeckRegionMapWindow.g.cs
+ TDeckWizardWindow.g.cs
+ Telemetry.cs
+ TelemetryDashboardWindow.g.cs
+ TelemetryWindow.g.cs
+ TileDownloaderWindow.g.cs
+ TracerouteWindow.g.cs
+ WaypointCreateDialog.g.cs
+ ZipImportWindow.g.cs
+PlotWindow.xaml.cs
+RemoteAdminWindow.xaml.cs
+SegmentSnrWindow.xaml.cs
+Services/
+ BluetoothConnectionService.cs
+ CachingHttpTileProvider.cs
+ DriveService.cs
+ IConnectionService.cs
+ LocalFileTileProvider.cs
+ LocationLogger.cs
+ Logger.cs
+ MeshtasticProtocolService.cs
+ MessageDatabaseService.cs
+ MessageDbManager.cs
+ MessageLogger.cs
+ MqttProxyService.cs
+ NodeKeyService.cs
+ PkiDecryptionService.cs
+ SerialConnectionService.cs
+ SerialPortService.cs
+ SettingsService.cs
+ SunriseSunsetService.cs
+ TcpConnectionService.cs
+ TDeckTileService.cs
+ TelemetryDatabaseService.cs
+ TileDownloaderService.cs
+ TileMigrationService.cs
+TDeckExportWindow.xaml.cs
+TDeckRegionMapWindow.xaml.cs
+TDeckWizardWindow.xaml.cs
+TelemetryDashboardWindow.xaml.cs
+TelemetryWindow.xaml.cs
+TileDownloaderWindow.xaml.cs
+TracerouteWindow.xaml.cs
+WaypointCreateDialog.xaml.cs
+ZipImportWindow.xaml.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/8.0.24/ref/net8.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+<DOTNET>/packs/Microsoft.WindowsDesktop.App.Ref/8.0.24/ref/net8.0/
+ Accessibility.dll
+ Microsoft.Win32.Registry.AccessControl.dll
+ Microsoft.Win32.SystemEvents.dll
+ PresentationCore.dll
+ PresentationFramework.Aero.dll
+ PresentationFramework.Aero2.dll
+ PresentationFramework.AeroLite.dll
+ PresentationFramework.Classic.dll
+ PresentationFramework.dll
+ PresentationFramework.Luna.dll
+ PresentationFramework.Royale.dll
+ PresentationUI.dll
+ ReachFramework.dll
+ System.CodeDom.dll
+ System.Configuration.ConfigurationManager.dll
+ System.Diagnostics.EventLog.dll
+ System.Diagnostics.PerformanceCounter.dll
+ System.DirectoryServices.dll
+ System.IO.Packaging.dll
+ System.Printing.dll
+ System.Resources.Extensions.dll
+ System.Security.Cryptography.Pkcs.dll
+ System.Security.Cryptography.ProtectedData.dll
+ System.Security.Cryptography.Xml.dll
+ System.Security.Permissions.dll
+ System.Threading.AccessControl.dll
+ System.Windows.Controls.Ribbon.dll
+ System.Windows.Extensions.dll
+ System.Windows.Input.Manipulations.dll
+ System.Windows.Presentation.dll
+ System.Xaml.dll
+ UIAutomationClient.dll
+ UIAutomationClientSideProviders.dll
+ UIAutomationProvider.dll
+ UIAutomationTypes.dll
+ WindowsBase.dll
+<NUGET>/
+ bouncycastle.cryptography/2.4.0/lib/net6.0/BouncyCastle.Cryptography.dll
+ brutile/5.0.6/lib/net6.0/BruTile.dll
+ communitytoolkit.mvvm/8.2.2/lib/net6.0/CommunityToolkit.Mvvm.dll
+ emoji.wpf/0.3.3/lib/netcoreapp3.1/
+  Emoji.Wpf.dll
+  Typography.GlyphLayout.dll
+  Typography.OpenFont.dll
+ excss/4.2.3/lib/net7.0/ExCSS.dll
+ google.protobuf/3.25.2/lib/net5.0/Google.Protobuf.dll
+ harfbuzzsharp/7.3.0.1/lib/net6.0/HarfBuzzSharp.dll
+ mapsui.nts/4.1.7/lib/net6.0/Mapsui.Nts.dll
+ mapsui.rendering.skia/4.1.7/lib/net6.0/Mapsui.Rendering.Skia.dll
+ mapsui.tiling/4.1.7/lib/net6.0/Mapsui.Tiling.dll
+ mapsui.wpf/4.1.7/lib/netcoreapp3.1/Mapsui.UI.Wpf.dll
+ mapsui/4.1.7/lib/net6.0/Mapsui.dll
+ microsoft.data.sqlite.core/10.0.3/lib/net8.0/Microsoft.Data.Sqlite.dll
+ microsoft.windows.sdk.net.ref/10.0.19041.57/lib/net8.0/
+  Microsoft.Windows.SDK.NET.dll
+  WinRT.Runtime.dll
+ modernwpfui/0.9.6/lib/net5.0-windows7.0/
+  ModernWpf.Controls.dll
+  ModernWpf.dll
+ mqttnet/4.3.7.1207/lib/net7.0/MQTTnet.dll
+ nettopologysuite.features/2.1.0/lib/netstandard2.0/NetTopologySuite.Features.dll
+ nettopologysuite.io.geojson4stj/4.0.0/lib/netstandard2.0/NetTopologySuite.IO.GeoJSON4STJ.dll
+ nettopologysuite/2.5.0/lib/netstandard2.0/NetTopologySuite.dll
+ oxyplot.core/2.2.0/lib/net8.0/OxyPlot.dll
+ oxyplot.wpf.shared/2.2.0/lib/net8.0-windows7.0/OxyPlot.Wpf.Shared.dll
+ oxyplot.wpf/2.2.0/lib/net8.0-windows7.0/OxyPlot.Wpf.dll
+ shimskiasharp/1.0.0.3/lib/net6.0/ShimSkiaSharp.dll
+ skiasharp.harfbuzz/2.88.7/lib/net6.0/SkiaSharp.HarfBuzz.dll
+ skiasharp.views.desktop.common/2.88.7/lib/netcoreapp3.1/SkiaSharp.Views.Desktop.Common.dll
+ skiasharp.views.wpf/2.88.7/lib/netcoreapp3.1/SkiaSharp.Views.WPF.dll
+ skiasharp/2.88.7/lib/net6.0/SkiaSharp.dll
+ sqlitepclraw.bundle_e_sqlite3/2.1.11/lib/netstandard2.0/SQLitePCLRaw.batteries_v2.dll
+ sqlitepclraw.core/2.1.11/lib/netstandard2.0/SQLitePCLRaw.core.dll
+ sqlitepclraw.provider.e_sqlite3/2.1.11/lib/net6.0-windows7.0/SQLitePCLRaw.provider.e_sqlite3.dll
+ svg.custom/1.0.0.3/lib/net6.0/Svg.Custom.dll
+ svg.model/1.0.0.3/lib/net6.0/Svg.Model.dll
+ svg.skia/1.0.0.3/lib/net6.0/Svg.Skia.dll
+ system.drawing.common/8.0.2/lib/net8.0/System.Drawing.Common.dll
+ system.io.ports/8.0.0/lib/net8.0/System.IO.Ports.dll
+ topten.richtextkit/0.4.166/lib/net5.0/Topten.RichTextKit.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/8.0.24/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.103/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<NUGET>/communitytoolkit.mvvm/8.2.2/analyzers/dotnet/roslyn4.3/cs/
+ CommunityToolkit.Mvvm.CodeFixers.dll
+ CommunityToolkit.Mvvm.SourceGenerators.dll
+<NUGET>/microsoft.net.illink.tasks/8.0.24/analyzers/dotnet/cs/
+ ILLink.CodeFixProvider.dll
+ ILLink.RoslynAnalyzer.dll
+<NUGET>/microsoft.windows.sdk.net.ref/10.0.19041.57/analyzers/dotnet/cs/WinRT.SourceGenerator.dll
+
+[analyzerConfigFiles]
+<DOTNET>/sdk/10.0.103/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_8_default.globalconfig
+obj/Debug/net8.0-windows10.0.19041.0/win-x64/MeshhessenClient.GeneratedMSBuildEditorConfig.editorconfig

--- a/MeshhessenClient/Models/DashboardModels.cs
+++ b/MeshhessenClient/Models/DashboardModels.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace MeshhessenClient.Models;
+
+public record DashboardWidget(
+    string Id,
+    string Type,        // "line", "area", "bar", "gauge", "heatmap", "scatter", "stat"
+    string Metric,      // "snr", "rssi", "battery", "voltage", "channel_util", "air_tx_util", "temperature", "humidity", "pressure"
+    List<uint> NodeIds,
+    int Days,
+    string Title,
+    double Width  = 420,
+    double Height = 300
+);
+
+public record Dashboard(
+    string Name,
+    List<DashboardWidget> Widgets
+);
+
+public class DashboardStore
+{
+    [JsonPropertyName("dashboards")]
+    public List<Dashboard> Dashboards { get; set; } = new();
+}

--- a/MeshhessenClient/Models/DashboardModels.cs
+++ b/MeshhessenClient/Models/DashboardModels.cs
@@ -4,13 +4,15 @@ namespace MeshhessenClient.Models;
 
 public record DashboardWidget(
     string Id,
-    string Type,        // "line", "area", "bar", "gauge", "heatmap", "scatter", "stat"
-    string Metric,      // "snr", "rssi", "battery", "voltage", "channel_util", "air_tx_util", "temperature", "humidity", "pressure"
+    string Type,        // "line","area","bar","gauge","heatmap","scatter","stat","ranking","multistat","meshhealth","histogram","candlestick","stateline","clock"
+    string Metric,      // "snr","rssi","battery","voltage","channel_util","air_tx_util","temperature","humidity","pressure","packet_count"
     List<uint> NodeIds,
     int Days,
     string Title,
     double Width  = 420,
-    double Height = 300
+    double Height = 300,
+    double Threshold = double.NaN,   // NaN = disabled; horizontal annotation line on charts
+    bool ShowMovingAverage = false   // MA overlay on line/area charts
 );
 
 public record Dashboard(

--- a/MeshhessenClient/Models/NodeInfo.cs
+++ b/MeshhessenClient/Models/NodeInfo.cs
@@ -21,6 +21,7 @@ public class NodeInfo
     public string ColorHex { get; set; } = string.Empty;  // Empty = no color, otherwise #RRGGBB
     public string Note { get; set; } = string.Empty;      // User note
     public bool IsPinned { get; set; }                    // Pinned to top of node list
+    public bool IsFavorite { get; set; }                  // Marked as favorite (synced with device)
     public string HardwareModel { get; set; } = string.Empty;
     public bool PkiKeyKnown { get; set; }
     public string PkiKeyIcon => PkiKeyKnown ? "🔑" : "";

--- a/MeshhessenClient/NodeConfigWindow.xaml.cs
+++ b/MeshhessenClient/NodeConfigWindow.xaml.cs
@@ -152,9 +152,8 @@ public partial class NodeConfigWindow : Window
             _loadingDone = false;
             _expectedConfigs.Clear();
             _receivedConfigs.Clear();
+            _loadingTimeoutTimer?.Dispose();
 
-            // Register all configs we expect to receive
-            // Channels are NOT included — disabled channels never fire, so they'd block completion
             _expectedConfigs.UnionWith(new[]
             {
                 "owner", "device", "lora", "position", "power", "network",
@@ -166,59 +165,100 @@ public partial class NodeConfigWindow : Window
             UpdateStatus(Loc("StrNcLoadingProgress", "0", _expectedConfigs.Count.ToString()));
             SaveButton.IsEnabled = false;
 
-            // Start 30-second timeout
-            _loadingTimeoutTimer?.Dispose();
-            _loadingTimeoutTimer = new System.Threading.Timer(_ =>
-            {
-                Dispatcher.BeginInvoke(() =>
-                {
-                    if (_loadingDone) return;
-                    _loadingDone = true;
-                    var missing = _expectedConfigs.Except(_receivedConfigs).ToList();
-                    UpdateStatus(Loc("StrNcLoadingTimeout", string.Join(", ", missing)));
-                    SaveButton.IsEnabled = true;
-                });
-            }, null, 30000, System.Threading.Timeout.Infinite);
+            // Sequential loading: send one request, wait for the response event,
+            // then send the next. This prevents firmware queue overflow on slow boards
+            // (e.g. Heltec). Per-request timeout: 8 s.
+            const int T = 8000;
 
-            await _protocolService.RequestOwnerAsync();
-            await Delay();
-            await _protocolService.RequestDeviceConfigAsync();
-            await Delay();
-            await _protocolService.RequestLoRaConfigAsync();
-            await Delay();
-            await _protocolService.RequestPositionConfigAsync();
-            await Delay();
-            await _protocolService.RequestPowerConfigAsync();
-            await Delay();
-            await _protocolService.RequestNetworkConfigAsync();
-            await Delay();
-            await _protocolService.RequestDisplayConfigAsync();
-            await Delay();
-            await _protocolService.RequestBluetoothConfigAsync();
-            await Delay();
-            await _protocolService.RequestMqttConfigAsync();
-            await Delay();
-            await _protocolService.RequestTelemetryConfigAsync();
-            await Delay();
-            await _protocolService.RequestNeighborInfoConfigAsync();
-            await Delay();
-            await _protocolService.RequestStoreForwardConfigAsync();
-            await Delay();
-            await _protocolService.RequestExternalNotificationConfigAsync();
-            await Delay();
-            await _protocolService.RequestCannedMessageConfigAsync();
-            await Delay();
-            await _protocolService.RequestRangeTestConfigAsync();
-            await Delay();
-            await _protocolService.RequestSerialConfigAsync();
-            await Delay();
-            await _protocolService.RequestSecurityConfigAsync();
-            await Delay();
-            // Request channels 0-7
+            await Seq<User>(_protocolService.RequestOwnerAsync,
+                h => _protocolService.OwnerReceived += h,
+                h => _protocolService.OwnerReceived -= h, T);
+
+            await Seq<DeviceConfig>(_protocolService.RequestDeviceConfigAsync,
+                h => _protocolService.DeviceConfigReceived += h,
+                h => _protocolService.DeviceConfigReceived -= h, T);
+
+            await Seq<LoRaConfig>(_protocolService.RequestLoRaConfigAsync,
+                h => _protocolService.LoRaConfigReceived += h,
+                h => _protocolService.LoRaConfigReceived -= h, T);
+
+            await Seq<PositionConfig>(_protocolService.RequestPositionConfigAsync,
+                h => _protocolService.PositionConfigReceived += h,
+                h => _protocolService.PositionConfigReceived -= h, T);
+
+            await Seq<PowerConfig>(_protocolService.RequestPowerConfigAsync,
+                h => _protocolService.PowerConfigReceived += h,
+                h => _protocolService.PowerConfigReceived -= h, T);
+
+            await Seq<NetworkConfig>(_protocolService.RequestNetworkConfigAsync,
+                h => _protocolService.NetworkConfigReceived += h,
+                h => _protocolService.NetworkConfigReceived -= h, T);
+
+            await Seq<DisplayConfig>(_protocolService.RequestDisplayConfigAsync,
+                h => _protocolService.DisplayConfigReceived += h,
+                h => _protocolService.DisplayConfigReceived -= h, T);
+
+            await Seq<BluetoothConfig>(_protocolService.RequestBluetoothConfigAsync,
+                h => _protocolService.BluetoothConfigReceived += h,
+                h => _protocolService.BluetoothConfigReceived -= h, T);
+
+            await Seq<MQTTConfig>(_protocolService.RequestMqttConfigAsync,
+                h => _protocolService.MqttConfigReceived += h,
+                h => _protocolService.MqttConfigReceived -= h, T);
+
+            await Seq<TelemetryConfig>(_protocolService.RequestTelemetryConfigAsync,
+                h => _protocolService.TelemetryConfigReceived += h,
+                h => _protocolService.TelemetryConfigReceived -= h, T);
+
+            await Seq<NeighborInfoConfig>(_protocolService.RequestNeighborInfoConfigAsync,
+                h => _protocolService.NeighborInfoConfigReceived += h,
+                h => _protocolService.NeighborInfoConfigReceived -= h, T);
+
+            await Seq<StoreForwardConfig>(_protocolService.RequestStoreForwardConfigAsync,
+                h => _protocolService.StoreForwardConfigReceived += h,
+                h => _protocolService.StoreForwardConfigReceived -= h, T);
+
+            await Seq<ExternalNotificationConfig>(_protocolService.RequestExternalNotificationConfigAsync,
+                h => _protocolService.ExternalNotificationConfigReceived += h,
+                h => _protocolService.ExternalNotificationConfigReceived -= h, T);
+
+            await Seq<CannedMessageConfig>(_protocolService.RequestCannedMessageConfigAsync,
+                h => _protocolService.CannedMessageConfigReceived += h,
+                h => _protocolService.CannedMessageConfigReceived -= h, T);
+
+            await Seq<RangeTestConfig>(_protocolService.RequestRangeTestConfigAsync,
+                h => _protocolService.RangeTestConfigReceived += h,
+                h => _protocolService.RangeTestConfigReceived -= h, T);
+
+            await Seq<SerialConfig>(_protocolService.RequestSerialConfigAsync,
+                h => _protocolService.SerialConfigReceived += h,
+                h => _protocolService.SerialConfigReceived -= h, T);
+
+            await Seq<SecurityConfig>(_protocolService.RequestSecurityConfigAsync,
+                h => _protocolService.SecurityConfigReceived += h,
+                h => _protocolService.SecurityConfigReceived -= h, T);
+
+            // Channels — disabled channels never respond, so timeout is expected
             for (int i = 0; i < 8; i++)
             {
-                await _protocolService.RequestChannelConfigAsync(i);
-                await Delay();
+                int idx = i;
+                await Seq<ChannelInfo>(() => _protocolService.RequestChannelConfigAsync(idx),
+                    h => _protocolService.ChannelInfoReceived += h,
+                    h => _protocolService.ChannelInfoReceived -= h, T);
+            }
+
+            // Done — if MarkReceived() already completed everything, _loadingDone is true.
+            // Otherwise show which configs are still missing and enable Save anyway.
+            if (!_loadingDone)
+            {
+                _loadingDone = true;
+                var missing = _expectedConfigs.Except(_receivedConfigs).ToList();
+                if (missing.Count > 0)
+                    UpdateStatus(Loc("StrNcLoadingTimeout", string.Join(", ", missing)));
+                else
+                    UpdateStatus(Loc("StrNcConfigLoaded") != "StrNcConfigLoaded"
+                        ? Loc("StrNcConfigLoaded") : "Konfiguration geladen.");
+                Dispatcher.BeginInvoke(() => SaveButton.IsEnabled = true);
             }
         }
         catch (Exception ex)
@@ -227,9 +267,37 @@ public partial class NodeConfigWindow : Window
         }
     }
 
-    // 500 ms between requests — slower boards (e.g. Heltec) overflow the firmware queue at 200 ms
+    // Small delay between write commands in the Save path
     private static System.Threading.Tasks.Task Delay() =>
-        System.Threading.Tasks.Task.Delay(500);
+        System.Threading.Tasks.Task.Delay(300);
+
+    /// <summary>
+    /// Sends a config request and waits for the matching response event with a timeout.
+    /// The existing event handlers (OnXxxReceived) remain subscribed and handle UI/tracking;
+    /// this helper only adds a temporary one-shot handler to pace the sequential loading.
+    /// </summary>
+    private static async System.Threading.Tasks.Task Seq<T>(
+        Func<System.Threading.Tasks.Task> send,
+        Action<EventHandler<T>> subscribe,
+        Action<EventHandler<T>> unsubscribe,
+        int timeoutMs)
+    {
+        var tcs = new System.Threading.Tasks.TaskCompletionSource<bool>(
+            System.Threading.Tasks.TaskCreationOptions.RunContinuationsAsynchronously);
+        EventHandler<T> handler = (_, _) => tcs.TrySetResult(true);
+        subscribe(handler);
+        try
+        {
+            await send();
+            await System.Threading.Tasks.Task.WhenAny(
+                tcs.Task,
+                System.Threading.Tasks.Task.Delay(timeoutMs));
+        }
+        finally
+        {
+            unsubscribe(handler);
+        }
+    }
 
     private string Loc(string key, params string[] args)
     {

--- a/MeshhessenClient/NodeConfigWindow.xaml.cs
+++ b/MeshhessenClient/NodeConfigWindow.xaml.cs
@@ -227,8 +227,9 @@ public partial class NodeConfigWindow : Window
         }
     }
 
+    // 500 ms between requests — slower boards (e.g. Heltec) overflow the firmware queue at 200 ms
     private static System.Threading.Tasks.Task Delay() =>
-        System.Threading.Tasks.Task.Delay(200);
+        System.Threading.Tasks.Task.Delay(500);
 
     private string Loc(string key, params string[] args)
     {
@@ -549,14 +550,14 @@ public partial class NodeConfigWindow : Window
         _loadedSecurity = config;
         Dispatcher.BeginInvoke(() =>
         {
-            // Public key: hex display (read-only)
+            // Public key: base64 display (read-only) — same format as Meshtastic app
             SecPublicKeyTextBox.Text = config.PublicKey != null && config.PublicKey.Length > 0
-                ? BitConverter.ToString(config.PublicKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
+                ? Convert.ToBase64String(config.PublicKey.ToByteArray())
                 : string.Empty;
 
-            // Private key: stored in box but masked; toggle reveals it
+            // Private key: stored in box but masked; toggle reveals it (base64 format)
             SecPrivKeyBox.Text = config.PrivateKey != null && config.PrivateKey.Length > 0
-                ? BitConverter.ToString(config.PrivateKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
+                ? Convert.ToBase64String(config.PrivateKey.ToByteArray())
                 : string.Empty;
             // Ensure masked view is visible
             SecPrivKeyToggle.IsChecked = false;

--- a/MeshhessenClient/Proto/admin.proto
+++ b/MeshhessenClient/Proto/admin.proto
@@ -45,5 +45,7 @@ message AdminMessage {
     DeviceMetadata get_device_metadata_response = 13;
     Position set_position = 88;
     bool remove_position = 89;
+    uint32 add_favorite_node = 36;
+    uint32 remove_favorite_node = 37;
   }
 }

--- a/MeshhessenClient/Proto/admin.proto
+++ b/MeshhessenClient/Proto/admin.proto
@@ -45,7 +45,7 @@ message AdminMessage {
     DeviceMetadata get_device_metadata_response = 13;
     Position set_position = 88;
     bool remove_position = 89;
-    uint32 add_favorite_node = 36;
-    uint32 remove_favorite_node = 37;
+    uint32 set_favorite_node = 39;
+    uint32 remove_favorite_node = 40;
   }
 }

--- a/MeshhessenClient/Proto/mesh.proto
+++ b/MeshhessenClient/Proto/mesh.proto
@@ -107,6 +107,15 @@ message MqttClientProxyMessage {
   bool retained = 4;
 }
 
+message QueueStatus {
+  int32 res = 1;
+  uint32 free = 2;
+  uint32 maxlen = 3;
+  uint32 mesh_packet_id = 4;
+}
+
+message Heartbeat {}
+
 message FromRadio {
   uint32 id = 1;
   oneof payload_variant {
@@ -118,6 +127,8 @@ message FromRadio {
     bool rebooted = 8;
     ModuleConfig module_config = 9;
     Channel channel = 10;
+    QueueStatus queue_status = 12;
+    DeviceMetadata metadata = 13;
     MqttClientProxyMessage mqtt_client_proxy_message = 14;
   }
 }
@@ -129,6 +140,7 @@ message ToRadio {
     bool disconnect = 4;
     bytes xmodem_packet = 5;
     MqttClientProxyMessage mqtt_client_proxy_message = 6;
+    Heartbeat heartbeat = 7;
   }
 }
 

--- a/MeshhessenClient/RemoteAdminWindow.xaml
+++ b/MeshhessenClient/RemoteAdminWindow.xaml
@@ -1,0 +1,383 @@
+<Window x:Class="MeshhessenClient.RemoteAdminWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
+        ui:WindowHelper.UseModernWindowStyle="True"
+        Title="{DynamicResource StrRemoteAdminTitle}"
+        Width="720" MinWidth="600"
+        Height="680" MinHeight="500"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip">
+
+    <Grid Margin="16,12,16,12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header row: Node info + status + favorite button -->
+        <Grid Grid.Row="0" Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <TextBlock x:Name="NodeNameLabel" FontSize="16" FontWeight="SemiBold"
+                           Text="{DynamicResource StrRemoteAdminConnecting}"/>
+                <TextBlock x:Name="NodeIdLabel" FontSize="11"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                           Margin="0,2,0,0"/>
+            </StackPanel>
+            <Button x:Name="FavoriteButton" Grid.Column="1"
+                    Content="★" FontSize="18" Width="40" Height="34"
+                    ToolTip="{DynamicResource StrRemoteAdminFavoriteTip}"
+                    Click="FavoriteButton_Click"
+                    Margin="8,0,0,0"/>
+            <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="8,0,0,0">
+                <Ellipse x:Name="StatusDot" Width="12" Height="12"
+                         Fill="#9E9E9E" VerticalAlignment="Center"/>
+                <TextBlock x:Name="StatusLabel" Text="{DynamicResource StrRemoteAdminWaiting}"
+                           VerticalAlignment="Center" Margin="6,0,0,0" FontSize="12"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Metadata info row — adapts to theme via SystemControlBackgroundChromeMediumLowBrush -->
+        <Border Grid.Row="1"
+                Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                BorderThickness="1"
+                CornerRadius="4" Padding="10,6" Margin="0,0,0,10">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="{DynamicResource StrRemoteAdminFirmware}" FontSize="10"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                    <TextBlock x:Name="FirmwareLabel" Text="-" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1">
+                    <TextBlock Text="{DynamicResource StrRemoteAdminHardware}" FontSize="10"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                    <TextBlock x:Name="HardwareLabel" Text="-" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                </StackPanel>
+                <StackPanel Grid.Column="2">
+                    <TextBlock Text="{DynamicResource StrRemoteAdminHops}" FontSize="10"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                    <TextBlock x:Name="HopsLabel" Text="-" FontSize="12"
+                               Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+                </StackPanel>
+                <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="{DynamicResource StrRemoteAdminTimeout}" FontSize="10"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBox x:Name="TimeoutBox" Width="50" FontSize="11"
+                             VerticalContentAlignment="Center"
+                             TextChanged="TimeoutBox_TextChanged"
+                             ToolTip="{DynamicResource StrRemoteAdminTimeoutTip}"/>
+                    <TextBlock Text="s" FontSize="11" VerticalAlignment="Center" Margin="3,0,0,0"
+                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Main content — disabled until connected -->
+        <TabControl x:Name="MainTabs" Grid.Row="2" IsEnabled="False">
+
+            <!-- Owner -->
+            <TabItem Header="{DynamicResource StrRaTabOwner}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <TextBlock Text="{DynamicResource StrRaOwnerShortName}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="OwnerShortName" MaxLength="4" Width="80"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                        <TextBlock Text="{DynamicResource StrRaOwnerLongName}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="OwnerLongName" MaxLength="39" Margin="0,4,0,12"/>
+                        <CheckBox x:Name="OwnerLicensed" Content="{DynamicResource StrRaOwnerLicensed}"
+                                  Margin="0,0,0,8"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Device Config -->
+            <TabItem Header="{DynamicResource StrRaTabDevice}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <TextBlock Text="{DynamicResource StrRaDeviceRole}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="DeviceRoleCombo" Margin="0,4,0,12" Width="220"
+                                  HorizontalAlignment="Left">
+                            <ComboBoxItem Tag="0" Content="Client"/>
+                            <ComboBoxItem Tag="1" Content="Client Mute"/>
+                            <ComboBoxItem Tag="2" Content="Router"/>
+                            <ComboBoxItem Tag="3" Content="Router Client"/>
+                            <ComboBoxItem Tag="4" Content="Repeater"/>
+                            <ComboBoxItem Tag="5" Content="Tracker"/>
+                            <ComboBoxItem Tag="6" Content="Sensor"/>
+                            <ComboBoxItem Tag="7" Content="ATAK"/>
+                            <ComboBoxItem Tag="8" Content="Client Hidden"/>
+                            <ComboBoxItem Tag="9" Content="Lost and Found"/>
+                            <ComboBoxItem Tag="10" Content="ATAK Tracker"/>
+                        </ComboBox>
+                        <TextBlock Text="{DynamicResource StrRaDeviceNodeInfoInterval}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="DeviceNodeInfoInterval" Width="100"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                        <CheckBox x:Name="DeviceSerialEnabled" Content="{DynamicResource StrRaDeviceSerialEnabled}"
+                                  Margin="0,0,0,8"/>
+                        <CheckBox x:Name="DeviceDebugLog" Content="{DynamicResource StrRaDeviceDebugLog}"
+                                  Margin="0,0,0,8"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Position Config -->
+            <TabItem Header="{DynamicResource StrRaTabPosition}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <TextBlock Text="{DynamicResource StrRaPosGpsMode}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="PosGpsMode" Margin="0,4,0,12" Width="200"
+                                  HorizontalAlignment="Left">
+                            <ComboBoxItem Tag="0" Content="Disabled"/>
+                            <ComboBoxItem Tag="1" Content="Enabled"/>
+                            <ComboBoxItem Tag="2" Content="Not Present"/>
+                        </ComboBox>
+                        <TextBlock Text="{DynamicResource StrRaPosBroadcastInterval}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="PosBroadcastInterval" Width="100"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                        <TextBlock Text="{DynamicResource StrRaPosBroadcastSmart}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <CheckBox x:Name="PosBroadcastSmart" Margin="0,4,0,12"/>
+                        <TextBlock Text="{DynamicResource StrRaPosGpsAttemptTime}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="PosGpsAttemptTime" Width="100"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                        <Separator Margin="0,4,0,8"/>
+                        <TextBlock Text="{DynamicResource StrRaPosFixed}" FontWeight="SemiBold"
+                                   Margin="0,0,0,6"/>
+                        <CheckBox x:Name="PosFixedEnabled" Content="{DynamicResource StrRaPosFixedEnabled}"
+                                  Margin="0,0,0,6"/>
+                        <Grid Margin="0,0,0,4">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="12"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="12"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0">
+                                <TextBlock Text="{DynamicResource StrRaPosLat}" FontSize="11"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                <TextBox x:Name="PosFixedLat" Margin="0,2,0,0"/>
+                            </StackPanel>
+                            <StackPanel Grid.Column="2">
+                                <TextBlock Text="{DynamicResource StrRaPosLon}" FontSize="11"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                <TextBox x:Name="PosFixedLon" Margin="0,2,0,0"/>
+                            </StackPanel>
+                            <StackPanel Grid.Column="4">
+                                <TextBlock Text="{DynamicResource StrRaPosAlt}" FontSize="11"
+                                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                                <TextBox x:Name="PosFixedAlt" Margin="0,2,0,0"/>
+                            </StackPanel>
+                        </Grid>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- LoRa Config -->
+            <TabItem Header="{DynamicResource StrRaTabLora}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <TextBlock Text="{DynamicResource StrRaLoraRegion}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="LoraRegionCombo" Margin="0,4,0,12" Width="200"
+                                  HorizontalAlignment="Left">
+                            <ComboBoxItem Tag="0" Content="Unset"/>
+                            <ComboBoxItem Tag="1" Content="US"/>
+                            <ComboBoxItem Tag="2" Content="EU_433"/>
+                            <ComboBoxItem Tag="3" Content="EU_868"/>
+                            <ComboBoxItem Tag="4" Content="CN"/>
+                            <ComboBoxItem Tag="5" Content="JP"/>
+                            <ComboBoxItem Tag="6" Content="ANZ"/>
+                            <ComboBoxItem Tag="7" Content="KR"/>
+                            <ComboBoxItem Tag="8" Content="TW"/>
+                            <ComboBoxItem Tag="9" Content="RU"/>
+                            <ComboBoxItem Tag="10" Content="IN"/>
+                            <ComboBoxItem Tag="11" Content="NZ_865"/>
+                            <ComboBoxItem Tag="12" Content="TH"/>
+                            <ComboBoxItem Tag="13" Content="UA_433"/>
+                            <ComboBoxItem Tag="14" Content="UA_868"/>
+                            <ComboBoxItem Tag="15" Content="MY_433"/>
+                            <ComboBoxItem Tag="16" Content="MY_919"/>
+                            <ComboBoxItem Tag="17" Content="SG_923"/>
+                        </ComboBox>
+                        <TextBlock Text="{DynamicResource StrRaLoraPreset}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="LoraPresetCombo" Margin="0,4,0,12" Width="280"
+                                  HorizontalAlignment="Left">
+                            <ComboBoxItem Tag="0" Content="Long Fast"/>
+                            <ComboBoxItem Tag="1" Content="Long Slow"/>
+                            <ComboBoxItem Tag="2" Content="Very Long Slow"/>
+                            <ComboBoxItem Tag="3" Content="Medium Slow"/>
+                            <ComboBoxItem Tag="4" Content="Medium Fast"/>
+                            <ComboBoxItem Tag="5" Content="Short Slow"/>
+                            <ComboBoxItem Tag="6" Content="Short Fast"/>
+                            <ComboBoxItem Tag="7" Content="Long Moderate"/>
+                        </ComboBox>
+                        <TextBlock Text="{DynamicResource StrRaLoraHopLimit}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="LoraHopLimit" Width="80"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                        <TextBlock Text="{DynamicResource StrRaLoraTxPower}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="LoraTxPower" Width="80"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                        <CheckBox x:Name="LoraTxEnabled" Content="{DynamicResource StrRaLoraTxEnabled}"
+                                  Margin="0,0,0,8"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Bluetooth -->
+            <TabItem Header="{DynamicResource StrRaTabBluetooth}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <CheckBox x:Name="BtEnabled" Content="{DynamicResource StrRaBtEnabled}"
+                                  Margin="0,0,0,12"/>
+                        <TextBlock Text="{DynamicResource StrRaBtMode}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="BtModeCombo" Margin="0,4,0,12" Width="180"
+                                  HorizontalAlignment="Left">
+                            <ComboBoxItem Tag="0" Content="Random PIN"/>
+                            <ComboBoxItem Tag="1" Content="Fixed PIN"/>
+                            <ComboBoxItem Tag="2" Content="No PIN"/>
+                        </ComboBox>
+                        <TextBlock Text="{DynamicResource StrRaBtPin}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="BtPin" Width="100"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Network / WiFi -->
+            <TabItem Header="{DynamicResource StrRaTabNetwork}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <CheckBox x:Name="WifiEnabled" Content="{DynamicResource StrRaWifiEnabled}"
+                                  Margin="0,0,0,12"/>
+                        <TextBlock Text="{DynamicResource StrRaWifiSsid}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="WifiSsid" Margin="0,4,0,12"/>
+                        <TextBlock Text="{DynamicResource StrRaWifiPsk}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <PasswordBox x:Name="WifiPsk" Margin="0,4,0,12"/>
+                        <CheckBox x:Name="WifiApMode" Content="{DynamicResource StrRaWifiApMode}"
+                                  Margin="0,0,0,8"/>
+                        <Separator Margin="0,4,0,8"/>
+                        <CheckBox x:Name="EthEnabled" Content="{DynamicResource StrRaEthEnabled}"
+                                  Margin="0,0,0,8"/>
+                        <TextBlock Text="{DynamicResource StrRaNtpServer}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="NtpServer" Margin="0,4,0,0"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Display -->
+            <TabItem Header="{DynamicResource StrRaTabDisplay}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <TextBlock Text="{DynamicResource StrRaDisplayTimeout}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="DisplayTimeout" Width="100"
+                                 HorizontalAlignment="Left" Margin="0,4,0,12"/>
+                        <CheckBox x:Name="DisplayFlipScreen" Content="{DynamicResource StrRaDisplayFlip}"
+                                  Margin="0,0,0,8"/>
+                        <TextBlock Text="{DynamicResource StrRaDisplayUnits}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="DisplayUnitsCombo" Margin="0,4,0,12" Width="150"
+                                  HorizontalAlignment="Left">
+                            <ComboBoxItem Tag="0" Content="Metric"/>
+                            <ComboBoxItem Tag="1" Content="Imperial"/>
+                        </ComboBox>
+                        <TextBlock Text="{DynamicResource StrRaDisplayOledType}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="OledTypeCombo" Margin="0,4,0,0" Width="200"
+                                  HorizontalAlignment="Left">
+                            <ComboBoxItem Tag="0" Content="Auto"/>
+                            <ComboBoxItem Tag="1" Content="SSD1306"/>
+                            <ComboBoxItem Tag="2" Content="SH1106"/>
+                            <ComboBoxItem Tag="3" Content="SH1107"/>
+                        </ComboBox>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Channels -->
+            <TabItem Header="{DynamicResource StrRaTabChannels}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel x:Name="ChannelsPanel" Margin="12,8,12,8"/>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Control -->
+            <TabItem Header="{DynamicResource StrRaTabControl}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <TextBlock Text="{DynamicResource StrRaControlDesc}"
+                                   TextWrapping="Wrap" Margin="0,0,0,16"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <Button x:Name="RebootButton" Content="{DynamicResource StrRaReboot}"
+                                Width="200" HorizontalAlignment="Left"
+                                Click="RebootButton_Click" Margin="0,0,0,10"/>
+                        <Button x:Name="ShutdownButton" Content="{DynamicResource StrRaShutdown}"
+                                Width="200" HorizontalAlignment="Left"
+                                Click="ShutdownButton_Click" Margin="0,0,0,10"/>
+                        <Separator Margin="0,8,0,8"/>
+                        <TextBlock Text="{DynamicResource StrRaNodeDbReset}"
+                                   TextWrapping="Wrap" Margin="0,0,0,8"
+                                   Foreground="OrangeRed"/>
+                        <Button x:Name="NodeDbResetButton" Content="{DynamicResource StrRaNodeDbResetBtn}"
+                                Width="200" HorizontalAlignment="Left"
+                                Click="NodeDbResetButton_Click"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+        </TabControl>
+
+        <!-- Bottom buttons -->
+        <Grid Grid.Row="3" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="RefreshButton" Grid.Column="0"
+                    Content="{DynamicResource StrRaRefresh}"
+                    Click="RefreshButton_Click" IsEnabled="False"/>
+            <Button x:Name="SaveButton" Grid.Column="2"
+                    Content="{DynamicResource StrRaSave}"
+                    Click="SaveButton_Click" IsEnabled="False"/>
+            <Button x:Name="CloseButton" Grid.Column="4"
+                    Content="{DynamicResource StrClose}"
+                    IsCancel="True" Click="CloseButton_Click"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/MeshhessenClient/RemoteAdminWindow.xaml
+++ b/MeshhessenClient/RemoteAdminWindow.xaml
@@ -334,6 +334,67 @@
                 </ScrollViewer>
             </TabItem>
 
+            <!-- Security -->
+            <TabItem Header="{DynamicResource StrRaTabSecurity}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12,12,12,8">
+                        <!-- Public key — read-only -->
+                        <TextBlock Text="{DynamicResource StrNcSecPublicKey}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="SecPublicKey" IsReadOnly="True"
+                                 FontFamily="Consolas" FontSize="11"
+                                 Margin="0,4,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcDescSecPublicKey}" FontSize="10"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+                        <!-- Admin keys -->
+                        <TextBlock Text="{DynamicResource StrNcSecAdminKey1}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="SecAdminKey1" FontFamily="Consolas" FontSize="11"
+                                 Margin="0,4,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcSecAdminKey2}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="SecAdminKey2" FontFamily="Consolas" FontSize="11"
+                                 Margin="0,4,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcSecAdminKey3}" FontSize="12"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <TextBox x:Name="SecAdminKey3" FontFamily="Consolas" FontSize="11"
+                                 Margin="0,4,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcDescSecAdminKeys}" FontSize="10"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+                        <Separator Margin="0,0,0,12"/>
+
+                        <!-- Flags -->
+                        <CheckBox x:Name="SecAdminChannelEnabled"
+                                  Content="{DynamicResource StrNcSecAdminChannel}" Margin="0,0,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcDescSecAdminChannel}" FontSize="10"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+                        <CheckBox x:Name="SecIsManaged"
+                                  Content="{DynamicResource StrNcSecIsManaged}" Margin="0,0,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcDescSecIsManaged}" FontSize="10"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+                        <CheckBox x:Name="SecSerialEnabled"
+                                  Content="{DynamicResource StrNcSecSerialEnabled}" Margin="0,0,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcDescSecSerialEnabled}" FontSize="10"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+                        <CheckBox x:Name="SecDebugLogEnabled"
+                                  Content="{DynamicResource StrNcSecDebugLog}" Margin="0,0,0,4"/>
+                        <TextBlock Text="{DynamicResource StrNcDescSecDebugLog}" FontSize="10"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
             <!-- Control -->
             <TabItem Header="{DynamicResource StrRaTabControl}">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -354,6 +415,24 @@
                         <Button x:Name="NodeDbResetButton" Content="{DynamicResource StrRaNodeDbResetBtn}"
                                 Width="200" HorizontalAlignment="Left"
                                 Click="NodeDbResetButton_Click"/>
+
+                        <Separator Margin="0,16,0,12"/>
+
+                        <!-- Remote node favorites management -->
+                        <TextBlock Text="{DynamicResource StrRaFavoritesSection}"
+                                   FontWeight="SemiBold" Margin="0,0,0,4"/>
+                        <TextBlock Text="{DynamicResource StrRaFavoritesDesc}"
+                                   TextWrapping="Wrap" Margin="0,0,0,10"
+                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+                        <ComboBox x:Name="FavoriteNodeCombo" Margin="0,0,0,8"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Button x:Name="AddFavoriteNodeButton"
+                                    Content="{DynamicResource StrRaFavoritesAdd}"
+                                    Width="160" Click="AddFavoriteNode_Click" Margin="0,0,8,0"/>
+                            <Button x:Name="RemoveFavoriteNodeButton"
+                                    Content="{DynamicResource StrRaFavoritesRemove}"
+                                    Width="160" Click="RemoveFavoriteNode_Click"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/MeshhessenClient/RemoteAdminWindow.xaml
+++ b/MeshhessenClient/RemoteAdminWindow.xaml
@@ -90,7 +90,8 @@
         </Border>
 
         <!-- Main content — disabled until connected -->
-        <TabControl x:Name="MainTabs" Grid.Row="2" IsEnabled="False">
+        <TabControl x:Name="MainTabs" Grid.Row="2" IsEnabled="False"
+                    SelectionChanged="MainTabs_SelectionChanged">
 
             <!-- Owner -->
             <TabItem Header="{DynamicResource StrRaTabOwner}">
@@ -443,6 +444,8 @@
         <Grid Grid.Row="3" Margin="0,12,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="8"/>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="8"/>
@@ -451,10 +454,14 @@
             <Button x:Name="RefreshButton" Grid.Column="0"
                     Content="{DynamicResource StrRaRefresh}"
                     Click="RefreshButton_Click" IsEnabled="False"/>
-            <Button x:Name="SaveButton" Grid.Column="2"
+            <Button x:Name="ReloadTabButton" Grid.Column="2"
+                    Content="{DynamicResource StrRaReloadTab}"
+                    Click="ReloadTabButton_Click" IsEnabled="False"
+                    ToolTip="{DynamicResource StrRaReloadTab}"/>
+            <Button x:Name="SaveButton" Grid.Column="4"
                     Content="{DynamicResource StrRaSave}"
                     Click="SaveButton_Click" IsEnabled="False"/>
-            <Button x:Name="CloseButton" Grid.Column="4"
+            <Button x:Name="CloseButton" Grid.Column="6"
                     Content="{DynamicResource StrClose}"
                     IsCancel="True" Click="CloseButton_Click"/>
         </Grid>

--- a/MeshhessenClient/RemoteAdminWindow.xaml.cs
+++ b/MeshhessenClient/RemoteAdminWindow.xaml.cs
@@ -24,6 +24,7 @@ public partial class RemoteAdminWindow : Window
     private BluetoothConfig? _loadedBt;
     private NetworkConfig? _loadedNetwork;
     private DisplayConfig? _loadedDisplay;
+    private SecurityConfig? _loadedSecurity;
     private readonly Channel?[] _loadedChannels = new Channel?[8];
 
     public RemoteAdminWindow(
@@ -43,6 +44,7 @@ public partial class RemoteAdminWindow : Window
         TimeoutBox.Text = (timeoutMs / 1000).ToString();
         _uiReady = true;
         UpdateFavoriteButton();
+        PopulateFavoriteNodeCombo();
 
         Loaded += async (_, _) => await ConnectAndLoadAsync();
     }
@@ -230,6 +232,20 @@ public partial class RemoteAdminWindow : Window
 
         await Task.Delay(200);
 
+        // Security config
+        var secResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = (uint)AdminMessage.Types.ConfigType.SecurityConfig },
+            _timeoutMs);
+        if (secResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            secResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Security)
+        {
+            _loadedSecurity = secResp.GetConfigResponse.Security;
+            Dispatcher.Invoke(() => ApplySecurityConfig(_loadedSecurity));
+        }
+
+        await Task.Delay(200);
+
         // Channels 0-7 — with one automatic retry per failed channel, plus per-row reload button
         Dispatcher.Invoke(() => ChannelsPanel.Children.Clear());
         for (int i = 0; i < 8; i++)
@@ -316,6 +332,39 @@ public partial class RemoteAdminWindow : Window
         DisplayFlipScreen.IsChecked = d.FlipScreen;
         SelectComboByTag(DisplayUnitsCombo, (int)d.Units);
         SelectComboByTag(OledTypeCombo, (int)d.Oled);
+    }
+
+    private void ApplySecurityConfig(SecurityConfig s)
+    {
+        SecPublicKey.Text = s.PublicKey != null && s.PublicKey.Length > 0
+            ? BitConverter.ToString(s.PublicKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
+            : string.Empty;
+
+        var keys = s.AdminKey.ToList();
+        SecAdminKey1.Text = keys.Count > 0 ? Convert.ToBase64String(keys[0].ToByteArray()) : string.Empty;
+        SecAdminKey2.Text = keys.Count > 1 ? Convert.ToBase64String(keys[1].ToByteArray()) : string.Empty;
+        SecAdminKey3.Text = keys.Count > 2 ? Convert.ToBase64String(keys[2].ToByteArray()) : string.Empty;
+
+        SecAdminChannelEnabled.IsChecked = s.AdminChannelEnabled;
+        SecIsManaged.IsChecked           = s.IsManaged;
+        SecSerialEnabled.IsChecked       = s.SerialEnabled;
+        SecDebugLogEnabled.IsChecked     = s.DebugLogApiEnabled;
+    }
+
+    private void PopulateFavoriteNodeCombo()
+    {
+        FavoriteNodeCombo.Items.Clear();
+        var nodes = _svc.GetKnownNodes()
+            .Where(kv => kv.Key != _targetNode.NodeId)
+            .OrderBy(kv => kv.Value.Name);
+        foreach (var kv in nodes)
+            FavoriteNodeCombo.Items.Add(new ComboBoxItem
+            {
+                Tag     = kv.Key,
+                Content = $"{kv.Value.Name}  (!{kv.Key:x8})"
+            });
+        if (FavoriteNodeCombo.Items.Count > 0)
+            FavoriteNodeCombo.SelectedIndex = 0;
     }
 
     private void AddOrUpdateChannelRow(int index, Channel? ch)
@@ -519,6 +568,29 @@ public partial class RemoteAdminWindow : Window
                 await Task.Delay(200);
             }
 
+            // Security config
+            if (_loadedSecurity != null)
+            {
+                var s = _loadedSecurity.Clone();
+                s.AdminChannelEnabled = SecAdminChannelEnabled.IsChecked == true;
+                s.IsManaged           = SecIsManaged.IsChecked           == true;
+                s.SerialEnabled       = SecSerialEnabled.IsChecked       == true;
+                s.DebugLogApiEnabled  = SecDebugLogEnabled.IsChecked     == true;
+
+                // Rebuild admin keys from the three text boxes
+                s.AdminKey.Clear();
+                foreach (var box in new[] { SecAdminKey1.Text.Trim(), SecAdminKey2.Text.Trim(), SecAdminKey3.Text.Trim() })
+                {
+                    if (string.IsNullOrEmpty(box)) continue;
+                    try { s.AdminKey.Add(Google.Protobuf.ByteString.CopyFrom(Convert.FromBase64String(box))); }
+                    catch { /* skip malformed key */ }
+                }
+
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetConfig = new Config { Security = s } });
+                await Task.Delay(200);
+            }
+
             await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
                 new AdminMessage { CommitEditSettings = true });
 
@@ -588,6 +660,28 @@ public partial class RemoteAdminWindow : Window
             _ = _svc.AddFavoriteNodeAsync(_targetNode.NodeId);
         else
             _ = _svc.RemoveFavoriteNodeAsync(_targetNode.NodeId);
+    }
+
+    private async void AddFavoriteNode_Click(object sender, RoutedEventArgs e)
+    {
+        if (FavoriteNodeCombo.SelectedItem is not ComboBoxItem item || item.Tag is not uint nodeId) return;
+        await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+            new AdminMessage { AddFavoriteNode = nodeId });
+        MessageBox.Show(
+            string.Format(Loc("StrRaFavoritesAdded"), item.Content),
+            Loc("StrRemoteAdminTitle"),
+            MessageBoxButton.OK, MessageBoxImage.Information);
+    }
+
+    private async void RemoveFavoriteNode_Click(object sender, RoutedEventArgs e)
+    {
+        if (FavoriteNodeCombo.SelectedItem is not ComboBoxItem item || item.Tag is not uint nodeId) return;
+        await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+            new AdminMessage { RemoveFavoriteNode = nodeId });
+        MessageBox.Show(
+            string.Format(Loc("StrRaFavoritesRemoved"), item.Content),
+            Loc("StrRemoteAdminTitle"),
+            MessageBoxButton.OK, MessageBoxImage.Information);
     }
 
     private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();

--- a/MeshhessenClient/RemoteAdminWindow.xaml.cs
+++ b/MeshhessenClient/RemoteAdminWindow.xaml.cs
@@ -1,0 +1,617 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Google.Protobuf;
+using Meshtastic.Protobufs;
+using MeshhessenClient.Services;
+using ModelNodeInfo = MeshhessenClient.Models.NodeInfo;
+
+namespace MeshhessenClient;
+
+public partial class RemoteAdminWindow : Window
+{
+    private readonly MeshtasticProtocolService _svc;
+    private readonly ModelNodeInfo _targetNode;
+    private int _timeoutMs;
+    private bool _isFavorite;
+    private bool _uiReady;
+
+    // Loaded config state
+    private User? _loadedOwner;
+    private DeviceConfig? _loadedDevice;
+    private PositionConfig? _loadedPosition;
+    private LoRaConfig? _loadedLora;
+    private BluetoothConfig? _loadedBt;
+    private NetworkConfig? _loadedNetwork;
+    private DisplayConfig? _loadedDisplay;
+    private readonly Channel?[] _loadedChannels = new Channel?[8];
+
+    public RemoteAdminWindow(
+        MeshtasticProtocolService svc,
+        ModelNodeInfo targetNode,
+        int timeoutMs = 30000,
+        bool isFavorite = false)
+    {
+        InitializeComponent();
+        _svc = svc;
+        _targetNode = targetNode;
+        _timeoutMs = timeoutMs;
+        _isFavorite = isFavorite;
+
+        NodeNameLabel.Text = targetNode.Name;
+        NodeIdLabel.Text = targetNode.Id;
+        TimeoutBox.Text = (timeoutMs / 1000).ToString();
+        _uiReady = true;
+        UpdateFavoriteButton();
+
+        Loaded += async (_, _) => await ConnectAndLoadAsync();
+    }
+
+    private void TimeoutBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (!_uiReady) return;
+        if (int.TryParse(TimeoutBox.Text, out int secs))
+            _timeoutMs = Math.Clamp(secs, 5, 300) * 1000;
+    }
+
+    private string Loc(string key) =>
+        Application.Current.TryFindResource(key) as string ?? key;
+
+    private void UpdateFavoriteButton()
+    {
+        FavoriteButton.Foreground = _isFavorite
+            ? new SolidColorBrush(Color.FromRgb(0xFF, 0xC1, 0x07))
+            : new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x80));
+        FavoriteButton.ToolTip = _isFavorite
+            ? Loc("StrUnfavorite")
+            : Loc("StrFavorite");
+    }
+
+    private void SetStatus(string textKey, string dotColor = "#9E9E9E")
+    {
+        Dispatcher.Invoke(() =>
+        {
+            StatusLabel.Text = Loc(textKey);
+            StatusDot.Fill = new SolidColorBrush((Color)ColorConverter.ConvertFromString(dotColor));
+        });
+    }
+
+    // ===== Connect + Load =====
+
+    private async Task ConnectAndLoadAsync()
+    {
+        SetStatus("StrRemoteAdminConnecting");
+
+        // Step 1: Request device metadata (checks connectivity and admin permission)
+        var metaResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetDeviceMetadataRequest = true },
+            _timeoutMs);
+
+        if (metaResp == null)
+        {
+            SetStatus("StrRemoteAdminTimeout", "#F44336");
+            Dispatcher.Invoke(() =>
+            {
+                StatusLabel.Text = Loc("StrRemoteAdminTimeout");
+                MessageBox.Show(
+                    Loc("StrRemoteAdminTimeoutMsg"),
+                    Loc("StrRemoteAdminTitle"),
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            });
+            return;
+        }
+
+        if (metaResp.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetDeviceMetadataResponse)
+        {
+            var meta = metaResp.GetDeviceMetadataResponse;
+            Dispatcher.Invoke(() =>
+            {
+                FirmwareLabel.Text = meta.FirmwareVersion ?? "-";
+                HardwareLabel.Text = meta.HwModel != HardwareModel.Unset ? meta.HwModel.ToString() : "-";
+                HopsLabel.Text = _targetNode.Snr != "-" ? _targetNode.Snr : "-";
+            });
+        }
+
+        // Step 2: Get session key
+        await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = 8 }, // 8 = SESSIONKEY_CONFIG
+            _timeoutMs);
+
+        SetStatus("StrRemoteAdminLoading", "#2196F3");
+
+        // Step 3: Load all configs in sequence
+        await LoadAllConfigsAsync();
+
+        SetStatus("StrRemoteAdminConnected", "#4CAF50");
+        Dispatcher.Invoke(() =>
+        {
+            MainTabs.IsEnabled = true;
+            SaveButton.IsEnabled = true;
+            RefreshButton.IsEnabled = true;
+        });
+    }
+
+    private async Task LoadAllConfigsAsync()
+    {
+        // Owner
+        var ownerResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetOwnerRequest = true }, _timeoutMs);
+        if (ownerResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetOwnerResponse)
+        {
+            _loadedOwner = ownerResp.GetOwnerResponse;
+            Dispatcher.Invoke(() => ApplyOwner(_loadedOwner));
+        }
+
+        await Task.Delay(200);
+
+        // Device config
+        var deviceResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = 0 },
+            _timeoutMs);
+        if (deviceResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            deviceResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Device)
+        {
+            _loadedDevice = deviceResp.GetConfigResponse.Device;
+            Dispatcher.Invoke(() => ApplyDeviceConfig(_loadedDevice));
+        }
+
+        await Task.Delay(200);
+
+        // Position config
+        var posResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = 1 },
+            _timeoutMs);
+        if (posResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            posResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Position)
+        {
+            _loadedPosition = posResp.GetConfigResponse.Position;
+            Dispatcher.Invoke(() => ApplyPositionConfig(_loadedPosition));
+        }
+
+        await Task.Delay(200);
+
+        // LoRa config
+        var loraResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = 5 },
+            _timeoutMs);
+        if (loraResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            loraResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Lora)
+        {
+            _loadedLora = loraResp.GetConfigResponse.Lora;
+            Dispatcher.Invoke(() => ApplyLoraConfig(_loadedLora));
+        }
+
+        await Task.Delay(200);
+
+        // Bluetooth config
+        var btResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = 6 },
+            _timeoutMs);
+        if (btResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            btResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Bluetooth)
+        {
+            _loadedBt = btResp.GetConfigResponse.Bluetooth;
+            Dispatcher.Invoke(() => ApplyBluetoothConfig(_loadedBt));
+        }
+
+        await Task.Delay(200);
+
+        // Network config
+        var netResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = 3 },
+            _timeoutMs);
+        if (netResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            netResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Network)
+        {
+            _loadedNetwork = netResp.GetConfigResponse.Network;
+            Dispatcher.Invoke(() => ApplyNetworkConfig(_loadedNetwork));
+        }
+
+        await Task.Delay(200);
+
+        // Display config
+        var dispResp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = 4 },
+            _timeoutMs);
+        if (dispResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            dispResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Display)
+        {
+            _loadedDisplay = dispResp.GetConfigResponse.Display;
+            Dispatcher.Invoke(() => ApplyDisplayConfig(_loadedDisplay));
+        }
+
+        await Task.Delay(200);
+
+        // Channels 0-7 — with one automatic retry per failed channel, plus per-row reload button
+        Dispatcher.Invoke(() => ChannelsPanel.Children.Clear());
+        for (int i = 0; i < 8; i++)
+        {
+            await LoadSingleChannelAsync(i);
+            await Task.Delay(180);
+        }
+    }
+
+    private async Task LoadSingleChannelAsync(int index)
+    {
+        // Try twice — remote channel gets can be lossy
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            var chResp = await _svc.SendRemoteAdminRequestAsync(
+                _targetNode.NodeId,
+                new AdminMessage { GetChannelRequest = (uint)index },
+                _timeoutMs);
+            if (chResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetChannelResponse)
+            {
+                _loadedChannels[index] = chResp.GetChannelResponse;
+                var ch = chResp.GetChannelResponse;
+                Dispatcher.Invoke(() => AddOrUpdateChannelRow(index, ch));
+                return;
+            }
+            if (attempt == 0) await Task.Delay(400);
+        }
+        // Still failed — insert placeholder row so user can retry
+        Dispatcher.Invoke(() => AddOrUpdateChannelRow(index, null));
+    }
+
+    // ===== Apply config to UI =====
+
+    private void ApplyOwner(User u)
+    {
+        OwnerShortName.Text = u.ShortName ?? "";
+        OwnerLongName.Text  = u.LongName  ?? "";
+        OwnerLicensed.IsChecked = u.IsLicensed;
+    }
+
+    private void ApplyDeviceConfig(DeviceConfig d)
+    {
+        SelectComboByTag(DeviceRoleCombo, (int)d.Role);
+        DeviceNodeInfoInterval.Text = d.NodeInfoBroadcastSecs.ToString();
+    }
+
+    private void ApplyPositionConfig(PositionConfig p)
+    {
+        SelectComboByTag(PosGpsMode, (int)p.GpsMode);
+        PosBroadcastInterval.Text = p.PositionBroadcastSecs.ToString();
+        PosBroadcastSmart.IsChecked = p.PositionBroadcastSmartEnabled;
+        PosFixedEnabled.IsChecked = p.FixedPosition;
+        // Fixed position lat/lon/alt are stored separately — enter manually to override
+    }
+
+    private void ApplyLoraConfig(LoRaConfig l)
+    {
+        SelectComboByTag(LoraRegionCombo, (int)l.Region);
+        SelectComboByTag(LoraPresetCombo, (int)l.ModemPreset);
+        LoraHopLimit.Text  = l.HopLimit.ToString();
+        LoraTxPower.Text   = l.TxPower.ToString();
+        LoraTxEnabled.IsChecked = l.TxEnabled;
+    }
+
+    private void ApplyBluetoothConfig(BluetoothConfig b)
+    {
+        BtEnabled.IsChecked = b.Enabled;
+        SelectComboByTag(BtModeCombo, (int)b.Mode);
+        BtPin.Text = b.FixedPin.ToString();
+    }
+
+    private void ApplyNetworkConfig(NetworkConfig n)
+    {
+        WifiEnabled.IsChecked  = n.WifiEnabled;
+        WifiSsid.Text          = n.WifiSsid ?? "";
+        WifiPsk.Password       = n.WifiPsk  ?? "";
+        EthEnabled.IsChecked   = n.EthEnabled;
+        NtpServer.Text         = n.NtpServer ?? "";
+    }
+
+    private void ApplyDisplayConfig(DisplayConfig d)
+    {
+        DisplayTimeout.Text  = d.ScreenOnSecs.ToString();
+        DisplayFlipScreen.IsChecked = d.FlipScreen;
+        SelectComboByTag(DisplayUnitsCombo, (int)d.Units);
+        SelectComboByTag(OledTypeCombo, (int)d.Oled);
+    }
+
+    private void AddOrUpdateChannelRow(int index, Channel? ch)
+    {
+        // Remove old row for this index if present
+        var old = ChannelsPanel.Children.OfType<Border>()
+            .FirstOrDefault(b => b.Tag is int t && t == index);
+        if (old != null) ChannelsPanel.Children.Remove(old);
+
+        var border = new Border
+        {
+            Tag = index,
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            Padding = new Thickness(0, 6, 0, 6),
+            Margin  = new Thickness(0, 0, 0, 2)
+        };
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(40) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(80) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(28) });
+
+        void AddCell(int col, string text, bool bold = false, Brush? fg = null)
+        {
+            var tb = new TextBlock
+            {
+                Text = text,
+                VerticalAlignment = VerticalAlignment.Center,
+                FontWeight = bold ? FontWeights.SemiBold : FontWeights.Normal,
+            };
+            if (fg != null) tb.Foreground = fg;
+            Grid.SetColumn(tb, col);
+            grid.Children.Add(tb);
+        }
+
+        if (ch == null)
+        {
+            var failBrush = new SolidColorBrush(Color.FromRgb(240, 76, 76));
+            AddCell(0, index.ToString(), true, failBrush);
+            AddCell(1, "—", fg: failBrush);
+            AddCell(2, Loc("StrRemoteAdminChannelFailed"), fg: failBrush);
+            AddCell(3, "", fg: failBrush);
+        }
+        else
+        {
+            var name = ch.Settings?.Name ?? "";
+            var psk  = ch.Settings?.Psk != null ? Convert.ToBase64String(ch.Settings.Psk.ToByteArray()) : "";
+            var role = ch.Role.ToString();
+            AddCell(0, index.ToString(), true);
+            AddCell(1, role);
+            AddCell(2, name);
+            AddCell(3, psk.Length > 0 ? $"PSK: {psk[..Math.Min(16, psk.Length)]}…" : "(no PSK)");
+        }
+
+        // Per-channel reload button
+        var reloadBtn = new Button
+        {
+            Content = "⟳",
+            Width = 24,
+            Height = 22,
+            FontSize = 13,
+            Padding = new Thickness(0),
+            ToolTip = Loc("StrRemoteAdminChannelReload"),
+            Tag = index,
+            Cursor = System.Windows.Input.Cursors.Hand,
+        };
+        reloadBtn.Click += async (_, _) => await ReloadSingleChannelAsync(index);
+        Grid.SetColumn(reloadBtn, 4);
+        grid.Children.Add(reloadBtn);
+
+        border.Child = grid;
+        ChannelsPanel.Children.Add(border);
+    }
+
+    private async Task ReloadSingleChannelAsync(int index)
+    {
+        SetStatus("StrRemoteAdminLoading", "#2196F3");
+        await LoadSingleChannelAsync(index);
+        SetStatus("StrRemoteAdminConnected", "#4CAF50");
+    }
+
+    // ===== Save =====
+
+    private async void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        SaveButton.IsEnabled = false;
+        SetStatus("StrRemoteAdminSaving", "#FF9800");
+
+        try
+        {
+            await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                new AdminMessage { BeginEditSettings = true });
+            await Task.Delay(300);
+
+            // Owner
+            if (_loadedOwner != null)
+            {
+                var newOwner = _loadedOwner.Clone();
+                newOwner.ShortName  = OwnerShortName.Text.Trim();
+                newOwner.LongName   = OwnerLongName.Text.Trim();
+                newOwner.IsLicensed = OwnerLicensed.IsChecked == true;
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetOwner = newOwner });
+                await Task.Delay(200);
+            }
+
+            // Device config
+            if (_loadedDevice != null)
+            {
+                var d = _loadedDevice.Clone();
+                d.Role = (Role)(GetComboTag(DeviceRoleCombo) ?? 0);
+                if (uint.TryParse(DeviceNodeInfoInterval.Text, out var ni)) d.NodeInfoBroadcastSecs = ni;
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetConfig = new Config { Device = d } });
+                await Task.Delay(200);
+            }
+
+            // Position config
+            if (_loadedPosition != null)
+            {
+                var p = _loadedPosition.Clone();
+                p.GpsMode = (GpsMode)(GetComboTag(PosGpsMode) ?? 1);
+                if (uint.TryParse(PosBroadcastInterval.Text, out var pi)) p.PositionBroadcastSecs = pi;
+                p.PositionBroadcastSmartEnabled = PosBroadcastSmart.IsChecked == true;
+                p.FixedPosition = PosFixedEnabled.IsChecked == true;
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetConfig = new Config { Position = p } });
+                await Task.Delay(200);
+
+                // Fixed position coordinates sent via set_position
+                if (p.FixedPosition &&
+                    double.TryParse(PosFixedLat.Text, System.Globalization.NumberStyles.Any,
+                        System.Globalization.CultureInfo.InvariantCulture, out var lat) &&
+                    double.TryParse(PosFixedLon.Text, System.Globalization.NumberStyles.Any,
+                        System.Globalization.CultureInfo.InvariantCulture, out var lon) &&
+                    int.TryParse(PosFixedAlt.Text, out var alt))
+                {
+                    await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                        new AdminMessage { SetPosition = new Position
+                        {
+                            LatitudeI  = (int)(lat * 1e7),
+                            LongitudeI = (int)(lon * 1e7),
+                            Altitude   = alt
+                        }});
+                    await Task.Delay(200);
+                }
+            }
+
+            // LoRa config
+            if (_loadedLora != null)
+            {
+                var l = _loadedLora.Clone();
+                l.Region      = (Region)(GetComboTag(LoraRegionCombo) ?? 0);
+                l.ModemPreset = (ModemPreset)(GetComboTag(LoraPresetCombo) ?? 0);
+                if (uint.TryParse(LoraHopLimit.Text, out var hl)) l.HopLimit = hl;
+                if (int.TryParse(LoraTxPower.Text, out var tp))   l.TxPower  = tp;
+                l.TxEnabled = LoraTxEnabled.IsChecked == true;
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetConfig = new Config { Lora = l } });
+                await Task.Delay(200);
+            }
+
+            // Bluetooth config
+            if (_loadedBt != null)
+            {
+                var b = _loadedBt.Clone();
+                b.Enabled = BtEnabled.IsChecked == true;
+                b.Mode    = (uint)(GetComboTag(BtModeCombo) ?? 0);
+                if (uint.TryParse(BtPin.Text, out var pin)) b.FixedPin = pin;
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetConfig = new Config { Bluetooth = b } });
+                await Task.Delay(200);
+            }
+
+            // Network config
+            if (_loadedNetwork != null)
+            {
+                var n = _loadedNetwork.Clone();
+                n.WifiEnabled = WifiEnabled.IsChecked == true;
+                n.WifiSsid    = WifiSsid.Text.Trim();
+                n.WifiPsk     = WifiPsk.Password;
+                n.EthEnabled  = EthEnabled.IsChecked == true;
+                n.NtpServer   = NtpServer.Text.Trim();
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetConfig = new Config { Network = n } });
+                await Task.Delay(200);
+            }
+
+            // Display config
+            if (_loadedDisplay != null)
+            {
+                var d = _loadedDisplay.Clone();
+                if (uint.TryParse(DisplayTimeout.Text, out var dto)) d.ScreenOnSecs = dto;
+                d.FlipScreen = DisplayFlipScreen.IsChecked == true;
+                d.Units    = (uint)(GetComboTag(DisplayUnitsCombo) ?? 0);
+                d.Oled     = (uint)(GetComboTag(OledTypeCombo) ?? 0);
+                await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                    new AdminMessage { SetConfig = new Config { Display = d } });
+                await Task.Delay(200);
+            }
+
+            await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+                new AdminMessage { CommitEditSettings = true });
+
+            SetStatus("StrRemoteAdminSaved", "#4CAF50");
+            Dispatcher.Invoke(() => MessageBox.Show(
+                Loc("StrRemoteAdminSavedMsg"), Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.OK, MessageBoxImage.Information));
+        }
+        catch (Exception ex)
+        {
+            SetStatus("StrRemoteAdminError", "#F44336");
+            Dispatcher.Invoke(() => MessageBox.Show(
+                $"{Loc("StrRemoteAdminErrorMsg")}\n{ex.Message}", Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.OK, MessageBoxImage.Error));
+        }
+        finally
+        {
+            Dispatcher.Invoke(() => SaveButton.IsEnabled = true);
+        }
+    }
+
+    private async void RefreshButton_Click(object sender, RoutedEventArgs e)
+    {
+        RefreshButton.IsEnabled = false;
+        SaveButton.IsEnabled = false;
+        MainTabs.IsEnabled = false;
+        _svc.ClearRemoteSessionKey(_targetNode.NodeId);
+        await ConnectAndLoadAsync();
+    }
+
+    // ===== Control tab =====
+
+    private async void RebootButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (MessageBox.Show(Loc("StrRemoteAdminRebootConfirm"), Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes) return;
+        await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+            new AdminMessage { RebootSeconds = 3 });
+        SetStatus("StrRemoteAdminRebooting", "#FF9800");
+    }
+
+    private async void ShutdownButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (MessageBox.Show(Loc("StrRemoteAdminShutdownConfirm"), Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes) return;
+        await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+            new AdminMessage { ShutdownSeconds = 3 });
+        SetStatus("StrRemoteAdminShutdown", "#9E9E9E");
+    }
+
+    private async void NodeDbResetButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (MessageBox.Show(Loc("StrRemoteAdminNodeDbResetConfirm"), Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes) return;
+        await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
+            new AdminMessage { NodedbReset = true });
+    }
+
+    // ===== Favorite button =====
+
+    private void FavoriteButton_Click(object sender, RoutedEventArgs e)
+    {
+        _isFavorite = !_isFavorite;
+        UpdateFavoriteButton();
+
+        if (_isFavorite)
+            _ = _svc.AddFavoriteNodeAsync(_targetNode.NodeId);
+        else
+            _ = _svc.RemoveFavoriteNodeAsync(_targetNode.NodeId);
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+
+    // ===== Helpers =====
+
+    private static void SelectComboByTag(ComboBox combo, int tagValue)
+    {
+        foreach (ComboBoxItem item in combo.Items)
+        {
+            if (item.Tag is string ts && int.TryParse(ts, out int tv) && tv == tagValue)
+            {
+                combo.SelectedItem = item;
+                return;
+            }
+        }
+        if (combo.Items.Count > 0) combo.SelectedIndex = 0;
+    }
+
+    private static int? GetComboTag(ComboBox combo)
+    {
+        if (combo.SelectedItem is ComboBoxItem item && item.Tag is string ts &&
+            int.TryParse(ts, out int v))
+            return v;
+        return null;
+    }
+}

--- a/MeshhessenClient/RemoteAdminWindow.xaml.cs
+++ b/MeshhessenClient/RemoteAdminWindow.xaml.cs
@@ -78,6 +78,15 @@ public partial class RemoteAdminWindow : Window
         });
     }
 
+    private void SetStatusStep(string name, int step, int total)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            StatusLabel.Text = $"{name} ({step}/{total})";
+            StatusDot.Fill = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#2196F3"));
+        });
+    }
+
     // ===== Connect + Load =====
 
     private async Task ConnectAndLoadAsync()
@@ -121,6 +130,8 @@ public partial class RemoteAdminWindow : Window
             new AdminMessage { GetConfigRequest = 8 }, // 8 = SESSIONKEY_CONFIG
             _timeoutMs);
 
+        // Enable tabs immediately so sections become visible as each config loads
+        Dispatcher.Invoke(() => MainTabs.IsEnabled = true);
         SetStatus("StrRemoteAdminLoading", "#2196F3");
 
         // Step 3: Load all configs in sequence
@@ -129,7 +140,6 @@ public partial class RemoteAdminWindow : Window
         SetStatus("StrRemoteAdminConnected", "#4CAF50");
         Dispatcher.Invoke(() =>
         {
-            MainTabs.IsEnabled = true;
             SaveButton.IsEnabled = true;
             RefreshButton.IsEnabled = true;
         });
@@ -137,7 +147,10 @@ public partial class RemoteAdminWindow : Window
 
     private async Task LoadAllConfigsAsync()
     {
+        const int total = 16; // 8 configs + 8 channels
+
         // Owner
+        SetStatusStep("Besitzer", 1, total);
         var ownerResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId, new AdminMessage { GetOwnerRequest = true }, _timeoutMs);
         if (ownerResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetOwnerResponse)
@@ -149,6 +162,7 @@ public partial class RemoteAdminWindow : Window
         await Task.Delay(200);
 
         // Device config
+        SetStatusStep("Gerätekonfiguration", 2, total);
         var deviceResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId,
             new AdminMessage { GetConfigRequest = 0 },
@@ -163,6 +177,7 @@ public partial class RemoteAdminWindow : Window
         await Task.Delay(200);
 
         // Position config
+        SetStatusStep("Positionskonfiguration", 3, total);
         var posResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId,
             new AdminMessage { GetConfigRequest = 1 },
@@ -177,6 +192,7 @@ public partial class RemoteAdminWindow : Window
         await Task.Delay(200);
 
         // LoRa config
+        SetStatusStep("LoRa-Konfiguration", 4, total);
         var loraResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId,
             new AdminMessage { GetConfigRequest = 5 },
@@ -191,6 +207,7 @@ public partial class RemoteAdminWindow : Window
         await Task.Delay(200);
 
         // Bluetooth config
+        SetStatusStep("Bluetooth-Konfiguration", 5, total);
         var btResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId,
             new AdminMessage { GetConfigRequest = 6 },
@@ -205,6 +222,7 @@ public partial class RemoteAdminWindow : Window
         await Task.Delay(200);
 
         // Network config
+        SetStatusStep("Netzwerkkonfiguration", 6, total);
         var netResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId,
             new AdminMessage { GetConfigRequest = 3 },
@@ -219,6 +237,7 @@ public partial class RemoteAdminWindow : Window
         await Task.Delay(200);
 
         // Display config
+        SetStatusStep("Displaykonfiguration", 7, total);
         var dispResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId,
             new AdminMessage { GetConfigRequest = 4 },
@@ -233,6 +252,7 @@ public partial class RemoteAdminWindow : Window
         await Task.Delay(200);
 
         // Security config
+        SetStatusStep("Sicherheitskonfiguration", 8, total);
         var secResp = await _svc.SendRemoteAdminRequestAsync(
             _targetNode.NodeId,
             new AdminMessage { GetConfigRequest = (uint)AdminMessage.Types.ConfigType.SecurityConfig },
@@ -250,6 +270,7 @@ public partial class RemoteAdminWindow : Window
         Dispatcher.Invoke(() => ChannelsPanel.Children.Clear());
         for (int i = 0; i < 8; i++)
         {
+            SetStatusStep($"Kanal {i}", 8 + i + 1, total);
             await LoadSingleChannelAsync(i);
             await Task.Delay(180);
         }

--- a/MeshhessenClient/RemoteAdminWindow.xaml.cs
+++ b/MeshhessenClient/RemoteAdminWindow.xaml.cs
@@ -389,7 +389,7 @@ public partial class RemoteAdminWindow : Window
         {
             var chResp = await _svc.SendRemoteAdminRequestAsync(
                 _targetNode.NodeId,
-                new AdminMessage { GetChannelRequest = (uint)index },
+                new AdminMessage { GetChannelRequest = (uint)(index + 1) }, // Protocol is 1-based: 1 = ch0, 2 = ch1 …
                 _timeoutMs);
 
             if (chResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetChannelResponse)

--- a/MeshhessenClient/RemoteAdminWindow.xaml.cs
+++ b/MeshhessenClient/RemoteAdminWindow.xaml.cs
@@ -831,7 +831,7 @@ public partial class RemoteAdminWindow : Window
     {
         if (FavoriteNodeCombo.SelectedItem is not ComboBoxItem item || item.Tag is not uint nodeId) return;
         await _svc.SendRemoteAdminWriteAsync(_targetNode.NodeId,
-            new AdminMessage { AddFavoriteNode = nodeId });
+            new AdminMessage { SetFavoriteNode = nodeId }); // field 39
         MessageBox.Show(
             string.Format(Loc("StrRaFavoritesAdded"), item.Content),
             Loc("StrRemoteAdminTitle"),

--- a/MeshhessenClient/RemoteAdminWindow.xaml.cs
+++ b/MeshhessenClient/RemoteAdminWindow.xaml.cs
@@ -381,8 +381,11 @@ public partial class RemoteAdminWindow : Window
 
     private async Task LoadSingleChannelAsync(int index)
     {
-        // Try up to 3 times — remote channel responses can be lossy or arrive out of order
-        for (int attempt = 0; attempt < 3; attempt++)
+        // Try twice — remote channel responses can be lossy.
+        // NOTE: ch.Index in the response is often 0 (firmware default) even for non-zero
+        // channels, so we do NOT validate it against the requested index — we simply trust
+        // that the response belongs to the channel we just asked for.
+        for (int attempt = 0; attempt < 2; attempt++)
         {
             var chResp = await _svc.SendRemoteAdminRequestAsync(
                 _targetNode.NodeId,
@@ -392,24 +395,12 @@ public partial class RemoteAdminWindow : Window
             if (chResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetChannelResponse)
             {
                 var ch = chResp.GetChannelResponse;
-                int actualIndex = ch.Index; // Use the index from the response, not the requested one
-
-                // If a stale response for a different channel arrived, store it in the correct slot
-                // and retry for the originally requested index
-                if (actualIndex != index && actualIndex >= 0 && actualIndex < 8)
-                {
-                    _loadedChannels[actualIndex] = ch;
-                    Dispatcher.Invoke(() => AddOrUpdateChannelRow(actualIndex, ch));
-                    await Task.Delay(300);
-                    continue; // Retry for the requested index
-                }
-
                 _loadedChannels[index] = ch;
                 Dispatcher.Invoke(() => AddOrUpdateChannelRow(index, ch));
                 return;
             }
 
-            if (attempt < 2) await Task.Delay(400);
+            if (attempt == 0) await Task.Delay(400);
         }
         // Still failed — insert placeholder row so user can retry
         Dispatcher.Invoke(() => AddOrUpdateChannelRow(index, null));

--- a/MeshhessenClient/RemoteAdminWindow.xaml.cs
+++ b/MeshhessenClient/RemoteAdminWindow.xaml.cs
@@ -15,6 +15,8 @@ public partial class RemoteAdminWindow : Window
     private int _timeoutMs;
     private bool _isFavorite;
     private bool _uiReady;
+    private bool _lazyMode;
+    private readonly HashSet<string> _loadedSections = new();
 
     // Loaded config state
     private User? _loadedOwner;
@@ -92,6 +94,7 @@ public partial class RemoteAdminWindow : Window
     private async Task ConnectAndLoadAsync()
     {
         SetStatus("StrRemoteAdminConnecting");
+        _loadedSections.Clear();
 
         // Step 1: Request device metadata (checks connectivity and admin permission)
         var metaResp = await _svc.SendRemoteAdminRequestAsync(
@@ -130,147 +133,247 @@ public partial class RemoteAdminWindow : Window
             new AdminMessage { GetConfigRequest = 8 }, // 8 = SESSIONKEY_CONFIG
             _timeoutMs);
 
-        // Enable tabs immediately so sections become visible as each config loads
+        // Enable tabs so user can navigate
         Dispatcher.Invoke(() => MainTabs.IsEnabled = true);
-        SetStatus("StrRemoteAdminLoading", "#2196F3");
 
-        // Step 3: Load all configs in sequence
-        await LoadAllConfigsAsync();
+        // Step 3: Ask user — load everything now, or page by page?
+        var loadAll = Dispatcher.Invoke(() =>
+            MessageBox.Show(
+                Loc("StrRaLoadAllQuestion"),
+                Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question) == MessageBoxResult.Yes);
+
+        if (loadAll)
+        {
+            _lazyMode = false;
+            SetStatus("StrRemoteAdminLoading", "#2196F3");
+            await LoadAllConfigsAsync();
+        }
+        else
+        {
+            _lazyMode = true;
+            // Load only the currently visible tab
+            await LoadCurrentTabAsync();
+        }
 
         SetStatus("StrRemoteAdminConnected", "#4CAF50");
         Dispatcher.Invoke(() =>
         {
             SaveButton.IsEnabled = true;
             RefreshButton.IsEnabled = true;
+            ReloadTabButton.IsEnabled = true;
         });
     }
 
+    // ===== Lazy tab loading =====
+
+    private async Task LoadCurrentTabAsync()
+    {
+        var tabIndex = Dispatcher.Invoke(() => MainTabs.SelectedIndex);
+        await LoadTabByIndexAsync(tabIndex, force: false);
+    }
+
+    private async Task LoadTabByIndexAsync(int tabIndex, bool force = false)
+    {
+        var section = GetTabSection(tabIndex);
+        if (section == null) return; // Control tab — nothing to load
+        if (!force && _loadedSections.Contains(section)) return; // Already loaded
+
+        SetStatus("StrRemoteAdminLoading", "#2196F3");
+
+        switch (section)
+        {
+            case "owner":     await LoadOwnerSectionAsync(); break;
+            case "device":    await LoadDeviceSectionAsync(); break;
+            case "position":  await LoadPositionSectionAsync(); break;
+            case "lora":      await LoadLoraSectionAsync(); break;
+            case "bluetooth": await LoadBluetoothSectionAsync(); break;
+            case "network":   await LoadNetworkSectionAsync(); break;
+            case "display":   await LoadDisplaySectionAsync(); break;
+            case "channels":
+                Dispatcher.Invoke(() => ChannelsPanel.Children.Clear());
+                await LoadChannelsSectionAsync();
+                break;
+            case "security":  await LoadSecuritySectionAsync(); break;
+        }
+
+        _loadedSections.Add(section);
+        SetStatus("StrRemoteAdminConnected", "#4CAF50");
+    }
+
+    private static string? GetTabSection(int tabIndex) => tabIndex switch
+    {
+        0 => "owner",
+        1 => "device",
+        2 => "position",
+        3 => "lora",
+        4 => "bluetooth",
+        5 => "network",
+        6 => "display",
+        7 => "channels",
+        8 => "security",
+        _ => null // Control tab (9)
+    };
+
+    private async void MainTabs_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!_lazyMode || !MainTabs.IsEnabled) return;
+        await LoadTabByIndexAsync(MainTabs.SelectedIndex, force: false);
+    }
+
+    // ===== Full load (all sections sequentially) =====
+
     private async Task LoadAllConfigsAsync()
     {
-        const int total = 16; // 8 configs + 8 channels
+        const int total = 17; // 9 config sections + 8 channels
 
-        // Owner
-        SetStatusStep("Besitzer", 1, total);
-        var ownerResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId, new AdminMessage { GetOwnerRequest = true }, _timeoutMs);
-        if (ownerResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetOwnerResponse)
-        {
-            _loadedOwner = ownerResp.GetOwnerResponse;
-            Dispatcher.Invoke(() => ApplyOwner(_loadedOwner));
-        }
-
+        SetStatusStep(Loc("StrRaTabOwner"), 1, total);
+        await LoadOwnerSectionAsync(); _loadedSections.Add("owner");
         await Task.Delay(200);
 
-        // Device config
-        SetStatusStep("Gerätekonfiguration", 2, total);
-        var deviceResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId,
-            new AdminMessage { GetConfigRequest = 0 },
-            _timeoutMs);
-        if (deviceResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
-            deviceResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Device)
-        {
-            _loadedDevice = deviceResp.GetConfigResponse.Device;
-            Dispatcher.Invoke(() => ApplyDeviceConfig(_loadedDevice));
-        }
-
+        SetStatusStep(Loc("StrRaTabDevice"), 2, total);
+        await LoadDeviceSectionAsync(); _loadedSections.Add("device");
         await Task.Delay(200);
 
-        // Position config
-        SetStatusStep("Positionskonfiguration", 3, total);
-        var posResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId,
-            new AdminMessage { GetConfigRequest = 1 },
-            _timeoutMs);
-        if (posResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
-            posResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Position)
-        {
-            _loadedPosition = posResp.GetConfigResponse.Position;
-            Dispatcher.Invoke(() => ApplyPositionConfig(_loadedPosition));
-        }
-
+        SetStatusStep(Loc("StrRaTabPosition"), 3, total);
+        await LoadPositionSectionAsync(); _loadedSections.Add("position");
         await Task.Delay(200);
 
-        // LoRa config
-        SetStatusStep("LoRa-Konfiguration", 4, total);
-        var loraResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId,
-            new AdminMessage { GetConfigRequest = 5 },
-            _timeoutMs);
-        if (loraResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
-            loraResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Lora)
-        {
-            _loadedLora = loraResp.GetConfigResponse.Lora;
-            Dispatcher.Invoke(() => ApplyLoraConfig(_loadedLora));
-        }
-
+        SetStatusStep(Loc("StrRaTabLora"), 4, total);
+        await LoadLoraSectionAsync(); _loadedSections.Add("lora");
         await Task.Delay(200);
 
-        // Bluetooth config
-        SetStatusStep("Bluetooth-Konfiguration", 5, total);
-        var btResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId,
-            new AdminMessage { GetConfigRequest = 6 },
-            _timeoutMs);
-        if (btResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
-            btResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Bluetooth)
-        {
-            _loadedBt = btResp.GetConfigResponse.Bluetooth;
-            Dispatcher.Invoke(() => ApplyBluetoothConfig(_loadedBt));
-        }
-
+        SetStatusStep(Loc("StrRaTabBluetooth"), 5, total);
+        await LoadBluetoothSectionAsync(); _loadedSections.Add("bluetooth");
         await Task.Delay(200);
 
-        // Network config
-        SetStatusStep("Netzwerkkonfiguration", 6, total);
-        var netResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId,
-            new AdminMessage { GetConfigRequest = 3 },
-            _timeoutMs);
-        if (netResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
-            netResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Network)
-        {
-            _loadedNetwork = netResp.GetConfigResponse.Network;
-            Dispatcher.Invoke(() => ApplyNetworkConfig(_loadedNetwork));
-        }
-
+        SetStatusStep(Loc("StrRaTabNetwork"), 6, total);
+        await LoadNetworkSectionAsync(); _loadedSections.Add("network");
         await Task.Delay(200);
 
-        // Display config
-        SetStatusStep("Displaykonfiguration", 7, total);
-        var dispResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId,
-            new AdminMessage { GetConfigRequest = 4 },
-            _timeoutMs);
-        if (dispResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
-            dispResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Display)
-        {
-            _loadedDisplay = dispResp.GetConfigResponse.Display;
-            Dispatcher.Invoke(() => ApplyDisplayConfig(_loadedDisplay));
-        }
-
+        SetStatusStep(Loc("StrRaTabDisplay"), 7, total);
+        await LoadDisplaySectionAsync(); _loadedSections.Add("display");
         await Task.Delay(200);
 
-        // Security config
-        SetStatusStep("Sicherheitskonfiguration", 8, total);
-        var secResp = await _svc.SendRemoteAdminRequestAsync(
-            _targetNode.NodeId,
-            new AdminMessage { GetConfigRequest = (uint)AdminMessage.Types.ConfigType.SecurityConfig },
-            _timeoutMs);
-        if (secResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
-            secResp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Security)
-        {
-            _loadedSecurity = secResp.GetConfigResponse.Security;
-            Dispatcher.Invoke(() => ApplySecurityConfig(_loadedSecurity));
-        }
-
+        SetStatusStep(Loc("StrRaTabSecurity"), 8, total);
+        await LoadSecuritySectionAsync(); _loadedSections.Add("security");
         await Task.Delay(200);
 
-        // Channels 0-7 — with one automatic retry per failed channel, plus per-row reload button
+        // Channels 0–7
         Dispatcher.Invoke(() => ChannelsPanel.Children.Clear());
         for (int i = 0; i < 8; i++)
         {
-            SetStatusStep($"Kanal {i}", 8 + i + 1, total);
+            SetStatusStep($"{Loc("StrRaTabChannels")} {i}", 9 + i, total);
+            await LoadSingleChannelAsync(i);
+            await Task.Delay(180);
+        }
+        _loadedSections.Add("channels");
+    }
+
+    // ===== Individual section loaders =====
+
+    private async Task LoadOwnerSectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetOwnerRequest = true }, _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetOwnerResponse)
+        {
+            _loadedOwner = resp.GetOwnerResponse;
+            Dispatcher.Invoke(() => ApplyOwner(_loadedOwner));
+        }
+    }
+
+    private async Task LoadDeviceSectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetConfigRequest = 0 }, _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            resp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Device)
+        {
+            _loadedDevice = resp.GetConfigResponse.Device;
+            Dispatcher.Invoke(() => ApplyDeviceConfig(_loadedDevice));
+        }
+    }
+
+    private async Task LoadPositionSectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetConfigRequest = 1 }, _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            resp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Position)
+        {
+            _loadedPosition = resp.GetConfigResponse.Position;
+            Dispatcher.Invoke(() => ApplyPositionConfig(_loadedPosition));
+        }
+    }
+
+    private async Task LoadLoraSectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetConfigRequest = 5 }, _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            resp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Lora)
+        {
+            _loadedLora = resp.GetConfigResponse.Lora;
+            Dispatcher.Invoke(() => ApplyLoraConfig(_loadedLora));
+        }
+    }
+
+    private async Task LoadBluetoothSectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetConfigRequest = 6 }, _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            resp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Bluetooth)
+        {
+            _loadedBt = resp.GetConfigResponse.Bluetooth;
+            Dispatcher.Invoke(() => ApplyBluetoothConfig(_loadedBt));
+        }
+    }
+
+    private async Task LoadNetworkSectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetConfigRequest = 3 }, _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            resp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Network)
+        {
+            _loadedNetwork = resp.GetConfigResponse.Network;
+            Dispatcher.Invoke(() => ApplyNetworkConfig(_loadedNetwork));
+        }
+    }
+
+    private async Task LoadDisplaySectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId, new AdminMessage { GetConfigRequest = 4 }, _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            resp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Display)
+        {
+            _loadedDisplay = resp.GetConfigResponse.Display;
+            Dispatcher.Invoke(() => ApplyDisplayConfig(_loadedDisplay));
+        }
+    }
+
+    private async Task LoadSecuritySectionAsync()
+    {
+        var resp = await _svc.SendRemoteAdminRequestAsync(
+            _targetNode.NodeId,
+            new AdminMessage { GetConfigRequest = (uint)AdminMessage.Types.ConfigType.SecurityConfig },
+            _timeoutMs);
+        if (resp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetConfigResponse &&
+            resp.GetConfigResponse.PayloadVariantCase == Config.PayloadVariantOneofCase.Security)
+        {
+            _loadedSecurity = resp.GetConfigResponse.Security;
+            Dispatcher.Invoke(() => ApplySecurityConfig(_loadedSecurity));
+        }
+    }
+
+    private async Task LoadChannelsSectionAsync()
+    {
+        for (int i = 0; i < 8; i++)
+        {
             await LoadSingleChannelAsync(i);
             await Task.Delay(180);
         }
@@ -278,21 +381,35 @@ public partial class RemoteAdminWindow : Window
 
     private async Task LoadSingleChannelAsync(int index)
     {
-        // Try twice — remote channel gets can be lossy
-        for (int attempt = 0; attempt < 2; attempt++)
+        // Try up to 3 times — remote channel responses can be lossy or arrive out of order
+        for (int attempt = 0; attempt < 3; attempt++)
         {
             var chResp = await _svc.SendRemoteAdminRequestAsync(
                 _targetNode.NodeId,
                 new AdminMessage { GetChannelRequest = (uint)index },
                 _timeoutMs);
+
             if (chResp?.PayloadVariantCase == AdminMessage.PayloadVariantOneofCase.GetChannelResponse)
             {
-                _loadedChannels[index] = chResp.GetChannelResponse;
                 var ch = chResp.GetChannelResponse;
+                int actualIndex = ch.Index; // Use the index from the response, not the requested one
+
+                // If a stale response for a different channel arrived, store it in the correct slot
+                // and retry for the originally requested index
+                if (actualIndex != index && actualIndex >= 0 && actualIndex < 8)
+                {
+                    _loadedChannels[actualIndex] = ch;
+                    Dispatcher.Invoke(() => AddOrUpdateChannelRow(actualIndex, ch));
+                    await Task.Delay(300);
+                    continue; // Retry for the requested index
+                }
+
+                _loadedChannels[index] = ch;
                 Dispatcher.Invoke(() => AddOrUpdateChannelRow(index, ch));
                 return;
             }
-            if (attempt == 0) await Task.Delay(400);
+
+            if (attempt < 2) await Task.Delay(400);
         }
         // Still failed — insert placeholder row so user can retry
         Dispatcher.Invoke(() => AddOrUpdateChannelRow(index, null));
@@ -357,8 +474,9 @@ public partial class RemoteAdminWindow : Window
 
     private void ApplySecurityConfig(SecurityConfig s)
     {
+        // FIX: display keys as base64 (same format as Meshtastic app), not hex
         SecPublicKey.Text = s.PublicKey != null && s.PublicKey.Length > 0
-            ? BitConverter.ToString(s.PublicKey.ToByteArray()).Replace("-", "").ToLowerInvariant()
+            ? Convert.ToBase64String(s.PublicKey.ToByteArray())
             : string.Empty;
 
         var keys = s.AdminKey.ToList();
@@ -459,7 +577,18 @@ public partial class RemoteAdminWindow : Window
         grid.Children.Add(reloadBtn);
 
         border.Child = grid;
-        ChannelsPanel.Children.Add(border);
+
+        // Insert at correct position (by index order)
+        int insertPos = ChannelsPanel.Children.Count;
+        for (int i = 0; i < ChannelsPanel.Children.Count; i++)
+        {
+            if (ChannelsPanel.Children[i] is Border b && b.Tag is int t && t > index)
+            {
+                insertPos = i;
+                break;
+            }
+        }
+        ChannelsPanel.Children.Insert(insertPos, border);
     }
 
     private async Task ReloadSingleChannelAsync(int index)
@@ -636,10 +765,22 @@ public partial class RemoteAdminWindow : Window
     private async void RefreshButton_Click(object sender, RoutedEventArgs e)
     {
         RefreshButton.IsEnabled = false;
+        ReloadTabButton.IsEnabled = false;
         SaveButton.IsEnabled = false;
         MainTabs.IsEnabled = false;
         _svc.ClearRemoteSessionKey(_targetNode.NodeId);
         await ConnectAndLoadAsync();
+    }
+
+    private async void ReloadTabButton_Click(object sender, RoutedEventArgs e)
+    {
+        ReloadTabButton.IsEnabled = false;
+        var tabIndex = MainTabs.SelectedIndex;
+        // Remove from loaded set to force reload
+        var section = GetTabSection(tabIndex);
+        if (section != null) _loadedSections.Remove(section);
+        await LoadTabByIndexAsync(tabIndex, force: true);
+        ReloadTabButton.IsEnabled = true;
     }
 
     // ===== Control tab =====
@@ -672,15 +813,27 @@ public partial class RemoteAdminWindow : Window
 
     // ===== Favorite button =====
 
-    private void FavoriteButton_Click(object sender, RoutedEventArgs e)
+    private async void FavoriteButton_Click(object sender, RoutedEventArgs e)
     {
         _isFavorite = !_isFavorite;
         UpdateFavoriteButton();
-
-        if (_isFavorite)
-            _ = _svc.AddFavoriteNodeAsync(_targetNode.NodeId);
-        else
-            _ = _svc.RemoveFavoriteNodeAsync(_targetNode.NodeId);
+        try
+        {
+            if (_isFavorite)
+                await _svc.AddFavoriteNodeAsync(_targetNode.NodeId);
+            else
+                await _svc.RemoveFavoriteNodeAsync(_targetNode.NodeId);
+        }
+        catch (Exception ex)
+        {
+            // Revert UI state on failure
+            _isFavorite = !_isFavorite;
+            UpdateFavoriteButton();
+            MessageBox.Show(
+                $"{Loc("StrRemoteAdminErrorMsg")}\n{ex.Message}",
+                Loc("StrRemoteAdminTitle"),
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 
     private async void AddFavoriteNode_Click(object sender, RoutedEventArgs e)

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -67,6 +67,7 @@
     <sys:String x:Key="StrDevice">Gerät:</sys:String>
     <sys:String x:Key="StrScanDevices">Geräte suchen</sys:String>
     <sys:String x:Key="StrOpenDms">Direktnachrichten öffnen</sys:String>
+    <sys:String x:Key="StrOpenDashboard">Telemetrie-Dashboard öffnen</sys:String>
 
     <!-- Alert -->
     <sys:String x:Key="StrAlertReceived">Notruf empfangen!</sys:String>
@@ -965,6 +966,7 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrRaTabNetwork">Netzwerk</sys:String>
     <sys:String x:Key="StrRaTabDisplay">Anzeige</sys:String>
     <sys:String x:Key="StrRaTabChannels">Kanäle</sys:String>
+    <sys:String x:Key="StrRaTabSecurity">Sicherheit</sys:String>
     <sys:String x:Key="StrRaTabControl">Steuerung</sys:String>
     <!-- Owner tab -->
     <sys:String x:Key="StrRaOwnerShortName">Kurzname (max. 4 Zeichen)</sys:String>
@@ -1013,6 +1015,12 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrRaShutdown">⏹ Herunterfahren</sys:String>
     <sys:String x:Key="StrRaNodeDbReset">⚠️ Node-DB löschen: Entfernt alle bekannten Knoten aus der Datenbank des Geräts.</sys:String>
     <sys:String x:Key="StrRaNodeDbResetBtn">⚠️ Node-DB löschen</sys:String>
+    <sys:String x:Key="StrRaFavoritesSection">Favoriten auf Remote-Knoten verwalten</sys:String>
+    <sys:String x:Key="StrRaFavoritesDesc">Markiere oder entferne einen Knoten als Favoriten auf dem entfernten Gerät. Der Knoten wird dann in der Kontaktliste des Remote-Knotens priorisiert angezeigt.</sys:String>
+    <sys:String x:Key="StrRaFavoritesAdd">⭐ Als Favorit setzen</sys:String>
+    <sys:String x:Key="StrRaFavoritesRemove">✕ Favorit entfernen</sys:String>
+    <sys:String x:Key="StrRaFavoritesAdded">Knoten „{0}" wurde auf dem Remote-Gerät als Favorit gesetzt.</sys:String>
+    <sys:String x:Key="StrRaFavoritesRemoved">Knoten „{0}" wurde auf dem Remote-Gerät aus den Favoriten entfernt.</sys:String>
     <!-- Bottom buttons -->
     <sys:String x:Key="StrRaRefresh">🔄 Neu laden</sys:String>
     <sys:String x:Key="StrRaSave">💾 Speichern</sys:String>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -1079,4 +1079,18 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrDays30">30 Tage</sys:String>
     <sys:String x:Key="StrDaysAll">Gesamt</sys:String>
 
+    <sys:String x:Key="StrWidgetTypeRanking">Ranking (Tabelle)</sys:String>
+    <sys:String x:Key="StrWidgetTypeMultiStat">Multi-Stat (Kacheln)</sys:String>
+    <sys:String x:Key="StrWidgetTypeMeshHealth">Mesh-Health (Ampel)</sys:String>
+    <sys:String x:Key="StrDashboardExportCsv">CSV exportieren</sys:String>
+    <sys:String x:Key="StrDashboardExportDone">Exportiert nach: {0}</sys:String>
+    <sys:String x:Key="StrDashboardThreshold">Schwellwert</sys:String>
+    <sys:String x:Key="StrDashboardMovingAvg">Gleitender Ø</sys:String>
+    <sys:String x:Key="StrDashboardNoData">Keine Daten</sys:String>
+    <sys:String x:Key="StrRankingNode">Knoten</sys:String>
+    <sys:String x:Key="StrMeshHealthOffline">Offline</sys:String>
+    <sys:String x:Key="StrMeshHealthGood">Gut</sys:String>
+    <sys:String x:Key="StrMeshHealthWeak">Schwach</sys:String>
+    <sys:String x:Key="StrMeshHealthPoor">Schlecht</sys:String>
+
 </ResourceDictionary>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -1092,5 +1092,13 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrMeshHealthGood">Gut</sys:String>
     <sys:String x:Key="StrMeshHealthWeak">Schwach</sys:String>
     <sys:String x:Key="StrMeshHealthPoor">Schlecht</sys:String>
+    <sys:String x:Key="StrMeshHealthScore">Mesh Health</sys:String>
+    <sys:String x:Key="StrMeshHealthWeather">Wetter</sys:String>
+    <sys:String x:Key="StrMeshHealthAntenna">Antenne</sys:String>
+    <sys:String x:Key="StrMeshHealthNeighbor">Nachbar</sys:String>
+    <sys:String x:Key="StrMeshHealthPath">Pfade</sys:String>
+    <sys:String x:Key="StrMeshHealthNeighborCount">Nachbarn</sys:String>
+    <sys:String x:Key="StrMeshHealthHopCost">Pfadkosten</sys:String>
+    <sys:String x:Key="StrDashboardThresholdTip">Horizontale gestrichelte Linie im Chart — z.B. kritischer RSSI-Wert</sys:String>
 
 </ResourceDictionary>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -19,6 +19,9 @@
     <sys:String x:Key="StrTabInfo">ℹ️ Info</sys:String>
 
     <!-- Node context menu -->
+    <sys:String x:Key="StrFavorite">★ Als Favorit markieren</sys:String>
+    <sys:String x:Key="StrUnfavorite">★ Favorit entfernen</sys:String>
+    <sys:String x:Key="StrFavoriteColTooltip">Favoriten (★ = Favorit, wird mit Gerät synchronisiert)</sys:String>
     <sys:String x:Key="StrPin">📌 Anheften</sys:String>
     <sys:String x:Key="StrUnpin">📌 Loslösen</sys:String>
     <sys:String x:Key="StrShowPath">🛤️ Bewegungspfad anzeigen</sys:String>
@@ -625,6 +628,9 @@
     <sys:String x:Key="StrSignalAntennaUnit">Tage (langfristig)</sys:String>
     <!-- Settings tab - time sync -->
     <sys:String x:Key="StrTimeSyncDriftZero">(0 = kein Drift-Check)</sys:String>
+    <!-- Remote Admin settings -->
+    <sys:String x:Key="StrRemoteAdminGroup">Fernverwaltung</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeoutLabel">Anfrage-Timeout:</sys:String>
     <!-- Settings saved dialog -->
     <sys:String x:Key="StrSettingsSaved">Einstellungen gespeichert.</sys:String>
     <sys:String x:Key="StrSettingsSavedTitle">Info</sys:String>
@@ -635,6 +641,7 @@
     <sys:String x:Key="StrTel30d">30 Tage</sys:String>
     <sys:String x:Key="StrTelAll">Gesamt</sys:String>
     <sys:String x:Key="StrTelOpenPlot">📈 Im Plot öffnen</sys:String>
+    <sys:String x:Key="StrTelOpenDashboard">📊 Dashboard öffnen</sys:String>
     <sys:String x:Key="StrTelSnrSection">SNR (Empfangsqualität)</sys:String>
     <sys:String x:Key="StrTelDayLabel">Tag</sys:String>
     <sys:String x:Key="StrTelNightLabel">Nacht</sys:String>
@@ -918,5 +925,150 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrRelayHopsTooltip">Relay-Hops (Anzahl Zwischenknoten)</sys:String>
     <sys:String x:Key="StrErrConnectionRefused">Verbindung abgelehnt — läuft der Meshtastic-Dienst auf dem Gerät und ist der Port korrekt?</sys:String>
     <sys:String x:Key="StrMqttBubbleTooltip">Nachricht via MQTT empfangen (nicht direkt per LoRa)</sys:String>
+
+    <!-- Remote Admin -->
+    <sys:String x:Key="StrRemoteAdminHint">Fernverwaltung eines Favoriten-Knotens über Meshtastic-Admin-Protokoll. Der Zielknoten muss erreichbar sein und Admin-Zugriff erlauben. Es werden nur Knoten angezeigt, die als ★ Favorit markiert sind.</sys:String>
+    <sys:String x:Key="StrRemoteAdmin">🛠️ Fernverwaltung</sys:String>
+    <sys:String x:Key="StrRemoteAdminTitle">Fernverwaltung</sys:String>
+    <sys:String x:Key="StrRemoteAdminConnecting">Verbinde...</sys:String>
+    <sys:String x:Key="StrRemoteAdminLoading">Lade Konfiguration...</sys:String>
+    <sys:String x:Key="StrRemoteAdminConnected">Verbunden</sys:String>
+    <sys:String x:Key="StrRemoteAdminWaiting">Warte auf Antwort</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeout">Timeout — keine Antwort</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeoutMsg">Keine Antwort vom Knoten innerhalb des Timeouts. Der Knoten ist möglicherweise nicht erreichbar oder hat keinen Admin-Zugriff gewährt.</sys:String>
+    <sys:String x:Key="StrRemoteAdminSaving">Speichere...</sys:String>
+    <sys:String x:Key="StrRemoteAdminSaved">Gespeichert</sys:String>
+    <sys:String x:Key="StrRemoteAdminSavedMsg">Konfiguration erfolgreich an den Knoten übermittelt.</sys:String>
+    <sys:String x:Key="StrRemoteAdminError">Fehler</sys:String>
+    <sys:String x:Key="StrRemoteAdminErrorMsg">Fehler beim Speichern:</sys:String>
+    <sys:String x:Key="StrRemoteAdminRebooting">Neustart gesendet</sys:String>
+    <sys:String x:Key="StrRemoteAdminShutdown">Herunterfahren gesendet</sys:String>
+    <sys:String x:Key="StrRemoteAdminFirmware">Firmware</sys:String>
+    <sys:String x:Key="StrRemoteAdminHardware">Hardware</sys:String>
+    <sys:String x:Key="StrRemoteAdminHops">SNR</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeout2">Timeout</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeoutTip">Anfrage-Timeout in Sekunden (5–300). Bei entfernten Nodes ggf. höher setzen.</sys:String>
+    <sys:String x:Key="StrRemoteAdminChannelFailed">Abruf fehlgeschlagen – ⟳ klicken</sys:String>
+    <sys:String x:Key="StrRemoteAdminChannelReload">Diesen Kanal erneut laden</sys:String>
+    <sys:String x:Key="StrRemoteAdminFavoriteTip">Als Favorit markieren / entfernen</sys:String>
+    <sys:String x:Key="StrRemoteAdminRebootConfirm">Knoten wirklich neu starten?</sys:String>
+    <sys:String x:Key="StrRemoteAdminShutdownConfirm">Knoten wirklich herunterfahren?</sys:String>
+    <sys:String x:Key="StrRemoteAdminNodeDbResetConfirm">Node-Datenbank des Knotens wirklich löschen? Alle bekannten Nodes werden vergessen!</sys:String>
+    <sys:String x:Key="StrRemoteAdminSelectNode">Knoten für Fernverwaltung auswählen</sys:String>
+    <sys:String x:Key="StrRemoteAdminNoFavorites">Keine Favoriten gesetzt. Markiere zuerst Knoten als Favoriten (Rechtsklick → Als Favorit markieren).</sys:String>
+    <!-- Remote Admin tabs -->
+    <sys:String x:Key="StrRaTabOwner">Besitzer</sys:String>
+    <sys:String x:Key="StrRaTabDevice">Gerät</sys:String>
+    <sys:String x:Key="StrRaTabPosition">Position</sys:String>
+    <sys:String x:Key="StrRaTabLora">LoRa</sys:String>
+    <sys:String x:Key="StrRaTabBluetooth">Bluetooth</sys:String>
+    <sys:String x:Key="StrRaTabNetwork">Netzwerk</sys:String>
+    <sys:String x:Key="StrRaTabDisplay">Anzeige</sys:String>
+    <sys:String x:Key="StrRaTabChannels">Kanäle</sys:String>
+    <sys:String x:Key="StrRaTabControl">Steuerung</sys:String>
+    <!-- Owner tab -->
+    <sys:String x:Key="StrRaOwnerShortName">Kurzname (max. 4 Zeichen)</sys:String>
+    <sys:String x:Key="StrRaOwnerLongName">Langname</sys:String>
+    <sys:String x:Key="StrRaOwnerLicensed">Lizenzierter Amateurfunker</sys:String>
+    <!-- Device tab -->
+    <sys:String x:Key="StrRaDeviceRole">Rolle</sys:String>
+    <sys:String x:Key="StrRaDeviceNodeInfoInterval">NodeInfo-Sendeintervall (Sekunden, 0=nie)</sys:String>
+    <sys:String x:Key="StrRaDeviceSerialEnabled">Serielle Konsole aktiviert</sys:String>
+    <sys:String x:Key="StrRaDeviceDebugLog">Debug-Logging aktiviert</sys:String>
+    <!-- Position tab -->
+    <sys:String x:Key="StrRaPosGpsMode">GPS-Modus</sys:String>
+    <sys:String x:Key="StrRaPosBroadcastInterval">Sendeintervall (s)</sys:String>
+    <sys:String x:Key="StrRaPosBroadcastSmart">Smart-Broadcast aktiviert</sys:String>
+    <sys:String x:Key="StrRaPosGpsAttemptTime">GPS-Versuchszeit (s)</sys:String>
+    <sys:String x:Key="StrRaPosFixed">Feste Position</sys:String>
+    <sys:String x:Key="StrRaPosFixedEnabled">Feste Position aktiviert</sys:String>
+    <sys:String x:Key="StrRaPosLat">Breitengrad</sys:String>
+    <sys:String x:Key="StrRaPosLon">Längengrad</sys:String>
+    <sys:String x:Key="StrRaPosAlt">Höhe (m)</sys:String>
+    <!-- LoRa tab -->
+    <sys:String x:Key="StrRaLoraRegion">Region</sys:String>
+    <sys:String x:Key="StrRaLoraPreset">Modem-Preset</sys:String>
+    <sys:String x:Key="StrRaLoraHopLimit">Hop-Limit</sys:String>
+    <sys:String x:Key="StrRaLoraTxPower">TX-Leistung (dBm, 0=max.)</sys:String>
+    <sys:String x:Key="StrRaLoraTxEnabled">TX aktiviert</sys:String>
+    <!-- Bluetooth tab -->
+    <sys:String x:Key="StrRaBtEnabled">Bluetooth aktiviert</sys:String>
+    <sys:String x:Key="StrRaBtMode">Pairing-Modus</sys:String>
+    <sys:String x:Key="StrRaBtPin">Fester PIN (6-stellig)</sys:String>
+    <!-- Network tab -->
+    <sys:String x:Key="StrRaWifiEnabled">WLAN aktiviert</sys:String>
+    <sys:String x:Key="StrRaWifiSsid">WLAN-SSID</sys:String>
+    <sys:String x:Key="StrRaWifiPsk">WLAN-Passwort</sys:String>
+    <sys:String x:Key="StrRaWifiApMode">Access-Point-Modus</sys:String>
+    <sys:String x:Key="StrRaEthEnabled">Ethernet aktiviert</sys:String>
+    <sys:String x:Key="StrRaNtpServer">NTP-Server</sys:String>
+    <!-- Display tab -->
+    <sys:String x:Key="StrRaDisplayTimeout">Display-Timeout (s, 0=nie)</sys:String>
+    <sys:String x:Key="StrRaDisplayFlip">Display gespiegelt</sys:String>
+    <sys:String x:Key="StrRaDisplayUnits">Einheiten</sys:String>
+    <sys:String x:Key="StrRaDisplayOledType">OLED-Typ</sys:String>
+    <!-- Control tab -->
+    <sys:String x:Key="StrRaControlDesc">Sende Steuerbefehle an den entfernten Knoten. Diese Aktionen sind sofort wirksam!</sys:String>
+    <sys:String x:Key="StrRaReboot">🔄 Neu starten</sys:String>
+    <sys:String x:Key="StrRaShutdown">⏹ Herunterfahren</sys:String>
+    <sys:String x:Key="StrRaNodeDbReset">⚠️ Node-DB löschen: Entfernt alle bekannten Knoten aus der Datenbank des Geräts.</sys:String>
+    <sys:String x:Key="StrRaNodeDbResetBtn">⚠️ Node-DB löschen</sys:String>
+    <!-- Bottom buttons -->
+    <sys:String x:Key="StrRaRefresh">🔄 Neu laden</sys:String>
+    <sys:String x:Key="StrRaSave">💾 Speichern</sys:String>
+    <!-- Telemetry Dashboard -->
+    <sys:String x:Key="StrDashboardTitle">Telemetrie-Dashboard</sys:String>
+    <sys:String x:Key="StrDashboardLabel">Dashboard:</sys:String>
+    <sys:String x:Key="StrDashboardNew">+ Neu</sys:String>
+    <sys:String x:Key="StrDashboardRename">Umbenennen</sys:String>
+    <sys:String x:Key="StrDashboardDelete">Löschen</sys:String>
+    <sys:String x:Key="StrDashboardAddWidget">+ Widget hinzufügen</sys:String>
+    <sys:String x:Key="StrDashboardRefresh">↺ Aktualisieren</sys:String>
+    <sys:String x:Key="StrDashboardNewTitle">Neues Dashboard</sys:String>
+    <sys:String x:Key="StrDashboardRenameTitle">Dashboard umbenennen</sys:String>
+    <sys:String x:Key="StrDashboardNewPrompt">Name:</sys:String>
+    <sys:String x:Key="StrDashboardDefaultName">Dashboard</sys:String>
+    <sys:String x:Key="StrDashboardDeleteConfirm">Dashboard "{0}" wirklich löschen?</sys:String>
+    <sys:String x:Key="StrDashboardNoDashboard">Bitte zuerst ein Dashboard erstellen.</sys:String>
+    <sys:String x:Key="StrDashboardEmpty">Kein Dashboard ausgewählt. Erstelle ein neues Dashboard und füge Widgets hinzu.</sys:String>
+    <sys:String x:Key="StrDashboardWidgetCount">Widgets</sys:String>
+    <sys:String x:Key="StrDashboardRemoveWidget">Widget entfernen</sys:String>
+    <sys:String x:Key="StrDashboardEditWidget">Widget bearbeiten</sys:String>
+    <sys:String x:Key="StrDashboardLastUpdated">Letzter Wert</sys:String>
+    <sys:String x:Key="StrDashboardHourOfDay">Stunde (0–23)</sys:String>
+    <sys:String x:Key="StrDashboardDayIndex">Tag</sys:String>
+    <!-- Add Widget Dialog -->
+    <sys:String x:Key="StrAddWidgetTitle">Widget hinzufügen</sys:String>
+    <sys:String x:Key="StrAddWidgetType">Widget-Typ:</sys:String>
+    <sys:String x:Key="StrAddWidgetMetric">Metrik:</sys:String>
+    <sys:String x:Key="StrAddWidgetDays">Zeitraum:</sys:String>
+    <sys:String x:Key="StrAddWidgetNodes">Knoten (Mehrfachauswahl möglich):</sys:String>
+    <sys:String x:Key="StrAddWidgetCustomTitle">Titel (leer = automatisch):</sys:String>
+    <sys:String x:Key="StrAddWidgetNoNode">Bitte mindestens einen Knoten auswählen.</sys:String>
+    <sys:String x:Key="StrWidgetTypeLine">Zeitverlauf (Linienchart)</sys:String>
+    <sys:String x:Key="StrWidgetTypeBar">Balkendiagramm (Aktuell)</sys:String>
+    <sys:String x:Key="StrWidgetTypeGauge">Anzeige (Gauge)</sys:String>
+    <sys:String x:Key="StrWidgetTypeHeatmap">Heatmap (Stunde × Tag)</sys:String>
+    <sys:String x:Key="StrWidgetTypeArea">Flächendiagramm (Area)</sys:String>
+    <sys:String x:Key="StrWidgetTypeScatter">Streudiagramm (Scatter)</sys:String>
+    <sys:String x:Key="StrWidgetTypeStat">Kennzahl (Stat-Karte)</sys:String>
+    <sys:String x:Key="StrWidgetTypeClock">Uhr (UTC + Lokal)</sys:String>
+    <sys:String x:Key="StrWidgetTypeHistogram">Histogramm (Verteilung)</sys:String>
+    <sys:String x:Key="StrWidgetTypeCandlestick">Candlestick (Tages-OHLC)</sys:String>
+    <sys:String x:Key="StrWidgetTypeStateline">Status-Timeline (Aktivität)</sys:String>
+    <sys:String x:Key="StrDashboardCount">Anzahl</sys:String>
+    <!-- Auto-refresh -->
+    <sys:String x:Key="StrDashboardAutoRefresh">Auto-Refresh:</sys:String>
+    <sys:String x:Key="StrDashboardRefreshOff">Aus</sys:String>
+    <sys:String x:Key="StrDashboardLastRefreshed">Aktualisiert: {0}</sys:String>
+    <!-- Node search / single-node hint -->
+    <sys:String x:Key="StrAddWidgetNodeSearch">Knoten suchen…</sys:String>
+    <sys:String x:Key="StrAddWidgetSingleNodeHint">Nur 1 Knoten</sys:String>
+    <!-- Time range labels -->
+    <sys:String x:Key="StrDays1">1 Tag</sys:String>
+    <sys:String x:Key="StrDays7">7 Tage</sys:String>
+    <sys:String x:Key="StrDays14">14 Tage</sys:String>
+    <sys:String x:Key="StrDays30">30 Tage</sys:String>
+    <sys:String x:Key="StrDaysAll">Gesamt</sys:String>
 
 </ResourceDictionary>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -1101,4 +1101,140 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrMeshHealthHopCost">Pfadkosten</sys:String>
     <sys:String x:Key="StrDashboardThresholdTip">Horizontale gestrichelte Linie im Chart — z.B. kritischer RSSI-Wert</sys:String>
 
+    <!-- Tools tab -->
+    <sys:String x:Key="StrTabTools">🔧 Tools</sys:String>
+    <sys:String x:Key="StrToolsTDeckSection">T-Deck Karten-Assistent</sys:String>
+    <sys:String x:Key="StrToolsTDeckDesc">Bereite eine SD-Karte mit Offline-Karten für dein Meshtastic T-Deck vor. Der Assistent führt dich durch Formatierung, Bereichsauswahl und Download.</sys:String>
+    <sys:String x:Key="StrToolsTDeckBtn">🗺️ Karten für T-Deck vorbereiten...</sys:String>
+    <sys:String x:Key="StrToolsExportSection">Tile-Export</sys:String>
+    <sys:String x:Key="StrToolsExportDesc">Exportiere deine lokal heruntergeladenen Karten-Tiles als ZIP-Datei.</sys:String>
+    <sys:String x:Key="StrToolsExportBtn">📦 Tiles als ZIP exportieren...</sys:String>
+
+    <!-- TDeck Wizard: common -->
+    <sys:String x:Key="StrTDeckTitle">T-Deck Karten-Assistent</sys:String>
+    <sys:String x:Key="StrTDeckGermanyOnly">ℹ️ Offline-Karten sind nur für Deutschland verfügbar.</sys:String>
+    <sys:String x:Key="StrTDeckBack">◀ Zurück</sys:String>
+    <sys:String x:Key="StrTDeckNext">Weiter ▶</sys:String>
+    <sys:String x:Key="StrTDeckCancel">Abbrechen</sys:String>
+    <sys:String x:Key="StrTDeckClose">Schließen</sys:String>
+    <sys:String x:Key="StrTDeckStep">Schritt {0} von {1}</sys:String>
+
+    <!-- TDeck Step 1: Welcome -->
+    <sys:String x:Key="StrTDeckS1Title">Willkommen</sys:String>
+    <sys:String x:Key="StrTDeckS1Desc">Dieser Assistent hilft dir, Offline-Karten-Tiles auf eine SD-Karte für dein Meshtastic T-Deck zu übertragen.
+
+Was macht dieser Assistent?
+  • Prüft und formatiert die SD-Karte (FAT32 / exFAT)
+  • Lässt dich den Kartenbereich auswählen (Bundesland, ganz Deutschland oder eigener Bereich)
+  • Wählt Zoom-Stufe und Kartentyp (OSM, OpenTopo, OSM Dark)
+  • Kopiert bereits vorhandene Tiles direkt — und lädt fehlende nach
+
+ℹ️ Karten sind nur für Deutschland verfügbar (eigener Meshhessen-Tile-Server).
+
+Die Downloads sind additiv: Bereits vorhandene Tiles auf der SD-Karte werden nicht erneut übertragen.</sys:String>
+
+    <!-- TDeck Step 2: Drive selection -->
+    <sys:String x:Key="StrTDeckS2Title">SD-Karte auswählen</sys:String>
+    <sys:String x:Key="StrTDeckS2Hint">Wähle das Laufwerk deiner SD-Karte. Es werden nur Wechseldatenträger angezeigt.</sys:String>
+    <sys:String x:Key="StrTDeckDriveLabel">Verfügbare Wechsellaufwerke:</sys:String>
+    <sys:String x:Key="StrTDeckRefresh">Aktualisieren</sys:String>
+    <sys:String x:Key="StrTDeckNoDrives">Keine Wechsellaufwerke gefunden. SD-Karte einlegen und „Aktualisieren" klicken.</sys:String>
+    <sys:String x:Key="StrTDeckDriveInfo">Gesamt: {0} | Frei: {1} | Dateisystem: {2}</sys:String>
+    <sys:String x:Key="StrTDeckSelectDriveFirst">Bitte zuerst ein Laufwerk auswählen.</sys:String>
+
+    <!-- TDeck Step 3: Format check -->
+    <sys:String x:Key="StrTDeckS3Title">Formatierung prüfen</sys:String>
+    <sys:String x:Key="StrTDeckFormatOk">✅ Laufwerk ist korrekt formatiert ({0}). Keine Aktion erforderlich.</sys:String>
+    <sys:String x:Key="StrTDeckFormatWarn">⚠️ Laufwerk ist mit „{0}" formatiert.
+Empfohlen: FAT32 (bis 32 GB) oder exFAT (über 32 GB) mit kleinstmöglicher Zuordnungseinheit.
+Du kannst trotzdem fortfahren oder das Laufwerk formatieren.</sys:String>
+    <sys:String x:Key="StrTDeckFormatHint">Das T-Deck erkennt exFAT am zuverlässigsten. Wichtig: Wähle die kleinste verfügbare Zuordnungseinheit (z.B. 4096 Bytes). Viele Tiles (besonders Meer/leere Flächen) sind nur ~100 Bytes groß, belegen aber immer mindestens eine ganze Zuordnungseinheit — kleine Einheiten sparen hier erheblich Speicherplatz. Die Formatierung erfordert Administrator-Rechte.</sys:String>
+    <sys:String x:Key="StrTDeckFormatBtn">Laufwerk formatieren...</sys:String>
+    <sys:String x:Key="StrTDeckSkipFormat">Formatierung überspringen</sys:String>
+    <sys:String x:Key="StrTDeckFmtConfirmTitle">Formatierung bestätigen</sys:String>
+    <sys:String x:Key="StrTDeckFmtConfirm1">⚠️ WARNUNG: Alle Daten auf Laufwerk {0} werden unwiderruflich gelöscht!
+
+Wirklich formatieren?</sys:String>
+    <sys:String x:Key="StrTDeckFmtConfirm2">🔴 LETZTE WARNUNG: Das Formatieren löscht ALLE Daten auf {0} für immer!
+
+Endgültig fortfahren?</sys:String>
+    <sys:String x:Key="StrTDeckFmtExFAT">exFAT mit 4096 Bytes (empfohlen für T-Deck)</sys:String>
+    <sys:String x:Key="StrTDeckFmtFAT32">FAT32 mit 512 Bytes (ältere Geräte, max. 32 GB)</sys:String>
+    <sys:String x:Key="StrTDeckFmtChoiceTitle">Dateisystem wählen</sys:String>
+    <sys:String x:Key="StrTDeckFmtChoiceHint">Wähle das Dateisystem für die Formatierung. exFAT mit 4096 Bytes wird für das T-Deck empfohlen:</sys:String>
+    <sys:String x:Key="StrTDeckFormatting">Formatiere Laufwerk {0}... (UAC-Fenster beachten)</sys:String>
+    <sys:String x:Key="StrTDeckFormatDone">✅ Laufwerk erfolgreich formatiert ({0}).</sys:String>
+    <sys:String x:Key="StrTDeckFormatFailed">❌ Formatierung fehlgeschlagen oder abgebrochen.</sys:String>
+
+    <!-- TDeck Step 4: Region selection -->
+    <sys:String x:Key="StrTDeckS4Title">Bereich auswählen</sys:String>
+    <sys:String x:Key="StrTDeckRegionByState">Nach Bundesland(er) auswählen</sys:String>
+    <sys:String x:Key="StrTDeckRegionGermany">Ganz Deutschland</sys:String>
+    <sys:String x:Key="StrTDeckRegionFreeStyle">Eigenen Bereich zeichnen</sys:String>
+    <sys:String x:Key="StrTDeckStateSelectAll">Alle</sys:String>
+    <sys:String x:Key="StrTDeckStateSelectNone">Keine</sys:String>
+    <sys:String x:Key="StrTDeckOpenMap">🗺️ Bereich auf Karte zeichnen...</sys:String>
+    <sys:String x:Key="StrTDeckBboxPreview">Ausgewählter Bereich: N {0:F4}° | S {1:F4}° | W {2:F4}° | E {3:F4}°</sys:String>
+    <sys:String x:Key="StrTDeckNoRegion">Bitte mindestens ein Bundesland auswählen oder einen Bereich zeichnen.</sys:String>
+    <sys:String x:Key="StrTDeckFreestyleNotSet">Noch kein Bereich gezeichnet. Klicke „Bereich auf Karte zeichnen".</sys:String>
+
+    <!-- TDeck Step 5: Zoom & map type -->
+    <sys:String x:Key="StrTDeckS5Title">Zoom-Stufe und Kartentyp</sys:String>
+    <sys:String x:Key="StrTDeckZoomLabel">Maximale Zoom-Stufe (Stufe 1 wird immer eingeschlossen):</sys:String>
+    <sys:String x:Key="StrTDeckZoom8">8 — Überblick (Bundesländer)</sys:String>
+    <sys:String x:Key="StrTDeckZoom10">10 — Landkreise</sys:String>
+    <sys:String x:Key="StrTDeckZoom12">12 — Stadtebene</sys:String>
+    <sys:String x:Key="StrTDeckZoom14">14 — Straßen (empfohlen)</sys:String>
+    <sys:String x:Key="StrTDeckZoom16">16 — Detail (viele Tiles!)</sys:String>
+    <sys:String x:Key="StrTDeckZoom17">17 — Maximum (extrem viele Tiles!)</sys:String>
+    <sys:String x:Key="StrTDeckZoomWarn14">⚠️ Zoom 14 kann bereits viele zehntausend Tiles umfassen. Der Download kann Stunden dauern.</sys:String>
+    <sys:String x:Key="StrTDeckZoomWarn16">🔴 Zoom 16+ bedeutet potenziell Millionen von Tiles! Der Download kann Tage dauern und sehr viel Speicherplatz benötigen.</sys:String>
+    <sys:String x:Key="StrTDeckMapTypeLabel">Kartentyp:</sys:String>
+    <sys:String x:Key="StrTDeckMapOSM">OpenStreetMap (Standard)</sys:String>
+    <sys:String x:Key="StrTDeckMapDark">OSM Dark</sys:String>
+    <sys:String x:Key="StrTDeckMapTopo">OpenTopoMap</sys:String>
+    <sys:String x:Key="StrTDeckEstimate">Geschätzte Tiles: ca. {0:N0} (~{1})</sys:String>
+    <sys:String x:Key="StrTDeckSDFree">Freier Speicher auf SD: {0}</sys:String>
+    <sys:String x:Key="StrTDeckSDLow">⚠️ Möglicherweise nicht genug Speicherplatz auf der SD-Karte!</sys:String>
+    <sys:String x:Key="StrTDeckSelectMapType">Bitte einen Kartentyp auswählen.</sys:String>
+
+    <!-- TDeck Step 6: Download -->
+    <sys:String x:Key="StrTDeckS6Title">Download &amp; Übertragung</sys:String>
+    <sys:String x:Key="StrTDeckSummaryTitle">Zusammenfassung:</sys:String>
+    <sys:String x:Key="StrTDeckSumDrive">Laufwerk:</sys:String>
+    <sys:String x:Key="StrTDeckSumRegion">Bereich:</sys:String>
+    <sys:String x:Key="StrTDeckSumZoom">Max. Zoom:</sys:String>
+    <sys:String x:Key="StrTDeckSumType">Kartentyp:</sys:String>
+    <sys:String x:Key="StrTDeckSumTiles">Geschätzte Tiles:</sys:String>
+    <sys:String x:Key="StrTDeckCopyHint">✅ Bereits lokal vorhandene Tiles werden direkt kopiert — kein erneuter Download.</sys:String>
+    <sys:String x:Key="StrTDeckAdditiveHint">✅ Bereits auf der SD-Karte vorhandene Tiles werden übersprungen.</sys:String>
+    <sys:String x:Key="StrTDeckStartBtn">▶ Herunterladen &amp; Kopieren</sys:String>
+    <sys:String x:Key="StrTDeckProgressTile">Tile {0} / {1} ({2:P0})</sys:String>
+    <sys:String x:Key="StrTDeckProgressZoom">Zoom {0} — X:{1} Y:{2}</sys:String>
+    <sys:String x:Key="StrTDeckDone">✅ Übertragung abgeschlossen! {0:N0} Tiles auf SD-Karte.</sys:String>
+    <sys:String x:Key="StrTDeckCancelled">Abgebrochen.</sys:String>
+    <sys:String x:Key="StrTDeckError">Fehler: {0}</sys:String>
+
+    <!-- TDeck region map window -->
+    <sys:String x:Key="StrTDeckMapPickTitle">Bereich auf Karte zeichnen</sys:String>
+    <sys:String x:Key="StrTDeckMapPickHint">Navigiere zur Region, aktiviere „Zeichenmodus" und ziehe Rechtecke auf. Mehrere Rechtecke möglich – alle werden als Hüllbereich verwendet.</sys:String>
+    <sys:String x:Key="StrTDeckMapPickAccept">✅ Übernehmen</sys:String>
+    <sys:String x:Key="StrTDeckMapPickClear">Auswahl löschen</sys:String>
+    <sys:String x:Key="StrTDeckMapPickNoSel">Noch kein Bereich gezeichnet.</sys:String>
+    <sys:String x:Key="StrTDeckMapPickSel">{0} Bereich(e) – Hülle: N {1:F4}° S {2:F4}° W {3:F4}° E {4:F4}°</sys:String>
+    <sys:String x:Key="StrTDeckMapDrawModeOn">✏ Zeichenmodus</sys:String>
+    <sys:String x:Key="StrTDeckMapDrawModeOff">🖐 Navigation</sys:String>
+    <sys:String x:Key="StrTDeckMapClearLast">Letztes löschen</sys:String>
+    <sys:String x:Key="StrTDeckMapClearAll">Alle löschen</sys:String>
+
+    <!-- TDeck export window -->
+    <sys:String x:Key="StrTDeckExportTitle">Tiles als ZIP exportieren</sys:String>
+    <sys:String x:Key="StrTDeckExportHint">Exportiert alle lokal gespeicherten Karten-Tiles in eine ZIP-Datei. Diese kann später über „Maptiles aus ZIP laden" wieder importiert werden.</sys:String>
+    <sys:String x:Key="StrTDeckExportTypeLabel">Kartentyp:</sys:String>
+    <sys:String x:Key="StrTDeckExportAllTypes">Alle Typen</sys:String>
+    <sys:String x:Key="StrTDeckExportStartBtn">📦 Exportieren...</sys:String>
+    <sys:String x:Key="StrTDeckExportDone">✅ Export abgeschlossen: {0}</sys:String>
+    <sys:String x:Key="StrTDeckExportFailed">❌ Export fehlgeschlagen: {0}</sys:String>
+    <sys:String x:Key="StrTDeckExportNoTiles">Keine lokalen Tiles für diesen Kartentyp gefunden.</sys:String>
+
 </ResourceDictionary>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -1022,8 +1022,10 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrRaFavoritesAdded">Knoten „{0}" wurde auf dem Remote-Gerät als Favorit gesetzt.</sys:String>
     <sys:String x:Key="StrRaFavoritesRemoved">Knoten „{0}" wurde auf dem Remote-Gerät aus den Favoriten entfernt.</sys:String>
     <!-- Bottom buttons -->
-    <sys:String x:Key="StrRaRefresh">🔄 Neu laden</sys:String>
+    <sys:String x:Key="StrRaRefresh">🔄 Alles neu laden</sys:String>
+    <sys:String x:Key="StrRaReloadTab">↻ Tab neu laden</sys:String>
     <sys:String x:Key="StrRaSave">💾 Speichern</sys:String>
+    <sys:String x:Key="StrRaLoadAllQuestion">Alle Einstellungen jetzt laden?&#x0a;&#x0a;Ja  = sofort alles laden (ca. 30–60 Sek.)&#x0a;Nein = seitenweise laden (Tab anklicken)</sys:String>
     <!-- Telemetry Dashboard -->
     <sys:String x:Key="StrDashboardTitle">Telemetrie-Dashboard</sys:String>
     <sys:String x:Key="StrDashboardLabel">Dashboard:</sys:String>

--- a/MeshhessenClient/Resources/Strings.de.xaml
+++ b/MeshhessenClient/Resources/Strings.de.xaml
@@ -1110,6 +1110,19 @@ Grün ≤15% | Gelb 15–25% | Rot &gt;25% | Grau = keine Airtime-Daten</sys:Str
     <sys:String x:Key="StrToolsExportDesc">Exportiere deine lokal heruntergeladenen Karten-Tiles als ZIP-Datei.</sys:String>
     <sys:String x:Key="StrToolsExportBtn">📦 Tiles als ZIP exportieren...</sys:String>
 
+    <!-- Virtual Node -->
+    <sys:String x:Key="StrVirtualNodeSection">Virtual Node</sys:String>
+    <sys:String x:Key="StrVirtualNodeDesc">Startet einen TCP-Server, mit dem sich Meshtastic-Apps (Android/iOS) verbinden können – als wäre es ein echtes Gerät. Erfordert eine bestehende Verbindung zu einem physischen Node.</sys:String>
+    <sys:String x:Key="StrVirtualNodeEnable">Virtual Node aktivieren</sys:String>
+    <sys:String x:Key="StrVirtualNodePort">Port:</sys:String>
+    <sys:String x:Key="StrVirtualNodeBlockAdmin">Admin-Befehle von Clients blockieren</sys:String>
+    <sys:String x:Key="StrVirtualNodeStatus">Status:</sys:String>
+    <sys:String x:Key="StrVirtualNodeRunning">Läuft ✓</sys:String>
+    <sys:String x:Key="StrVirtualNodeStopped">Gestoppt</sys:String>
+    <sys:String x:Key="StrVirtualNodeClients">Verbundene Clients:</sys:String>
+    <sys:String x:Key="StrVirtualNodeNoClients">(keine)</sys:String>
+    <sys:String x:Key="StrVirtualNodeNotConnected">Kein physischer Node verbunden.</sys:String>
+
     <!-- TDeck Wizard: common -->
     <sys:String x:Key="StrTDeckTitle">T-Deck Karten-Assistent</sys:String>
     <sys:String x:Key="StrTDeckGermanyOnly">ℹ️ Offline-Karten sind nur für Deutschland verfügbar.</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -67,6 +67,7 @@
     <sys:String x:Key="StrDevice">Device:</sys:String>
     <sys:String x:Key="StrScanDevices">Search devices</sys:String>
     <sys:String x:Key="StrOpenDms">Open direct messages</sys:String>
+    <sys:String x:Key="StrOpenDashboard">Open telemetry dashboard</sys:String>
 
     <!-- Alert -->
     <sys:String x:Key="StrAlertReceived">Emergency call received!</sys:String>
@@ -965,6 +966,7 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrRaTabNetwork">Network</sys:String>
     <sys:String x:Key="StrRaTabDisplay">Display</sys:String>
     <sys:String x:Key="StrRaTabChannels">Channels</sys:String>
+    <sys:String x:Key="StrRaTabSecurity">Security</sys:String>
     <sys:String x:Key="StrRaTabControl">Control</sys:String>
     <!-- Owner tab -->
     <sys:String x:Key="StrRaOwnerShortName">Short name (max. 4 characters)</sys:String>
@@ -1013,6 +1015,12 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrRaShutdown">⏹ Shutdown</sys:String>
     <sys:String x:Key="StrRaNodeDbReset">⚠️ Clear node DB: Removes all known nodes from the device database.</sys:String>
     <sys:String x:Key="StrRaNodeDbResetBtn">⚠️ Clear node DB</sys:String>
+    <sys:String x:Key="StrRaFavoritesSection">Manage favorites on remote node</sys:String>
+    <sys:String x:Key="StrRaFavoritesDesc">Add or remove a node as a favorite on the remote device. The node will then be prioritized in the remote node's contact list.</sys:String>
+    <sys:String x:Key="StrRaFavoritesAdd">⭐ Add as favorite</sys:String>
+    <sys:String x:Key="StrRaFavoritesRemove">✕ Remove favorite</sys:String>
+    <sys:String x:Key="StrRaFavoritesAdded">Node "{0}" was added as a favorite on the remote device.</sys:String>
+    <sys:String x:Key="StrRaFavoritesRemoved">Node "{0}" was removed from favorites on the remote device.</sys:String>
     <!-- Bottom buttons -->
     <sys:String x:Key="StrRaRefresh">🔄 Reload</sys:String>
     <sys:String x:Key="StrRaSave">💾 Save</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -1079,4 +1079,18 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrDays30">30 days</sys:String>
     <sys:String x:Key="StrDaysAll">All time</sys:String>
 
+    <sys:String x:Key="StrWidgetTypeRanking">Ranking (Table)</sys:String>
+    <sys:String x:Key="StrWidgetTypeMultiStat">Multi-Stat (Tiles)</sys:String>
+    <sys:String x:Key="StrWidgetTypeMeshHealth">Mesh Health (Status)</sys:String>
+    <sys:String x:Key="StrDashboardExportCsv">Export CSV</sys:String>
+    <sys:String x:Key="StrDashboardExportDone">Exported to: {0}</sys:String>
+    <sys:String x:Key="StrDashboardThreshold">Threshold</sys:String>
+    <sys:String x:Key="StrDashboardMovingAvg">Moving Avg.</sys:String>
+    <sys:String x:Key="StrDashboardNoData">No data</sys:String>
+    <sys:String x:Key="StrRankingNode">Node</sys:String>
+    <sys:String x:Key="StrMeshHealthOffline">Offline</sys:String>
+    <sys:String x:Key="StrMeshHealthGood">Good</sys:String>
+    <sys:String x:Key="StrMeshHealthWeak">Weak</sys:String>
+    <sys:String x:Key="StrMeshHealthPoor">Poor</sys:String>
+
 </ResourceDictionary>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -1092,5 +1092,13 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrMeshHealthGood">Good</sys:String>
     <sys:String x:Key="StrMeshHealthWeak">Weak</sys:String>
     <sys:String x:Key="StrMeshHealthPoor">Poor</sys:String>
+    <sys:String x:Key="StrMeshHealthScore">Mesh Health</sys:String>
+    <sys:String x:Key="StrMeshHealthWeather">Weather</sys:String>
+    <sys:String x:Key="StrMeshHealthAntenna">Antenna</sys:String>
+    <sys:String x:Key="StrMeshHealthNeighbor">Neighbor</sys:String>
+    <sys:String x:Key="StrMeshHealthPath">Paths</sys:String>
+    <sys:String x:Key="StrMeshHealthNeighborCount">Neighbors</sys:String>
+    <sys:String x:Key="StrMeshHealthHopCost">Hop Cost</sys:String>
+    <sys:String x:Key="StrDashboardThresholdTip">Horizontal dashed line in the chart — e.g. critical RSSI value</sys:String>
 
 </ResourceDictionary>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -19,6 +19,9 @@
     <sys:String x:Key="StrTabInfo">ℹ️ Info</sys:String>
 
     <!-- Node context menu -->
+    <sys:String x:Key="StrFavorite">★ Mark as favorite</sys:String>
+    <sys:String x:Key="StrUnfavorite">★ Remove favorite</sys:String>
+    <sys:String x:Key="StrFavoriteColTooltip">Favorites (★ = favorite, synced with device)</sys:String>
     <sys:String x:Key="StrPin">📌 Pin</sys:String>
     <sys:String x:Key="StrUnpin">📌 Unpin</sys:String>
     <sys:String x:Key="StrShowPath">🛤️ Show movement path</sys:String>
@@ -625,6 +628,9 @@
     <sys:String x:Key="StrSignalAntennaUnit">Days (long-term)</sys:String>
     <!-- Settings tab - time sync -->
     <sys:String x:Key="StrTimeSyncDriftZero">(0 = no drift check)</sys:String>
+    <!-- Remote Admin settings -->
+    <sys:String x:Key="StrRemoteAdminGroup">Remote Administration</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeoutLabel">Request timeout:</sys:String>
     <!-- Settings saved dialog -->
     <sys:String x:Key="StrSettingsSaved">Settings saved.</sys:String>
     <sys:String x:Key="StrSettingsSavedTitle">Info</sys:String>
@@ -635,6 +641,7 @@
     <sys:String x:Key="StrTel30d">30 Days</sys:String>
     <sys:String x:Key="StrTelAll">Total</sys:String>
     <sys:String x:Key="StrTelOpenPlot">📈 Open in Plot</sys:String>
+    <sys:String x:Key="StrTelOpenDashboard">📊 Open Dashboard</sys:String>
     <sys:String x:Key="StrTelSnrSection">SNR (Reception Quality)</sys:String>
     <sys:String x:Key="StrTelDayLabel">Day</sys:String>
     <sys:String x:Key="StrTelNightLabel">Night</sys:String>
@@ -918,5 +925,150 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrRelayHopsTooltip">Relay hops (number of intermediate nodes)</sys:String>
     <sys:String x:Key="StrErrConnectionRefused">Connection refused — is the Meshtastic service running on the device and is the port correct?</sys:String>
     <sys:String x:Key="StrMqttBubbleTooltip">Message received via MQTT (not directly via LoRa)</sys:String>
+
+    <!-- Remote Admin -->
+    <sys:String x:Key="StrRemoteAdminHint">Remote management of a favorite node via the Meshtastic admin protocol. The target node must be reachable and allow admin access. Only nodes marked as ★ Favorite are shown in the selection.</sys:String>
+    <sys:String x:Key="StrRemoteAdmin">🛠️ Remote Admin</sys:String>
+    <sys:String x:Key="StrRemoteAdminTitle">Remote Administration</sys:String>
+    <sys:String x:Key="StrRemoteAdminConnecting">Connecting...</sys:String>
+    <sys:String x:Key="StrRemoteAdminLoading">Loading configuration...</sys:String>
+    <sys:String x:Key="StrRemoteAdminConnected">Connected</sys:String>
+    <sys:String x:Key="StrRemoteAdminWaiting">Waiting for response</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeout">Timeout — no response</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeoutMsg">No response from node within the timeout. The node may be unreachable or has not granted admin access.</sys:String>
+    <sys:String x:Key="StrRemoteAdminSaving">Saving...</sys:String>
+    <sys:String x:Key="StrRemoteAdminSaved">Saved</sys:String>
+    <sys:String x:Key="StrRemoteAdminSavedMsg">Configuration successfully sent to the node.</sys:String>
+    <sys:String x:Key="StrRemoteAdminError">Error</sys:String>
+    <sys:String x:Key="StrRemoteAdminErrorMsg">Error while saving:</sys:String>
+    <sys:String x:Key="StrRemoteAdminRebooting">Reboot sent</sys:String>
+    <sys:String x:Key="StrRemoteAdminShutdown">Shutdown sent</sys:String>
+    <sys:String x:Key="StrRemoteAdminFirmware">Firmware</sys:String>
+    <sys:String x:Key="StrRemoteAdminHardware">Hardware</sys:String>
+    <sys:String x:Key="StrRemoteAdminHops">SNR</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeout2">Timeout</sys:String>
+    <sys:String x:Key="StrRemoteAdminTimeoutTip">Request timeout in seconds (5–300). Increase for distant nodes.</sys:String>
+    <sys:String x:Key="StrRemoteAdminChannelFailed">Fetch failed – click ⟳</sys:String>
+    <sys:String x:Key="StrRemoteAdminChannelReload">Reload this channel</sys:String>
+    <sys:String x:Key="StrRemoteAdminFavoriteTip">Mark as favorite / remove favorite</sys:String>
+    <sys:String x:Key="StrRemoteAdminRebootConfirm">Really reboot the node?</sys:String>
+    <sys:String x:Key="StrRemoteAdminShutdownConfirm">Really shut down the node?</sys:String>
+    <sys:String x:Key="StrRemoteAdminNodeDbResetConfirm">Really clear the node database? All known nodes will be forgotten!</sys:String>
+    <sys:String x:Key="StrRemoteAdminSelectNode">Select node for remote administration</sys:String>
+    <sys:String x:Key="StrRemoteAdminNoFavorites">No favorites set. First mark nodes as favorites (right-click → Mark as favorite).</sys:String>
+    <!-- Remote Admin tabs -->
+    <sys:String x:Key="StrRaTabOwner">Owner</sys:String>
+    <sys:String x:Key="StrRaTabDevice">Device</sys:String>
+    <sys:String x:Key="StrRaTabPosition">Position</sys:String>
+    <sys:String x:Key="StrRaTabLora">LoRa</sys:String>
+    <sys:String x:Key="StrRaTabBluetooth">Bluetooth</sys:String>
+    <sys:String x:Key="StrRaTabNetwork">Network</sys:String>
+    <sys:String x:Key="StrRaTabDisplay">Display</sys:String>
+    <sys:String x:Key="StrRaTabChannels">Channels</sys:String>
+    <sys:String x:Key="StrRaTabControl">Control</sys:String>
+    <!-- Owner tab -->
+    <sys:String x:Key="StrRaOwnerShortName">Short name (max. 4 characters)</sys:String>
+    <sys:String x:Key="StrRaOwnerLongName">Long name</sys:String>
+    <sys:String x:Key="StrRaOwnerLicensed">Licensed amateur radio operator</sys:String>
+    <!-- Device tab -->
+    <sys:String x:Key="StrRaDeviceRole">Role</sys:String>
+    <sys:String x:Key="StrRaDeviceNodeInfoInterval">NodeInfo broadcast interval (seconds, 0=never)</sys:String>
+    <sys:String x:Key="StrRaDeviceSerialEnabled">Serial console enabled</sys:String>
+    <sys:String x:Key="StrRaDeviceDebugLog">Debug logging enabled</sys:String>
+    <!-- Position tab -->
+    <sys:String x:Key="StrRaPosGpsMode">GPS mode</sys:String>
+    <sys:String x:Key="StrRaPosBroadcastInterval">Broadcast interval (s)</sys:String>
+    <sys:String x:Key="StrRaPosBroadcastSmart">Smart broadcast enabled</sys:String>
+    <sys:String x:Key="StrRaPosGpsAttemptTime">GPS attempt time (s)</sys:String>
+    <sys:String x:Key="StrRaPosFixed">Fixed position</sys:String>
+    <sys:String x:Key="StrRaPosFixedEnabled">Fixed position enabled</sys:String>
+    <sys:String x:Key="StrRaPosLat">Latitude</sys:String>
+    <sys:String x:Key="StrRaPosLon">Longitude</sys:String>
+    <sys:String x:Key="StrRaPosAlt">Altitude (m)</sys:String>
+    <!-- LoRa tab -->
+    <sys:String x:Key="StrRaLoraRegion">Region</sys:String>
+    <sys:String x:Key="StrRaLoraPreset">Modem preset</sys:String>
+    <sys:String x:Key="StrRaLoraHopLimit">Hop limit</sys:String>
+    <sys:String x:Key="StrRaLoraTxPower">TX power (dBm, 0=max.)</sys:String>
+    <sys:String x:Key="StrRaLoraTxEnabled">TX enabled</sys:String>
+    <!-- Bluetooth tab -->
+    <sys:String x:Key="StrRaBtEnabled">Bluetooth enabled</sys:String>
+    <sys:String x:Key="StrRaBtMode">Pairing mode</sys:String>
+    <sys:String x:Key="StrRaBtPin">Fixed PIN (6 digits)</sys:String>
+    <!-- Network tab -->
+    <sys:String x:Key="StrRaWifiEnabled">WiFi enabled</sys:String>
+    <sys:String x:Key="StrRaWifiSsid">WiFi SSID</sys:String>
+    <sys:String x:Key="StrRaWifiPsk">WiFi password</sys:String>
+    <sys:String x:Key="StrRaWifiApMode">Access point mode</sys:String>
+    <sys:String x:Key="StrRaEthEnabled">Ethernet enabled</sys:String>
+    <sys:String x:Key="StrRaNtpServer">NTP server</sys:String>
+    <!-- Display tab -->
+    <sys:String x:Key="StrRaDisplayTimeout">Display timeout (s, 0=never)</sys:String>
+    <sys:String x:Key="StrRaDisplayFlip">Flip screen</sys:String>
+    <sys:String x:Key="StrRaDisplayUnits">Units</sys:String>
+    <sys:String x:Key="StrRaDisplayOledType">OLED type</sys:String>
+    <!-- Control tab -->
+    <sys:String x:Key="StrRaControlDesc">Send control commands to the remote node. These actions take effect immediately!</sys:String>
+    <sys:String x:Key="StrRaReboot">🔄 Reboot</sys:String>
+    <sys:String x:Key="StrRaShutdown">⏹ Shutdown</sys:String>
+    <sys:String x:Key="StrRaNodeDbReset">⚠️ Clear node DB: Removes all known nodes from the device database.</sys:String>
+    <sys:String x:Key="StrRaNodeDbResetBtn">⚠️ Clear node DB</sys:String>
+    <!-- Bottom buttons -->
+    <sys:String x:Key="StrRaRefresh">🔄 Reload</sys:String>
+    <sys:String x:Key="StrRaSave">💾 Save</sys:String>
+    <!-- Telemetry Dashboard -->
+    <sys:String x:Key="StrDashboardTitle">Telemetry Dashboard</sys:String>
+    <sys:String x:Key="StrDashboardLabel">Dashboard:</sys:String>
+    <sys:String x:Key="StrDashboardNew">+ New</sys:String>
+    <sys:String x:Key="StrDashboardRename">Rename</sys:String>
+    <sys:String x:Key="StrDashboardDelete">Delete</sys:String>
+    <sys:String x:Key="StrDashboardAddWidget">+ Add Widget</sys:String>
+    <sys:String x:Key="StrDashboardRefresh">↺ Refresh</sys:String>
+    <sys:String x:Key="StrDashboardNewTitle">New Dashboard</sys:String>
+    <sys:String x:Key="StrDashboardRenameTitle">Rename Dashboard</sys:String>
+    <sys:String x:Key="StrDashboardNewPrompt">Name:</sys:String>
+    <sys:String x:Key="StrDashboardDefaultName">Dashboard</sys:String>
+    <sys:String x:Key="StrDashboardDeleteConfirm">Delete dashboard "{0}"?</sys:String>
+    <sys:String x:Key="StrDashboardNoDashboard">Please create a dashboard first.</sys:String>
+    <sys:String x:Key="StrDashboardEmpty">No dashboard selected. Create a new dashboard and add widgets.</sys:String>
+    <sys:String x:Key="StrDashboardWidgetCount">Widgets</sys:String>
+    <sys:String x:Key="StrDashboardRemoveWidget">Remove widget</sys:String>
+    <sys:String x:Key="StrDashboardEditWidget">Edit widget</sys:String>
+    <sys:String x:Key="StrDashboardLastUpdated">Last value</sys:String>
+    <sys:String x:Key="StrDashboardHourOfDay">Hour (0–23)</sys:String>
+    <sys:String x:Key="StrDashboardDayIndex">Day</sys:String>
+    <!-- Add Widget Dialog -->
+    <sys:String x:Key="StrAddWidgetTitle">Add Widget</sys:String>
+    <sys:String x:Key="StrAddWidgetType">Widget type:</sys:String>
+    <sys:String x:Key="StrAddWidgetMetric">Metric:</sys:String>
+    <sys:String x:Key="StrAddWidgetDays">Time range:</sys:String>
+    <sys:String x:Key="StrAddWidgetNodes">Nodes (multi-select):</sys:String>
+    <sys:String x:Key="StrAddWidgetCustomTitle">Title (empty = auto):</sys:String>
+    <sys:String x:Key="StrAddWidgetNoNode">Please select at least one node.</sys:String>
+    <sys:String x:Key="StrWidgetTypeLine">Time series (line chart)</sys:String>
+    <sys:String x:Key="StrWidgetTypeBar">Bar chart (current values)</sys:String>
+    <sys:String x:Key="StrWidgetTypeGauge">Gauge (single value)</sys:String>
+    <sys:String x:Key="StrWidgetTypeHeatmap">Heatmap (hour × day)</sys:String>
+    <sys:String x:Key="StrWidgetTypeArea">Area chart</sys:String>
+    <sys:String x:Key="StrWidgetTypeScatter">Scatter plot</sys:String>
+    <sys:String x:Key="StrWidgetTypeStat">Stat card (big number)</sys:String>
+    <sys:String x:Key="StrWidgetTypeClock">Clock (UTC + Local)</sys:String>
+    <sys:String x:Key="StrWidgetTypeHistogram">Histogram (Distribution)</sys:String>
+    <sys:String x:Key="StrWidgetTypeCandlestick">Candlestick (daily OHLC)</sys:String>
+    <sys:String x:Key="StrWidgetTypeStateline">State Timeline (Activity)</sys:String>
+    <sys:String x:Key="StrDashboardCount">Count</sys:String>
+    <!-- Auto-refresh -->
+    <sys:String x:Key="StrDashboardAutoRefresh">Auto-refresh:</sys:String>
+    <sys:String x:Key="StrDashboardRefreshOff">Off</sys:String>
+    <sys:String x:Key="StrDashboardLastRefreshed">Refreshed: {0}</sys:String>
+    <!-- Node search / single-node hint -->
+    <sys:String x:Key="StrAddWidgetNodeSearch">Search nodes…</sys:String>
+    <sys:String x:Key="StrAddWidgetSingleNodeHint">Single node only</sys:String>
+    <!-- Time range labels -->
+    <sys:String x:Key="StrDays1">1 day</sys:String>
+    <sys:String x:Key="StrDays7">7 days</sys:String>
+    <sys:String x:Key="StrDays14">14 days</sys:String>
+    <sys:String x:Key="StrDays30">30 days</sys:String>
+    <sys:String x:Key="StrDaysAll">All time</sys:String>
 
 </ResourceDictionary>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -1022,8 +1022,10 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrRaFavoritesAdded">Node "{0}" was added as a favorite on the remote device.</sys:String>
     <sys:String x:Key="StrRaFavoritesRemoved">Node "{0}" was removed from favorites on the remote device.</sys:String>
     <!-- Bottom buttons -->
-    <sys:String x:Key="StrRaRefresh">🔄 Reload</sys:String>
+    <sys:String x:Key="StrRaRefresh">🔄 Reload All</sys:String>
+    <sys:String x:Key="StrRaReloadTab">↻ Reload Tab</sys:String>
     <sys:String x:Key="StrRaSave">💾 Save</sys:String>
+    <sys:String x:Key="StrRaLoadAllQuestion">Load all settings now?&#x0a;&#x0a;Yes  = load everything immediately (approx. 30–60 sec.)&#x0a;No  = load page by page (click a tab)</sys:String>
     <!-- Telemetry Dashboard -->
     <sys:String x:Key="StrDashboardTitle">Telemetry Dashboard</sys:String>
     <sys:String x:Key="StrDashboardLabel">Dashboard:</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -1110,6 +1110,19 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrToolsExportDesc">Export your locally downloaded map tiles as a ZIP file.</sys:String>
     <sys:String x:Key="StrToolsExportBtn">📦 Export tiles as ZIP...</sys:String>
 
+    <!-- Virtual Node -->
+    <sys:String x:Key="StrVirtualNodeSection">Virtual Node</sys:String>
+    <sys:String x:Key="StrVirtualNodeDesc">Starts a TCP server that Meshtastic apps (Android/iOS) can connect to — as if it were a real device. Requires an active connection to a physical node.</sys:String>
+    <sys:String x:Key="StrVirtualNodeEnable">Enable Virtual Node</sys:String>
+    <sys:String x:Key="StrVirtualNodePort">Port:</sys:String>
+    <sys:String x:Key="StrVirtualNodeBlockAdmin">Block admin commands from clients</sys:String>
+    <sys:String x:Key="StrVirtualNodeStatus">Status:</sys:String>
+    <sys:String x:Key="StrVirtualNodeRunning">Running ✓</sys:String>
+    <sys:String x:Key="StrVirtualNodeStopped">Stopped</sys:String>
+    <sys:String x:Key="StrVirtualNodeClients">Connected clients:</sys:String>
+    <sys:String x:Key="StrVirtualNodeNoClients">(none)</sys:String>
+    <sys:String x:Key="StrVirtualNodeNotConnected">No physical node connected.</sys:String>
+
     <!-- TDeck Wizard: common -->
     <sys:String x:Key="StrTDeckTitle">T-Deck Map Assistant</sys:String>
     <sys:String x:Key="StrTDeckGermanyOnly">ℹ️ Offline maps are only available for Germany.</sys:String>

--- a/MeshhessenClient/Resources/Strings.en.xaml
+++ b/MeshhessenClient/Resources/Strings.en.xaml
@@ -1101,4 +1101,140 @@ Green ≤15% | Yellow 15–25% | Red &gt;25% | Gray = no airtime data</sys:Strin
     <sys:String x:Key="StrMeshHealthHopCost">Hop Cost</sys:String>
     <sys:String x:Key="StrDashboardThresholdTip">Horizontal dashed line in the chart — e.g. critical RSSI value</sys:String>
 
+    <!-- Tools tab -->
+    <sys:String x:Key="StrTabTools">🔧 Tools</sys:String>
+    <sys:String x:Key="StrToolsTDeckSection">T-Deck Map Assistant</sys:String>
+    <sys:String x:Key="StrToolsTDeckDesc">Prepare an SD card with offline maps for your Meshtastic T-Deck. The wizard guides you through formatting, region selection, and download.</sys:String>
+    <sys:String x:Key="StrToolsTDeckBtn">🗺️ Prepare maps for T-Deck...</sys:String>
+    <sys:String x:Key="StrToolsExportSection">Tile Export</sys:String>
+    <sys:String x:Key="StrToolsExportDesc">Export your locally downloaded map tiles as a ZIP file.</sys:String>
+    <sys:String x:Key="StrToolsExportBtn">📦 Export tiles as ZIP...</sys:String>
+
+    <!-- TDeck Wizard: common -->
+    <sys:String x:Key="StrTDeckTitle">T-Deck Map Assistant</sys:String>
+    <sys:String x:Key="StrTDeckGermanyOnly">ℹ️ Offline maps are only available for Germany.</sys:String>
+    <sys:String x:Key="StrTDeckBack">◀ Back</sys:String>
+    <sys:String x:Key="StrTDeckNext">Next ▶</sys:String>
+    <sys:String x:Key="StrTDeckCancel">Cancel</sys:String>
+    <sys:String x:Key="StrTDeckClose">Close</sys:String>
+    <sys:String x:Key="StrTDeckStep">Step {0} of {1}</sys:String>
+
+    <!-- TDeck Step 1: Welcome -->
+    <sys:String x:Key="StrTDeckS1Title">Welcome</sys:String>
+    <sys:String x:Key="StrTDeckS1Desc">This wizard helps you transfer offline map tiles to an SD card for your Meshtastic T-Deck.
+
+What does this wizard do?
+  • Checks and formats the SD card (exFAT / FAT32)
+  • Lets you select the map region (by state, all Germany, or custom area)
+  • Selects zoom level and map type (OSM, OpenTopo, OSM Dark)
+  • Copies locally available tiles directly — and downloads missing ones
+
+ℹ️ Maps are only available for Germany (Meshhessen tile server).
+
+Downloads are additive: tiles already on the SD card are not transferred again.</sys:String>
+
+    <!-- TDeck Step 2: Drive selection -->
+    <sys:String x:Key="StrTDeckS2Title">Select SD Card</sys:String>
+    <sys:String x:Key="StrTDeckS2Hint">Select the drive of your SD card. Only removable drives are shown.</sys:String>
+    <sys:String x:Key="StrTDeckDriveLabel">Available removable drives:</sys:String>
+    <sys:String x:Key="StrTDeckRefresh">Refresh</sys:String>
+    <sys:String x:Key="StrTDeckNoDrives">No removable drives found. Insert the SD card and click "Refresh".</sys:String>
+    <sys:String x:Key="StrTDeckDriveInfo">Total: {0} | Free: {1} | File system: {2}</sys:String>
+    <sys:String x:Key="StrTDeckSelectDriveFirst">Please select a drive first.</sys:String>
+
+    <!-- TDeck Step 3: Format check -->
+    <sys:String x:Key="StrTDeckS3Title">Check Formatting</sys:String>
+    <sys:String x:Key="StrTDeckFormatOk">✅ Drive is correctly formatted ({0}). No action required.</sys:String>
+    <sys:String x:Key="StrTDeckFormatWarn">⚠️ Drive is formatted as "{0}".
+Recommended: exFAT (any size) or FAT32 (up to 32 GB) with the smallest available allocation unit.
+You can continue anyway or format the drive.</sys:String>
+    <sys:String x:Key="StrTDeckFormatHint">The T-Deck recognises exFAT most reliably. Important: choose the smallest available allocation unit (e.g. 4096 bytes). Many tiles (especially ocean/empty areas) are only ~100 bytes but still occupy a full allocation unit — small units save significant space. Formatting requires administrator rights.</sys:String>
+    <sys:String x:Key="StrTDeckFormatBtn">Format drive...</sys:String>
+    <sys:String x:Key="StrTDeckSkipFormat">Skip formatting</sys:String>
+    <sys:String x:Key="StrTDeckFmtConfirmTitle">Confirm formatting</sys:String>
+    <sys:String x:Key="StrTDeckFmtConfirm1">⚠️ WARNING: All data on drive {0} will be permanently deleted!
+
+Really format?</sys:String>
+    <sys:String x:Key="StrTDeckFmtConfirm2">🔴 FINAL WARNING: Formatting will delete ALL data on {0} forever!
+
+Proceed?</sys:String>
+    <sys:String x:Key="StrTDeckFmtExFAT">exFAT with 4096 bytes (recommended for T-Deck)</sys:String>
+    <sys:String x:Key="StrTDeckFmtFAT32">FAT32 with 512 bytes (legacy devices, max. 32 GB)</sys:String>
+    <sys:String x:Key="StrTDeckFmtChoiceTitle">Choose file system</sys:String>
+    <sys:String x:Key="StrTDeckFmtChoiceHint">Choose the file system for formatting. exFAT with 4096 bytes is recommended for T-Deck:</sys:String>
+    <sys:String x:Key="StrTDeckFormatting">Formatting drive {0}... (watch for UAC prompt)</sys:String>
+    <sys:String x:Key="StrTDeckFormatDone">✅ Drive successfully formatted ({0}).</sys:String>
+    <sys:String x:Key="StrTDeckFormatFailed">❌ Formatting failed or was cancelled.</sys:String>
+
+    <!-- TDeck Step 4: Region selection -->
+    <sys:String x:Key="StrTDeckS4Title">Select Region</sys:String>
+    <sys:String x:Key="StrTDeckRegionByState">Select by federal state(s)</sys:String>
+    <sys:String x:Key="StrTDeckRegionGermany">All of Germany</sys:String>
+    <sys:String x:Key="StrTDeckRegionFreeStyle">Draw custom area</sys:String>
+    <sys:String x:Key="StrTDeckStateSelectAll">All</sys:String>
+    <sys:String x:Key="StrTDeckStateSelectNone">None</sys:String>
+    <sys:String x:Key="StrTDeckOpenMap">🗺️ Draw area on map...</sys:String>
+    <sys:String x:Key="StrTDeckBboxPreview">Selected area: N {0:F4}° | S {1:F4}° | W {2:F4}° | E {3:F4}°</sys:String>
+    <sys:String x:Key="StrTDeckNoRegion">Please select at least one state or draw an area.</sys:String>
+    <sys:String x:Key="StrTDeckFreestyleNotSet">No area drawn yet. Click "Draw area on map".</sys:String>
+
+    <!-- TDeck Step 5: Zoom & map type -->
+    <sys:String x:Key="StrTDeckS5Title">Zoom Level and Map Type</sys:String>
+    <sys:String x:Key="StrTDeckZoomLabel">Maximum zoom level (level 1 always included):</sys:String>
+    <sys:String x:Key="StrTDeckZoom8">8 — Overview (states)</sys:String>
+    <sys:String x:Key="StrTDeckZoom10">10 — Districts</sys:String>
+    <sys:String x:Key="StrTDeckZoom12">12 — City level</sys:String>
+    <sys:String x:Key="StrTDeckZoom14">14 — Streets (recommended)</sys:String>
+    <sys:String x:Key="StrTDeckZoom16">16 — Detail (many tiles!)</sys:String>
+    <sys:String x:Key="StrTDeckZoom17">17 — Maximum (extremely many tiles!)</sys:String>
+    <sys:String x:Key="StrTDeckZoomWarn14">⚠️ Zoom 14 can already cover many tens of thousands of tiles. Download may take hours.</sys:String>
+    <sys:String x:Key="StrTDeckZoomWarn16">🔴 Zoom 16+ may result in millions of tiles! Download can take days and requires significant storage.</sys:String>
+    <sys:String x:Key="StrTDeckMapTypeLabel">Map type:</sys:String>
+    <sys:String x:Key="StrTDeckMapOSM">OpenStreetMap (standard)</sys:String>
+    <sys:String x:Key="StrTDeckMapDark">OSM Dark</sys:String>
+    <sys:String x:Key="StrTDeckMapTopo">OpenTopoMap</sys:String>
+    <sys:String x:Key="StrTDeckEstimate">Estimated tiles: approx. {0:N0} (~{1})</sys:String>
+    <sys:String x:Key="StrTDeckSDFree">Free space on SD: {0}</sys:String>
+    <sys:String x:Key="StrTDeckSDLow">⚠️ The SD card may not have enough free space!</sys:String>
+    <sys:String x:Key="StrTDeckSelectMapType">Please select a map type.</sys:String>
+
+    <!-- TDeck Step 6: Download -->
+    <sys:String x:Key="StrTDeckS6Title">Download &amp; Transfer</sys:String>
+    <sys:String x:Key="StrTDeckSummaryTitle">Summary:</sys:String>
+    <sys:String x:Key="StrTDeckSumDrive">Drive:</sys:String>
+    <sys:String x:Key="StrTDeckSumRegion">Region:</sys:String>
+    <sys:String x:Key="StrTDeckSumZoom">Max. zoom:</sys:String>
+    <sys:String x:Key="StrTDeckSumType">Map type:</sys:String>
+    <sys:String x:Key="StrTDeckSumTiles">Estimated tiles:</sys:String>
+    <sys:String x:Key="StrTDeckCopyHint">✅ Locally available tiles are copied directly — no re-download needed.</sys:String>
+    <sys:String x:Key="StrTDeckAdditiveHint">✅ Tiles already on the SD card are skipped.</sys:String>
+    <sys:String x:Key="StrTDeckStartBtn">▶ Download &amp; Copy</sys:String>
+    <sys:String x:Key="StrTDeckProgressTile">Tile {0} / {1} ({2:P0})</sys:String>
+    <sys:String x:Key="StrTDeckProgressZoom">Zoom {0} — X:{1} Y:{2}</sys:String>
+    <sys:String x:Key="StrTDeckDone">✅ Transfer complete! {0:N0} tiles on SD card.</sys:String>
+    <sys:String x:Key="StrTDeckCancelled">Cancelled.</sys:String>
+    <sys:String x:Key="StrTDeckError">Error: {0}</sys:String>
+
+    <!-- TDeck region map window -->
+    <sys:String x:Key="StrTDeckMapPickTitle">Draw Area on Map</sys:String>
+    <sys:String x:Key="StrTDeckMapPickHint">Navigate to your region, activate "Draw Mode" and drag rectangles. Multiple rectangles allowed – the bounding hull of all areas is used.</sys:String>
+    <sys:String x:Key="StrTDeckMapPickAccept">✅ Accept</sys:String>
+    <sys:String x:Key="StrTDeckMapPickClear">Clear selection</sys:String>
+    <sys:String x:Key="StrTDeckMapPickNoSel">No area drawn yet.</sys:String>
+    <sys:String x:Key="StrTDeckMapPickSel">{0} area(s) – hull: N {1:F4}° S {2:F4}° W {3:F4}° E {4:F4}°</sys:String>
+    <sys:String x:Key="StrTDeckMapDrawModeOn">✏ Draw Mode</sys:String>
+    <sys:String x:Key="StrTDeckMapDrawModeOff">🖐 Navigate</sys:String>
+    <sys:String x:Key="StrTDeckMapClearLast">Clear Last</sys:String>
+    <sys:String x:Key="StrTDeckMapClearAll">Clear All</sys:String>
+
+    <!-- TDeck export window -->
+    <sys:String x:Key="StrTDeckExportTitle">Export Tiles as ZIP</sys:String>
+    <sys:String x:Key="StrTDeckExportHint">Exports all locally stored map tiles to a ZIP file. This can be re-imported later using the "Load Maptiles from ZIP" button.</sys:String>
+    <sys:String x:Key="StrTDeckExportTypeLabel">Map type:</sys:String>
+    <sys:String x:Key="StrTDeckExportAllTypes">All types</sys:String>
+    <sys:String x:Key="StrTDeckExportStartBtn">📦 Export...</sys:String>
+    <sys:String x:Key="StrTDeckExportDone">✅ Export complete: {0}</sys:String>
+    <sys:String x:Key="StrTDeckExportFailed">❌ Export failed: {0}</sys:String>
+    <sys:String x:Key="StrTDeckExportNoTiles">No local tiles found for this map type.</sys:String>
+
 </ResourceDictionary>

--- a/MeshhessenClient/Services/DriveService.cs
+++ b/MeshhessenClient/Services/DriveService.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.IO;
+
+namespace MeshhessenClient.Services;
+
+public enum FormatResult { Success, Failed, Cancelled }
+
+public record DriveFormatStatus(bool IsRecommended, string FileSystem, string Recommendation);
+
+public static class DriveService
+{
+    public static List<DriveInfo> GetRemovableDrives()
+    {
+        return DriveInfo.GetDrives()
+            .Where(d => d.DriveType == DriveType.Removable && d.IsReady)
+            .ToList();
+    }
+
+    public static DriveFormatStatus CheckFormat(DriveInfo drive)
+    {
+        var fs = drive.DriveFormat?.ToUpperInvariant() ?? "UNKNOWN";
+        bool ok = fs is "EXFAT" or "FAT32";
+        string rec = fs switch
+        {
+            "EXFAT" => "exFAT",
+            "FAT32" => "FAT32",
+            _ => "exFAT"
+        };
+        return new DriveFormatStatus(ok, drive.DriveFormat ?? "Unknown", rec);
+    }
+
+    // Returns recommended file system name for PowerShell Format-Volume
+    public static string RecommendedFileSystem(DriveInfo drive) => "exFAT";
+
+    // Allocation unit: 4096 for exFAT (recommended for T-Deck tile storage)
+    public static int GetAllocationUnit(string fileSystem) => fileSystem switch
+    {
+        "FAT32" => 512,
+        _ => 4096  // exFAT default - saves space for small tiles
+    };
+
+    public static string FormatSizeString(long bytes)
+    {
+        if (bytes >= 1L << 30) return $"{bytes / (1L << 30):F1} GB";
+        if (bytes >= 1L << 20) return $"{bytes / (1L << 20):F1} MB";
+        return $"{bytes / (1L << 10):F0} KB";
+    }
+
+    public static async Task<FormatResult> FormatDriveAsync(
+        char driveLetter,
+        string fileSystem,
+        IProgress<string>? progress = null)
+    {
+        // Map friendly names to PowerShell filesystem param
+        string psFs = fileSystem switch
+        {
+            "FAT32" => "FAT32",
+            _ => "exFAT"
+        };
+        int allocUnit = GetAllocationUnit(psFs);
+
+        // Build PowerShell command for Format-Volume (no interactive prompt)
+        string psArgs = $"-NonInteractive -WindowStyle Hidden -Command " +
+            $"\"Format-Volume -DriveLetter {driveLetter} " +
+            $"-FileSystem {psFs} " +
+            $"-AllocationUnitSize {allocUnit} " +
+            $"-NewFileSystemLabel 'T-DECK' " +
+            $"-Confirm:$false -Force\"";
+
+        progress?.Report($"Formatting {driveLetter}:\\ as {psFs} ({allocUnit} bytes)...");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = psArgs,
+            Verb = "runas",          // UAC elevation
+            UseShellExecute = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        };
+
+        try
+        {
+            var proc = Process.Start(psi);
+            if (proc == null) return FormatResult.Failed;
+            await proc.WaitForExitAsync();
+            return proc.ExitCode == 0 ? FormatResult.Success : FormatResult.Failed;
+        }
+        catch (Exception ex) when (ex.Message.Contains("cancelled", StringComparison.OrdinalIgnoreCase)
+                                 || ex.HResult == unchecked((int)0x800704C7))
+        {
+            return FormatResult.Cancelled;
+        }
+        catch
+        {
+            return FormatResult.Failed;
+        }
+    }
+
+    public static bool IsDriveReady(char driveLetter)
+    {
+        try
+        {
+            var info = new DriveInfo(driveLetter.ToString());
+            return info.IsReady;
+        }
+        catch { return false; }
+    }
+}

--- a/MeshhessenClient/Services/MeshtasticProtocolService.cs
+++ b/MeshhessenClient/Services/MeshtasticProtocolService.cs
@@ -27,6 +27,10 @@ public class MeshtasticProtocolService
     private bool _debugDevice = false;
     private readonly HashSet<int> _receivedChannelResponses = new(); // Tracks which channel indices we got via GetChannelResponse
     private byte[] _sessionPasskey = Array.Empty<byte>(); // Session key from admin responses (required for write operations)
+
+    // Remote admin state — per-node session keys and pending request completions
+    private readonly Dictionary<uint, byte[]> _remoteSessionKeys = new();
+    private readonly Dictionary<uint, TaskCompletionSource<AdminMessage>> _pendingRemoteRequests = new();
     private DateTime _lastValidPacketTime = DateTime.MinValue;
     private int _consecutiveTextChunks = 0;
     private bool _recoveryInProgress = false;
@@ -1239,6 +1243,7 @@ public class MeshtasticProtocolService
             }
 
             nodeInfo.PkiKeyKnown = _nodeKeyService?.GetPublicKey(protoNodeInfo.Num) != null;
+            nodeInfo.IsFavorite = protoNodeInfo.IsFavorite;
 
             // Update DeviceInfo if this is our own node
             if (protoNodeInfo.Num == _myNodeId && _myDeviceInfo != null && !string.IsNullOrEmpty(nodeInfo.HardwareModel))
@@ -2123,6 +2128,79 @@ public class MeshtasticProtocolService
         await SendAdminMessageAsync(adminMsg);
     }
 
+    public async Task AddFavoriteNodeAsync(uint nodeId)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { AddFavoriteNode = nodeId };
+        await SendAdminMessageAsync(adminMsg);
+        Logger.WriteLine($"AddFavoriteNode sent for node !{nodeId:x8}");
+    }
+
+    public async Task RemoveFavoriteNodeAsync(uint nodeId)
+    {
+        await EnsureSessionKeyAsync();
+        var adminMsg = new AdminMessage { RemoveFavoriteNode = nodeId };
+        await SendAdminMessageAsync(adminMsg);
+        Logger.WriteLine($"RemoveFavoriteNode sent for node !{nodeId:x8}");
+    }
+
+    // ===== Remote Admin =====
+
+    /// <summary>Sends an admin request to a remote node and waits for the response (or timeout).</summary>
+    public async Task<AdminMessage?> SendRemoteAdminRequestAsync(uint destNodeId, AdminMessage adminMsg, int timeoutMs = 30000)
+    {
+        var tcs = new TaskCompletionSource<AdminMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_dataLock)
+        {
+            _pendingRemoteRequests[destNodeId] = tcs;
+            if (_remoteSessionKeys.TryGetValue(destNodeId, out var key) && key.Length > 0)
+                adminMsg.SessionPasskey = ByteString.CopyFrom(key);
+        }
+        var meshPacket = new MeshPacket
+        {
+            From = _myNodeId,
+            To = destNodeId,
+            Decoded = new Data { Portnum = 6, Payload = adminMsg.ToByteString(), WantResponse = true },
+            Id = (uint)Random.Shared.Next()
+        };
+        await SendToRadioAsync(new ToRadio { Packet = meshPacket });
+        Logger.WriteLine($"[RemoteAdmin] Request {adminMsg.PayloadVariantCase} → !{destNodeId:x8} (timeout {timeoutMs}ms)");
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(timeoutMs));
+        lock (_dataLock) { _pendingRemoteRequests.Remove(destNodeId); }
+
+        if (completed != tcs.Task)
+        {
+            Logger.WriteLine($"[RemoteAdmin] Timeout waiting for response from !{destNodeId:x8}");
+            return null;
+        }
+        return tcs.Task.Result;
+    }
+
+    /// <summary>Sends an admin write to a remote node (fire-and-forget after obtaining session key).</summary>
+    public async Task SendRemoteAdminWriteAsync(uint destNodeId, AdminMessage adminMsg)
+    {
+        byte[]? key;
+        lock (_dataLock) { _remoteSessionKeys.TryGetValue(destNodeId, out key); }
+        if (key != null && key.Length > 0)
+            adminMsg.SessionPasskey = ByteString.CopyFrom(key);
+
+        var meshPacket = new MeshPacket
+        {
+            From = _myNodeId,
+            To = destNodeId,
+            Decoded = new Data { Portnum = 6, Payload = adminMsg.ToByteString(), WantResponse = false },
+            Id = (uint)Random.Shared.Next()
+        };
+        await SendToRadioAsync(new ToRadio { Packet = meshPacket });
+        Logger.WriteLine($"[RemoteAdmin] Write {adminMsg.PayloadVariantCase} → !{destNodeId:x8}");
+    }
+
+    public void ClearRemoteSessionKey(uint destNodeId)
+    {
+        lock (_dataLock) { _remoteSessionKeys.Remove(destNodeId); }
+    }
+
     public void Disconnect()
     {
         Logger.WriteLine("MeshtasticProtocolService: Disconnecting...");
@@ -2169,7 +2247,20 @@ public class MeshtasticProtocolService
             Logger.WriteLine($"Admin message RAW payload ({payloadBytes.Length} bytes): [{payloadHex}]");
 
             var adminMsg = AdminMessage.Parser.ParseFrom(data.Payload);
-            Logger.WriteLine($"Admin message: {adminMsg.PayloadVariantCase}");
+            Logger.WriteLine($"Admin message: {adminMsg.PayloadVariantCase} (from=!{packet.From:x8})");
+
+            // Remote admin response — route to waiting TCS and return
+            if (packet.From != _myNodeId && packet.From != 0)
+            {
+                lock (_dataLock)
+                {
+                    if (adminMsg.SessionPasskey != null && adminMsg.SessionPasskey.Length > 0)
+                        _remoteSessionKeys[packet.From] = adminMsg.SessionPasskey.ToByteArray();
+                    if (_pendingRemoteRequests.TryGetValue(packet.From, out var remoteTcs))
+                        remoteTcs.TrySetResult(adminMsg);
+                }
+                return;
+            }
 
             // Store session passkey from every admin response (required for write operations)
             if (adminMsg.SessionPasskey != null && adminMsg.SessionPasskey.Length > 0)

--- a/MeshhessenClient/Services/MeshtasticProtocolService.cs
+++ b/MeshhessenClient/Services/MeshtasticProtocolService.cs
@@ -2177,15 +2177,15 @@ public class MeshtasticProtocolService
     public async Task AddFavoriteNodeAsync(uint nodeId)
     {
         await EnsureSessionKeyAsync();
-        var adminMsg = new AdminMessage { AddFavoriteNode = nodeId };
+        var adminMsg = new AdminMessage { SetFavoriteNode = nodeId }; // field 39
         await SendAdminMessageAsync(adminMsg);
-        Logger.WriteLine($"AddFavoriteNode sent for node !{nodeId:x8}");
+        Logger.WriteLine($"SetFavoriteNode sent for node !{nodeId:x8}");
     }
 
     public async Task RemoveFavoriteNodeAsync(uint nodeId)
     {
         await EnsureSessionKeyAsync();
-        var adminMsg = new AdminMessage { RemoveFavoriteNode = nodeId };
+        var adminMsg = new AdminMessage { RemoveFavoriteNode = nodeId }; // field 40
         await SendAdminMessageAsync(adminMsg);
         Logger.WriteLine($"RemoveFavoriteNode sent for node !{nodeId:x8}");
     }

--- a/MeshhessenClient/Services/MeshtasticProtocolService.cs
+++ b/MeshhessenClient/Services/MeshtasticProtocolService.cs
@@ -69,6 +69,33 @@ public class MeshtasticProtocolService
     public event EventHandler<uint>? WaypointDeleted;
     /// <summary>Raised when the radio sends an MqttClientProxyMessage (device→broker direction).</summary>
     public event EventHandler<MqttClientProxyMessage>? MqttProxyMessageReceived;
+    /// <summary>Fired with each complete raw framed packet from the physical node (0x94 0xC3 + len + payload).</summary>
+    public event EventHandler<byte[]>? RawFrameReceived;
+
+    /// <summary>Injects a FromRadio payload originating from a VN client into the local processing pipeline.</summary>
+    public void ProcessExternalPacket(byte[] fromRadioPayload)
+    {
+        try
+        {
+            var fr = FromRadio.Parser.ParseFrom(fromRadioPayload);
+            if (fr.PayloadVariantCase != FromRadio.PayloadVariantOneofCase.Packet) return;
+
+            var packet = fr.Packet;
+            // Skip outgoing traceroute requests — the response will arrive via the normal physical path
+            if (packet.Decoded != null && packet.Decoded.WantResponse && packet.Decoded.Portnum == 70)
+                return;
+
+            // If the sender didn't fill in 'from', attribute the packet to our own node
+            if (packet.From == 0 && _myNodeId != 0)
+                packet.From = _myNodeId;
+
+            ProcessPacket(fr.ToByteArray());
+        }
+        catch (Exception ex)
+        {
+            Logger.WriteLine($"[VN inject] ProcessExternalPacket error: {ex.Message}");
+        }
+    }
     public int TimeDriftThresholdSeconds { get; set; } = 300; // 5 minutes
 
     private DateTime _lastDriftCheck = DateTime.MinValue;
@@ -433,11 +460,17 @@ public class MeshtasticProtocolService
             else
             {
                 // Serial/TCP use framing - buffer and process
+                List<byte[]>? rawFrames = null;
                 lock (_receiveBuffer)
                 {
                     _receiveBuffer.AddRange(data);
-                    ProcessBuffer();
+                    ProcessBuffer(ref rawFrames);
                 }
+                // Fire RawFrameReceived outside the lock so VN cache/broadcast work
+                // doesn't compete with the receive buffer on high-volume init streams
+                if (rawFrames != null)
+                    foreach (var rf in rawFrames)
+                        RawFrameReceived?.Invoke(this, rf);
             }
         }
         catch (Exception ex)
@@ -459,7 +492,7 @@ public class MeshtasticProtocolService
         }
     }
 
-    private void ProcessBuffer()
+    private void ProcessBuffer(ref List<byte[]>? rawFrames)
     {
         try
         {
@@ -554,6 +587,19 @@ public class MeshtasticProtocolService
                 // Gültiges Protobuf-Paket empfangen - Text-Modus-Zähler zurücksetzen
                 _consecutiveTextChunks = 0;
                 _lastValidPacketTime = DateTime.Now;
+
+                // Collect raw frame for Virtual Node proxy (fired outside lock)
+                if (RawFrameReceived != null)
+                {
+                    var rawFrame = new byte[4 + packetLength];
+                    rawFrame[0] = PACKET_START_BYTE_1;
+                    rawFrame[1] = PACKET_START_BYTE_2;
+                    rawFrame[2] = (byte)(packetLength >> 8);
+                    rawFrame[3] = (byte)(packetLength & 0xFF);
+                    Array.Copy(packet, 0, rawFrame, 4, packetLength);
+                    rawFrames ??= new List<byte[]>();
+                    rawFrames.Add(rawFrame);
+                }
 
                 try
                 {

--- a/MeshhessenClient/Services/SettingsService.cs
+++ b/MeshhessenClient/Services/SettingsService.cs
@@ -28,6 +28,7 @@ public record AppSettings(
     string Language,                         // UI language: "de" or "en"
     bool EnableLocationLogging,              // Log GPS positions to locationlogs/
     Dictionary<uint, bool> PinnedNodes,      // NodeId -> pinned
+    Dictionary<uint, bool> FavoriteNodes,    // NodeId -> favorite (synced with device)
     int TelemetryRetentionDays,              // 0=unlimited, 30/90/365
     PskMismatchAction NodeKeyMismatchAction, // Warn / Overwrite / Ask
     int SignalWeatherWindowHours,            // Short analysis window for weather detection (default 6h)
@@ -39,7 +40,8 @@ public record AppSettings(
     bool EnableMessageDb,                    // Persist messages in SQLite DB
     int MessageDbRetentionDays,              // 0=unlimited, 30/90/365
     string LastConnectionType,              // "Serial", "Bluetooth", "Tcp"
-    string LastBtDevice);                   // Last used Bluetooth device name
+    string LastBtDevice,                   // Last used Bluetooth device name
+    int RemoteAdminTimeoutSeconds);        // Timeout for remote admin requests in seconds (default 30)
 
 public static class SettingsService
 {
@@ -70,6 +72,7 @@ public static class SettingsService
             "de",   // Language default German
             false,  // EnableLocationLogging default off
             new Dictionary<uint, bool>(),   // PinnedNodes
+            new Dictionary<uint, bool>(),   // FavoriteNodes
             90,                             // TelemetryRetentionDays default 90
             PskMismatchAction.Overwrite,    // NodeKeyMismatchAction default Overwrite
             6,                              // SignalWeatherWindowHours default 6h
@@ -81,7 +84,8 @@ public static class SettingsService
             true,                           // EnableMessageDb default on
             90,                             // MessageDbRetentionDays default 90
             "Serial",                       // LastConnectionType default Serial
-            string.Empty);                  // LastBtDevice default empty
+            string.Empty,                   // LastBtDevice default empty
+            30);                            // RemoteAdminTimeoutSeconds default 30s
 
         try
         {
@@ -144,6 +148,20 @@ public static class SettingsService
                 }
             }
 
+            // Load favorite nodes
+            var favoriteNodes = new Dictionary<uint, bool>();
+            foreach (var key in values.Keys)
+            {
+                if (key.StartsWith("FavoriteNode_", StringComparison.OrdinalIgnoreCase))
+                {
+                    var nodeIdHex = key.Substring(13);
+                    if (uint.TryParse(nodeIdHex, NumberStyles.HexNumber, null, out uint nodeId))
+                    {
+                        favoriteNodes[nodeId] = true;
+                    }
+                }
+            }
+
             // Migration: Convert old TileServerUrl to new format
             string osmUrl = defaults.OSMTileUrl;
             string osmTopoUrl = defaults.OSMTopoTileUrl;
@@ -189,6 +207,7 @@ public static class SettingsService
                 Language: values.TryGetValue("Language", out var lang) && !string.IsNullOrEmpty(lang) ? lang : defaults.Language,
                 EnableLocationLogging: values.TryGetValue("EnableLocationLogging", out var ell) && bool.TryParse(ell, out var ellBool) && ellBool,
                 PinnedNodes: pinnedNodes,
+                FavoriteNodes: favoriteNodes,
                 TelemetryRetentionDays: values.TryGetValue("TelemetryRetentionDays", out var trd) && int.TryParse(trd, out var trdInt) ? trdInt : defaults.TelemetryRetentionDays,
                 NodeKeyMismatchAction: values.TryGetValue("NodeKeyMismatchAction", out var pkm) && Enum.TryParse(pkm, out PskMismatchAction pkmVal) ? pkmVal : defaults.NodeKeyMismatchAction,
                 SignalWeatherWindowHours: values.TryGetValue("SignalWeatherWindowHours", out var swh) && int.TryParse(swh, out var swhInt) ? swhInt : defaults.SignalWeatherWindowHours,
@@ -200,7 +219,8 @@ public static class SettingsService
                 EnableMessageDb: values.TryGetValue("EnableMessageDb", out var emdb) && bool.TryParse(emdb, out var emdbBool) ? emdbBool : defaults.EnableMessageDb,
                 MessageDbRetentionDays: values.TryGetValue("MessageDbRetentionDays", out var mdr) && int.TryParse(mdr, out var mdrInt) ? mdrInt : defaults.MessageDbRetentionDays,
                 LastConnectionType: values.TryGetValue("LastConnectionType", out var lct) && !string.IsNullOrEmpty(lct) ? lct : defaults.LastConnectionType,
-                LastBtDevice: values.TryGetValue("LastBtDevice", out var lbd) ? lbd : defaults.LastBtDevice
+                LastBtDevice: values.TryGetValue("LastBtDevice", out var lbd) ? lbd : defaults.LastBtDevice,
+                RemoteAdminTimeoutSeconds: values.TryGetValue("RemoteAdminTimeoutSeconds", out var rats) && int.TryParse(rats, out var ratsInt) ? ratsInt : defaults.RemoteAdminTimeoutSeconds
             );
         }
         catch (Exception ex)
@@ -248,7 +268,8 @@ public static class SettingsService
                 $"EnableMessageDb={settings.EnableMessageDb}",
                 $"MessageDbRetentionDays={settings.MessageDbRetentionDays}",
                 $"LastConnectionType={settings.LastConnectionType}",
-                $"LastBtDevice={settings.LastBtDevice}"
+                $"LastBtDevice={settings.LastBtDevice}",
+                $"RemoteAdminTimeoutSeconds={settings.RemoteAdminTimeoutSeconds}"
             };
 
             // Save node colors
@@ -267,6 +288,12 @@ public static class SettingsService
             foreach (var kvp in settings.PinnedNodes.Where(p => p.Value))
             {
                 lines.Add($"PinnedNode_{kvp.Key:X8}=true");
+            }
+
+            // Save favorite nodes
+            foreach (var kvp in settings.FavoriteNodes.Where(p => p.Value))
+            {
+                lines.Add($"FavoriteNode_{kvp.Key:X8}=true");
             }
 
             File.WriteAllLines(IniFilePath, lines);

--- a/MeshhessenClient/Services/SettingsService.cs
+++ b/MeshhessenClient/Services/SettingsService.cs
@@ -41,7 +41,10 @@ public record AppSettings(
     int MessageDbRetentionDays,              // 0=unlimited, 30/90/365
     string LastConnectionType,              // "Serial", "Bluetooth", "Tcp"
     string LastBtDevice,                   // Last used Bluetooth device name
-    int RemoteAdminTimeoutSeconds);        // Timeout for remote admin requests in seconds (default 30)
+    int RemoteAdminTimeoutSeconds,         // Timeout for remote admin requests in seconds (default 30)
+    bool VirtualNodeEnabled,               // Enable Virtual Node TCP proxy server
+    int VirtualNodePort,                   // TCP port for Virtual Node (default 4404)
+    bool VirtualNodeBlockAdmin);           // Block admin commands from Virtual Node clients
 
 public static class SettingsService
 {
@@ -85,7 +88,10 @@ public static class SettingsService
             90,                             // MessageDbRetentionDays default 90
             "Serial",                       // LastConnectionType default Serial
             string.Empty,                   // LastBtDevice default empty
-            30);                            // RemoteAdminTimeoutSeconds default 30s
+            30,                             // RemoteAdminTimeoutSeconds default 30s
+            false,                          // VirtualNodeEnabled default off
+            4404,                           // VirtualNodePort default 4404
+            false);                         // VirtualNodeBlockAdmin default off
 
         try
         {
@@ -220,7 +226,10 @@ public static class SettingsService
                 MessageDbRetentionDays: values.TryGetValue("MessageDbRetentionDays", out var mdr) && int.TryParse(mdr, out var mdrInt) ? mdrInt : defaults.MessageDbRetentionDays,
                 LastConnectionType: values.TryGetValue("LastConnectionType", out var lct) && !string.IsNullOrEmpty(lct) ? lct : defaults.LastConnectionType,
                 LastBtDevice: values.TryGetValue("LastBtDevice", out var lbd) ? lbd : defaults.LastBtDevice,
-                RemoteAdminTimeoutSeconds: values.TryGetValue("RemoteAdminTimeoutSeconds", out var rats) && int.TryParse(rats, out var ratsInt) ? ratsInt : defaults.RemoteAdminTimeoutSeconds
+                RemoteAdminTimeoutSeconds: values.TryGetValue("RemoteAdminTimeoutSeconds", out var rats) && int.TryParse(rats, out var ratsInt) ? ratsInt : defaults.RemoteAdminTimeoutSeconds,
+                VirtualNodeEnabled: values.TryGetValue("VirtualNodeEnabled", out var vne) && bool.TryParse(vne, out var vneBool) && vneBool,
+                VirtualNodePort: values.TryGetValue("VirtualNodePort", out var vnp) && int.TryParse(vnp, out var vnpInt) ? vnpInt : defaults.VirtualNodePort,
+                VirtualNodeBlockAdmin: values.TryGetValue("VirtualNodeBlockAdmin", out var vnba) && bool.TryParse(vnba, out var vnbaBool) && vnbaBool
             );
         }
         catch (Exception ex)
@@ -269,7 +278,10 @@ public static class SettingsService
                 $"MessageDbRetentionDays={settings.MessageDbRetentionDays}",
                 $"LastConnectionType={settings.LastConnectionType}",
                 $"LastBtDevice={settings.LastBtDevice}",
-                $"RemoteAdminTimeoutSeconds={settings.RemoteAdminTimeoutSeconds}"
+                $"RemoteAdminTimeoutSeconds={settings.RemoteAdminTimeoutSeconds}",
+                $"VirtualNodeEnabled={settings.VirtualNodeEnabled}",
+                $"VirtualNodePort={settings.VirtualNodePort}",
+                $"VirtualNodeBlockAdmin={settings.VirtualNodeBlockAdmin}"
             };
 
             // Save node colors

--- a/MeshhessenClient/Services/TDeckTileService.cs
+++ b/MeshhessenClient/Services/TDeckTileService.cs
@@ -1,0 +1,194 @@
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+
+namespace MeshhessenClient.Services;
+
+public record TileProgress(int Done, int Total, int Zoom, int X, int Y, bool WasCopied);
+
+public static class TDeckTileService
+{
+    private static readonly string _version =
+        System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+    private static readonly HttpClient _http = new()
+    {
+        DefaultRequestHeaders = { { "User-Agent", $"MeshhessenClient/{_version}" } }
+    };
+
+    // Folder names used on SD card (under maps/)
+    public static string GetSDFolderName(MapSource source) => source switch
+    {
+        MapSource.OSM     => "OSM",
+        MapSource.OSMTopo => "OpenTopo",
+        MapSource.OSMDark => "OSMDark",
+        _                 => "OSM"
+    };
+
+    // Maps/<SDFolder>/<z>/<x>/<y>.png
+    public static string GetSDTilePath(string sdRoot, MapSource source, int z, int x, int y)
+    {
+        var folder = GetSDFolderName(source);
+        return Path.Combine(sdRoot, "maps", folder, z.ToString(), x.ToString(), $"{y}.png");
+    }
+
+    // Local maptiles/<sourceFolder>/<z>/<x>/<y>.png
+    private static string GetLocalTilePath(string localTileDir, MapSource source, int z, int x, int y)
+    {
+        var folder = TileDownloaderService.GetSourceFolderName(source);
+        return Path.Combine(localTileDir, folder, z.ToString(), x.ToString(), $"{y}.png");
+    }
+
+    /// <summary>
+    /// Transfers all tiles in bbox/zoom range to SD card.
+    /// Runs entirely on a thread-pool thread so the UI stays responsive.
+    /// For each tile: skip if on SD, copy if local, else download.
+    /// </summary>
+    public static Task TransferTilesAsync(
+        MapSource source,
+        double north, double south, double east, double west,
+        int maxZoom,
+        string sdRoot,
+        string localTileDir,
+        IProgress<TileProgress>? progress,
+        CancellationToken ct)
+    {
+        // All file I/O (File.Exists, File.Copy, Directory.CreateDirectory) is
+        // synchronous and would freeze the UI thread. Task.Run moves everything
+        // to the thread-pool; the inner HttpClient await is fine there too.
+        return Task.Run(async () =>
+        {
+            int total = TileDownloaderService.EstimateTileCount(north, south, east, west, 1, maxZoom);
+            int done = 0;
+
+            var urlTemplate = source switch
+            {
+                MapSource.OSMTopo => TileDownloaderService.OSMTopoTileUrl,
+                MapSource.OSMDark => TileDownloaderService.OSMDarkTileUrl,
+                _                 => TileDownloaderService.OSMTileUrl
+            };
+
+            for (int z = 1; z <= maxZoom; z++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var (x1, y1) = TileDownloaderService.LatLonToTile(north, west, z);
+                var (x2, y2) = TileDownloaderService.LatLonToTile(south, east, z);
+
+                int xMin = Math.Min(x1, x2), xMax = Math.Max(x1, x2);
+                int yMin = Math.Min(y1, y2), yMax = Math.Max(y1, y2);
+
+                for (int x = xMin; x <= xMax; x++)
+                {
+                    ct.ThrowIfCancellationRequested();
+
+                    for (int y = yMin; y <= yMax; y++)
+                    {
+                        ct.ThrowIfCancellationRequested();
+
+                        bool copied = false;
+                        var sdPath = GetSDTilePath(sdRoot, source, z, x, y);
+
+                        if (!File.Exists(sdPath))
+                        {
+                            Directory.CreateDirectory(Path.GetDirectoryName(sdPath)!);
+
+                            var localPath = GetLocalTilePath(localTileDir, source, z, x, y);
+                            if (File.Exists(localPath))
+                            {
+                                File.Copy(localPath, sdPath, overwrite: true);
+                                copied = true;
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    var url = urlTemplate
+                                        .Replace("{z}", z.ToString())
+                                        .Replace("{x}", x.ToString())
+                                        .Replace("{y}", y.ToString());
+
+                                    var data = await _http.GetByteArrayAsync(url, ct).ConfigureAwait(false);
+                                    await File.WriteAllBytesAsync(sdPath, data, ct).ConfigureAwait(false);
+
+                                    // Also save to local cache
+                                    var localDir2 = Path.GetDirectoryName(localPath)!;
+                                    Directory.CreateDirectory(localDir2);
+                                    await File.WriteAllBytesAsync(localPath, data, ct).ConfigureAwait(false);
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    throw;
+                                }
+                                catch (Exception ex)
+                                {
+                                    Logger.WriteLine($"[TDeck] Tile download failed Z{z} X{x} Y{y}: {ex.Message}");
+                                }
+                            }
+                        }
+
+                        done++;
+                        progress?.Report(new TileProgress(done, total, z, x, y, copied));
+                    }
+                }
+            }
+        }, ct);
+    }
+
+    /// <summary>
+    /// Exports all local tiles for the given source(s) to a ZIP file.
+    /// Pass null for source to export all map types.
+    /// </summary>
+    public static Task ExportToZipAsync(
+        string localTileDir,
+        string outputZipPath,
+        MapSource? sourceFilter,
+        IProgress<(int done, int total, string status)>? progress,
+        CancellationToken ct)
+    {
+        return Task.Run(() =>
+        {
+            var sources = sourceFilter.HasValue
+                ? new[] { sourceFilter.Value }
+                : new[] { MapSource.OSM, MapSource.OSMTopo, MapSource.OSMDark };
+
+            var allFiles = new List<(string fullPath, string zipEntry)>();
+            foreach (var src in sources)
+            {
+                ct.ThrowIfCancellationRequested();
+                var folder = TileDownloaderService.GetSourceFolderName(src);
+                var dir = Path.Combine(localTileDir, folder);
+                if (!Directory.Exists(dir)) continue;
+
+                foreach (var f in Directory.EnumerateFiles(dir, "*.png", SearchOption.AllDirectories))
+                {
+                    var rel = Path.GetRelativePath(localTileDir, f).Replace('\\', '/');
+                    allFiles.Add((f, rel));
+                }
+            }
+
+            if (allFiles.Count == 0) return;
+
+            int done = 0;
+            int total = allFiles.Count;
+
+            using var zip = ZipFile.Open(outputZipPath, ZipArchiveMode.Create);
+            foreach (var (fullPath, entry) in allFiles)
+            {
+                ct.ThrowIfCancellationRequested();
+                zip.CreateEntryFromFile(fullPath, entry, CompressionLevel.SmallestSize);
+                done++;
+                progress?.Report((done, total, entry));
+            }
+        }, ct);
+    }
+
+    public static long EstimateSizeBytes(int tileCount, long avgTileBytes = 15_000)
+        => (long)tileCount * avgTileBytes;
+
+    public static string FormatSize(long bytes)
+    {
+        if (bytes >= 1L << 30) return $"{bytes / (double)(1L << 30):F1} GB";
+        if (bytes >= 1L << 20) return $"{bytes / (double)(1L << 20):F1} MB";
+        return $"{bytes / (double)(1L << 10):F0} KB";
+    }
+}

--- a/MeshhessenClient/Services/TelemetryDatabaseService.cs
+++ b/MeshhessenClient/Services/TelemetryDatabaseService.cs
@@ -596,23 +596,31 @@ LIMIT 50";
     // ── Query: Time series (for PlotWindow) ──────────────────────────────────
 
     /// <summary>
-    /// Available metrics: snr, rssi, battery, voltage, channel_util, air_tx_util, hop_count
+    /// Available metrics: snr, rssi, battery, voltage, channel_util, air_tx_util, hop_count,
+    /// temperature, humidity, pressure, packet_count (aggregated per hour).
     /// </summary>
     public List<TimeSeriesPoint> GetTimeSeries(IEnumerable<uint> nodeIds, string metric, int days)
     {
+        // packet_count is an aggregate (packets per hour bucket) — handled separately
+        if (string.Equals(metric, "packet_count", StringComparison.OrdinalIgnoreCase))
+            return QueryPacketCountSeries(nodeIds, days);
+
         long since = Since(days);
         var result = new List<TimeSeriesPoint>();
 
         (string table, string col) = metric.ToLowerInvariant() switch
         {
-            "snr"          => ("packet_rx",         "rx_snr"),
-            "rssi"         => ("packet_rx",         "rx_rssi"),
-            "hop_count"    => ("packet_rx",         "hop_count"),
-            "battery"      => ("device_telemetry",  "battery_percent"),
-            "voltage"      => ("device_telemetry",  "voltage"),
-            "channel_util" => ("device_telemetry",  "channel_utilization"),
-            "air_tx_util"  => ("device_telemetry",  "air_util_tx"),
-            _              => ("packet_rx",         "rx_snr"),
+            "snr"          => ("packet_rx",             "rx_snr"),
+            "rssi"         => ("packet_rx",             "rx_rssi"),
+            "hop_count"    => ("packet_rx",             "hop_count"),
+            "battery"      => ("device_telemetry",      "battery_percent"),
+            "voltage"      => ("device_telemetry",      "voltage"),
+            "channel_util" => ("device_telemetry",      "channel_utilization"),
+            "air_tx_util"  => ("device_telemetry",      "air_util_tx"),
+            "temperature"  => ("environment_telemetry", "temperature"),
+            "humidity"     => ("environment_telemetry", "relative_humidity"),
+            "pressure"     => ("environment_telemetry", "barometric_pressure"),
+            _              => ("packet_rx",             "rx_snr"),
         };
 
         using var con = Open();
@@ -635,6 +643,177 @@ LIMIT 50";
             }
         }
 
+        return result;
+    }
+
+    // ── Query: Packet count per time bucket ─────────────────────────────────
+
+    /// <summary>
+    /// Returns packets-per-hour time series for each node. Value = count within the hour bucket.
+    /// </summary>
+    private List<TimeSeriesPoint> QueryPacketCountSeries(IEnumerable<uint> nodeIds, int days)
+    {
+        long since = Since(days);
+        const int bucketSec = 3600;
+        var result = new List<TimeSeriesPoint>();
+
+        using var con = Open();
+        foreach (var nodeId in nodeIds)
+        {
+            using var cmd = con.CreateCommand();
+            cmd.CommandText = $@"
+SELECT (timestamp / {bucketSec}) * {bucketSec} AS bucket, COUNT(*) AS cnt
+FROM packet_rx
+WHERE node_id = $n AND timestamp >= $s
+GROUP BY bucket
+ORDER BY bucket";
+            cmd.Parameters.AddWithValue("$n", (long)nodeId);
+            cmd.Parameters.AddWithValue("$s", since);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                result.Add(new TimeSeriesPoint
+                {
+                    NodeId    = nodeId,
+                    Timestamp = FromUnix(r.GetInt64(0)),
+                    Value     = r.GetInt64(1),
+                    Metric    = "packet_count",
+                });
+            }
+        }
+        return result;
+    }
+
+    // ── Query: Heatmap (hour-of-day × day) ──────────────────────────────────
+
+    /// <summary>
+    /// Returns a 2D array [dayIndex, hourOfDay] with average metric value (or NaN if no data).
+    /// dayIndex 0 = oldest day, dayIndex days-1 = most recent day.
+    /// </summary>
+    public double[,] GetHeatmapData(uint nodeId, string metric, int days)
+    {
+        int effectiveDays = days > 0 ? days : 30;
+        long since = Since(effectiveDays);
+
+        // packet_count: count packets per (day, hour) cell
+        if (string.Equals(metric, "packet_count", StringComparison.OrdinalIgnoreCase))
+            return BuildPacketCountHeatmap(nodeId, effectiveDays, since);
+
+        (string table, string col) = metric.ToLowerInvariant() switch
+        {
+            "snr"          => ("packet_rx",             "rx_snr"),
+            "rssi"         => ("packet_rx",             "rx_rssi"),
+            "battery"      => ("device_telemetry",      "battery_percent"),
+            "temperature"  => ("environment_telemetry", "temperature"),
+            "humidity"     => ("environment_telemetry", "relative_humidity"),
+            _              => ("packet_rx",             "rx_snr"),
+        };
+
+        var sums   = new double[effectiveDays, 24];
+        var counts = new int[effectiveDays, 24];
+
+        using var con = Open();
+        using var cmd = con.CreateCommand();
+        cmd.CommandText = $"SELECT timestamp, {col} FROM {table} WHERE node_id=$n AND timestamp>=$s AND {col} IS NOT NULL ORDER BY timestamp";
+        cmd.Parameters.AddWithValue("$n", (long)nodeId);
+        cmd.Parameters.AddWithValue("$s", since);
+
+        using var r = cmd.ExecuteReader();
+        long nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        while (r.Read())
+        {
+            long ts  = r.GetInt64(0);
+            double v = r.GetDouble(1);
+            var dt   = DateTimeOffset.FromUnixTimeSeconds(ts).ToLocalTime();
+            int hour = dt.Hour;
+            int day  = (int)((nowUnix - ts) / 86400);
+            int dayIdx = effectiveDays - 1 - day;
+            if (dayIdx < 0 || dayIdx >= effectiveDays) continue;
+            sums[dayIdx, hour]   += v;
+            counts[dayIdx, hour] += 1;
+        }
+
+        var result = new double[effectiveDays, 24];
+        for (int d = 0; d < effectiveDays; d++)
+            for (int h = 0; h < 24; h++)
+                result[d, h] = counts[d, h] > 0 ? sums[d, h] / counts[d, h] : double.NaN;
+        return result;
+    }
+
+    private double[,] BuildPacketCountHeatmap(uint nodeId, int days, long since)
+    {
+        var result   = new double[days, 24];
+        long nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        using var con = Open();
+        using var cmd = con.CreateCommand();
+        cmd.CommandText = "SELECT timestamp FROM packet_rx WHERE node_id=$n AND timestamp>=$s";
+        cmd.Parameters.AddWithValue("$n", (long)nodeId);
+        cmd.Parameters.AddWithValue("$s", since);
+        using var r = cmd.ExecuteReader();
+        while (r.Read())
+        {
+            long ts = r.GetInt64(0);
+            var dt  = DateTimeOffset.FromUnixTimeSeconds(ts).ToLocalTime();
+            int hour = dt.Hour;
+            int day  = (int)((nowUnix - ts) / 86400);
+            int dayIdx = days - 1 - day;
+            if (dayIdx >= 0 && dayIdx < days)
+                result[dayIdx, hour] += 1;
+        }
+        return result;
+    }
+
+    // ── Query: Candlestick (daily OHLC) ─────────────────────────────────────
+
+    public record CandlePoint(DateTime Time, double Open, double High, double Low, double Close);
+
+    public List<CandlePoint> GetCandlestickData(uint nodeId, string metric, int days)
+    {
+        var pts = GetTimeSeries(new[] { nodeId }, metric, days)
+                  .OrderBy(p => p.Timestamp).ToList();
+        if (pts.Count == 0) return new();
+
+        return pts.GroupBy(p => p.Timestamp.Date)
+                  .OrderBy(g => g.Key)
+                  .Select(g =>
+                  {
+                      var vals = g.OrderBy(x => x.Timestamp).Select(x => x.Value).ToList();
+                      return new CandlePoint(
+                          DateTime.SpecifyKind(g.Key, DateTimeKind.Utc),
+                          vals.First(), vals.Max(), vals.Min(), vals.Last());
+                  })
+                  .ToList();
+    }
+
+    // ── Query: Node activity grid (for state timeline) ────────────────────────
+
+    /// <summary>
+    /// Returns a 2D array [dayIndex, hourOfDay] where 1.0 = node was heard, 0.0 = silent.
+    /// dayIndex 0 = oldest, dayIndex days-1 = most recent.
+    /// </summary>
+    public double[,] GetNodeActivityGrid(uint nodeId, int days)
+    {
+        int effectiveDays = days > 0 ? days : 14;
+        long since    = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - (long)effectiveDays * 86400;
+        var  startDt  = DateTimeOffset.FromUnixTimeSeconds(since).UtcDateTime.Date;
+        var  result   = new double[effectiveDays, 24];
+
+        using var con = Open();
+        using var cmd = con.CreateCommand();
+        cmd.CommandText = "SELECT timestamp FROM packet_rx WHERE node_id=$n AND timestamp>=$since";
+        cmd.Parameters.AddWithValue("$n",     (long)nodeId);
+        cmd.Parameters.AddWithValue("$since", since);
+
+        using var rdr = cmd.ExecuteReader();
+        while (rdr.Read())
+        {
+            var ts     = DateTimeOffset.FromUnixTimeSeconds(rdr.GetInt64(0)).UtcDateTime;
+            int dayIdx = (int)(ts.Date - startDt).TotalDays;
+            int hour   = ts.Hour;
+            if (dayIdx >= 0 && dayIdx < effectiveDays)
+                result[dayIdx, hour] = 1.0;
+        }
         return result;
     }
 

--- a/MeshhessenClient/Services/TelemetryDatabaseService.cs
+++ b/MeshhessenClient/Services/TelemetryDatabaseService.cs
@@ -1371,6 +1371,20 @@ GROUP BY node_id";
     /// Returns the most recent rx_snr per node within the given day window.
     /// Used to pre-populate SignalQualityColor on startup from DB history.
     /// </summary>
+    public List<uint> GetKnownNodeIds()
+    {
+        var result = new HashSet<uint>();
+        using var con = Open();
+        foreach (var table in new[] { "device_telemetry", "environment_telemetry", "packet_rx" })
+        {
+            using var cmd = con.CreateCommand();
+            cmd.CommandText = $"SELECT DISTINCT node_id FROM {table}";
+            using var r = cmd.ExecuteReader();
+            while (r.Read()) result.Add((uint)r.GetInt64(0));
+        }
+        return result.ToList();
+    }
+
     public Dictionary<uint, float> GetLastSnrPerNode(int days)
     {
         long since = Since(days);

--- a/MeshhessenClient/Services/TelemetryDatabaseService.cs
+++ b/MeshhessenClient/Services/TelemetryDatabaseService.cs
@@ -1063,7 +1063,7 @@ ORDER BY bucket";
     /// Returns the total number of traceroute rows (including direct-link sentinels) for a node.
     /// Used to distinguish "no data" from "data but no SNR".
     /// </summary>
-    private int CountTracerouteRows(uint myNodeId, int days)
+    public int CountTracerouteRows(uint myNodeId, int days)
     {
         long since = Since(days);
         using var con = Open();

--- a/MeshhessenClient/Services/VirtualNodeService.cs
+++ b/MeshhessenClient/Services/VirtualNodeService.cs
@@ -1,0 +1,450 @@
+using System.Net;
+using System.Net.Sockets;
+using Google.Protobuf;
+using Meshtastic.Protobufs;
+using SysChannel = System.Threading.Channels.Channel;
+using SysChannelOptions = System.Threading.Channels.BoundedChannelOptions;
+using SysChannelFullMode = System.Threading.Channels.BoundedChannelFullMode;
+using SysChannelT = System.Threading.Channels.Channel<byte[]>;
+
+namespace MeshhessenClient.Services;
+
+public class VirtualNodeService : IDisposable
+{
+    private const byte START1 = 0x94;
+    private const byte START2 = 0xC3;
+
+    private TcpListener? _listener;
+    private CancellationTokenSource? _cts;
+    private int _nextClientId = 1;
+
+    private readonly Dictionary<string, VnClient> _clients = new();
+    private readonly object _clientsLock = new();
+
+    // Config cache: stores the last known framed bytes for each config category
+    private byte[]? _frameMyInfo;
+    private byte[]? _frameMetadata;
+    private readonly Dictionary<int, byte[]> _frameChannels = new();      // channel index → frame
+    private readonly Dictionary<int, byte[]> _frameConfigs = new();       // Config.PayloadVariantCase → frame
+    private readonly Dictionary<int, byte[]> _frameModuleConfigs = new(); // ModuleConfig.PayloadVariantCase → frame
+    private readonly Dictionary<uint, byte[]> _frameNodes = new();        // nodeNum → frame
+    private uint _configCompleteId;
+    private bool _configCacheReady;
+
+    // Queue for sending to physical node (max 100, drops oldest on overflow)
+    private readonly SysChannelT _toPhysicalQueue = SysChannel.CreateBounded<byte[]>(
+        new SysChannelOptions(100) { FullMode = SysChannelFullMode.DropOldest });
+
+    private readonly IConnectionService _physicalConnection;
+    private Task? _sendTask;
+
+    public int Port { get; set; } = 4404;
+    public bool BlockAdminCommands { get; set; } = false;
+    public bool IsRunning { get; private set; }
+
+    public event EventHandler<int>? ClientCountChanged;
+    public event EventHandler<string>? LogMessage;
+    // Fires with FromRadio bytes when a VN client sends a MeshPacket, so the main app can display it
+    public event EventHandler<byte[]>? ClientPacketReceived;
+
+    public VirtualNodeService(IConnectionService physicalConnection)
+    {
+        _physicalConnection = physicalConnection;
+    }
+
+    public async Task StartAsync()
+    {
+        if (IsRunning) return;
+        _cts = new CancellationTokenSource();
+
+        try
+        {
+            _listener = new TcpListener(IPAddress.Any, Port);
+            _listener.Start();
+            IsRunning = true;
+            Log($"Listening on port {Port}");
+            _sendTask = ProcessSendQueueAsync(_cts.Token);
+            _ = AcceptClientsAsync(_cts.Token);
+        }
+        catch (Exception ex)
+        {
+            IsRunning = false;
+            _cts.Cancel();
+            Log($"Start failed: {ex.Message}");
+            throw;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    public void Stop()
+    {
+        if (!IsRunning) return;
+        _cts?.Cancel();
+        _listener?.Stop();
+        IsRunning = false;
+
+        lock (_clientsLock)
+        {
+            foreach (var c in _clients.Values) c.Dispose();
+            _clients.Clear();
+        }
+        ClientCountChanged?.Invoke(this, 0);
+        Log("Stopped");
+    }
+
+    // Called by MeshtasticProtocolService with each complete raw frame from the physical node
+    public void OnRawFrameFromPhysical(byte[] frame)
+    {
+        try
+        {
+            var payload = new byte[frame.Length - 4];
+            Array.Copy(frame, 4, payload, 0, payload.Length);
+            var fromRadio = FromRadio.Parser.ParseFrom(payload);
+            UpdateConfigCache(fromRadio, frame);
+
+            // Don't forward ConfigComplete — we send our own during replay
+            if (fromRadio.PayloadVariantCase == FromRadio.PayloadVariantOneofCase.ConfigCompleteId)
+                return;
+        }
+        catch { /* ignore parse errors, still broadcast raw bytes */ }
+
+        BroadcastToClients(frame);
+    }
+
+    private void UpdateConfigCache(FromRadio fr, byte[] rawFrame)
+    {
+        switch (fr.PayloadVariantCase)
+        {
+            case FromRadio.PayloadVariantOneofCase.MyInfo:
+                _frameMyInfo = rawFrame;
+                break;
+            case FromRadio.PayloadVariantOneofCase.Metadata:
+                _frameMetadata = rawFrame;
+                break;
+            case FromRadio.PayloadVariantOneofCase.Channel:
+                _frameChannels[fr.Channel.Index] = rawFrame;
+                break;
+            case FromRadio.PayloadVariantOneofCase.Config:
+                _frameConfigs[(int)fr.Config.PayloadVariantCase] = rawFrame;
+                break;
+            case FromRadio.PayloadVariantOneofCase.ModuleConfig:
+                _frameModuleConfigs[(int)fr.ModuleConfig.PayloadVariantCase] = rawFrame;
+                break;
+            case FromRadio.PayloadVariantOneofCase.NodeInfo:
+                _frameNodes[fr.NodeInfo.Num] = rawFrame;
+                break;
+            case FromRadio.PayloadVariantOneofCase.ConfigCompleteId:
+                _configCompleteId = fr.ConfigCompleteId;
+                _configCacheReady = true;
+                break;
+        }
+    }
+
+    private async Task AcceptClientsAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var tcpClient = await _listener!.AcceptTcpClientAsync(ct);
+                var clientId = $"vn-{_nextClientId++}";
+                var client = new VnClient(clientId, tcpClient);
+
+                lock (_clientsLock)
+                    _clients[clientId] = client;
+
+                var remoteIp = ((IPEndPoint?)tcpClient.Client.RemoteEndPoint)?.Address.ToString() ?? "?";
+                Log($"Client {clientId} connected from {remoteIp}");
+                NotifyClientCount();
+                _ = HandleClientAsync(client, ct);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            if (!ct.IsCancellationRequested)
+                Log($"Accept error: {ex.Message}");
+        }
+    }
+
+    private async Task HandleClientAsync(VnClient client, CancellationToken ct)
+    {
+        try
+        {
+            var stream = client.TcpClient.GetStream();
+            var buffer = new byte[4096];
+            var frameBuffer = new List<byte>(1024);
+
+            while (!ct.IsCancellationRequested && client.TcpClient.Connected)
+            {
+                int bytesRead;
+                try { bytesRead = await stream.ReadAsync(buffer, ct); }
+                catch { break; }
+                if (bytesRead == 0) break;
+
+                frameBuffer.AddRange(buffer.AsSpan(0, bytesRead).ToArray());
+                await ProcessClientFramesAsync(client, frameBuffer, ct);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch { }
+        finally
+        {
+            RemoveClient(client.Id);
+        }
+    }
+
+    private async Task ProcessClientFramesAsync(VnClient client, List<byte> buf, CancellationToken ct)
+    {
+        while (buf.Count >= 4)
+        {
+            // Find frame start
+            int start = -1;
+            for (int i = 0; i < buf.Count - 1; i++)
+            {
+                if (buf[i] == START1 && buf[i + 1] == START2) { start = i; break; }
+            }
+            if (start == -1) { buf.Clear(); return; }
+            if (start > 0) buf.RemoveRange(0, start);
+            if (buf.Count < 4) return;
+
+            int len = (buf[2] << 8) | buf[3];
+            if (len == 0 || len > 512) { buf.RemoveRange(0, 2); continue; }
+            if (buf.Count < 4 + len) return;
+
+            var payload = buf.GetRange(4, len).ToArray();
+            buf.RemoveRange(0, 4 + len);
+
+            await HandleClientMessageAsync(client, payload, ct);
+        }
+    }
+
+    private async Task HandleClientMessageAsync(VnClient client, byte[] payload, CancellationToken ct)
+    {
+        try
+        {
+            var toRadio = ToRadio.Parser.ParseFrom(payload);
+
+            switch (toRadio.PayloadVariantCase)
+            {
+                case ToRadio.PayloadVariantOneofCase.WantConfigId:
+                    // Rate-limit repeated WantConfigId from same client (same ID within 5s = ignore)
+                    if (client.IsDuplicateConfigRequest(toRadio.WantConfigId))
+                    {
+                        Log($"Client {client.Id}: duplicate WantConfigId {toRadio.WantConfigId}, ignoring");
+                        return;
+                    }
+                    await SendConfigReplayAsync(client, toRadio.WantConfigId, ct);
+                    return;
+
+                case ToRadio.PayloadVariantOneofCase.Disconnect:
+                    return;
+
+                case ToRadio.PayloadVariantOneofCase.Heartbeat:
+                    // Respond locally with a minimal QueueStatus so the app doesn't time out
+                    var qs = new FromRadio { QueueStatus = new QueueStatus { Res = 0, Free = 16, Maxlen = 32 } };
+                    await client.SendAsync(BuildFrame(qs.ToByteArray()), ct);
+                    return;
+
+                case ToRadio.PayloadVariantOneofCase.Packet:
+                    if (BlockAdminCommands && toRadio.Packet.Decoded != null)
+                    {
+                        var portnum = (PortNum)toRadio.Packet.Decoded.Portnum;
+                        if (portnum == PortNum.AdminApp)
+                        {
+                            Log($"Client {client.Id}: blocked admin command");
+                            return;
+                        }
+                    }
+                    // Inject into main app so sent messages appear there too
+                    try
+                    {
+                        var fromRadioBytes = new FromRadio { Packet = toRadio.Packet }.ToByteArray();
+                        ClientPacketReceived?.Invoke(this, fromRadioBytes);
+                        // Broadcast to all other VN clients so they also see the message
+                        BroadcastToClientsExcept(client.Id, BuildFrame(fromRadioBytes));
+                    }
+                    catch { }
+                    break;
+            }
+
+            // Forward to physical node via queue
+            await _toPhysicalQueue.Writer.WriteAsync(BuildFrame(payload), ct);
+        }
+        catch (Exception ex)
+        {
+            Log($"Client {client.Id} message error: {ex.Message}");
+        }
+    }
+
+    private async Task SendConfigReplayAsync(VnClient client, uint wantConfigId, CancellationToken ct)
+    {
+        try
+        {
+            async Task Send(byte[]? frame)
+            {
+                if (frame == null) return;
+                await client.SendAsync(frame, ct);
+                await Task.Delay(10, ct);
+            }
+
+            await Send(_frameMyInfo);
+            await Send(_frameMetadata);
+
+            foreach (var ch in _frameChannels.OrderBy(kv => kv.Key).Select(kv => kv.Value))
+                await Send(ch);
+            foreach (var cfg in _frameConfigs.Values)
+                await Send(cfg);
+            foreach (var mod in _frameModuleConfigs.Values)
+                await Send(mod);
+            foreach (var ni in _frameNodes.Values)
+                await Send(ni);
+
+            // Always echo the client's own wantConfigId — the physical node's ID is irrelevant here
+            var cc = new FromRadio { ConfigCompleteId = wantConfigId };
+            await client.SendAsync(BuildFrame(cc.ToByteArray()), ct);
+
+            Log($"Client {client.Id}: config replay done ({_frameChannels.Count} ch, {_frameNodes.Count} nodes)");
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            Log($"Client {client.Id} replay error: {ex.Message}");
+        }
+    }
+
+    private async Task ProcessSendQueueAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var frame in _toPhysicalQueue.Reader.ReadAllAsync(ct))
+            {
+                try
+                {
+                    await _physicalConnection.WriteAsync(frame);
+                    await Task.Delay(10, ct);
+                }
+                catch (Exception ex)
+                {
+                    Log($"Forward to physical node failed: {ex.Message}");
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private void BroadcastToClients(byte[] frame)
+    {
+        List<VnClient> snapshot;
+        lock (_clientsLock)
+            snapshot = [.. _clients.Values];
+
+        foreach (var client in snapshot)
+            _ = client.SendAsync(frame, CancellationToken.None);
+    }
+
+    private void BroadcastToClientsExcept(string excludeId, byte[] frame)
+    {
+        List<VnClient> snapshot;
+        lock (_clientsLock)
+            snapshot = _clients.Values.Where(c => c.Id != excludeId).ToList();
+
+        foreach (var client in snapshot)
+            _ = client.SendAsync(frame, CancellationToken.None);
+    }
+
+    private void RemoveClient(string id)
+    {
+        lock (_clientsLock)
+        {
+            if (_clients.TryGetValue(id, out var c))
+            {
+                c.Dispose();
+                _clients.Remove(id);
+            }
+        }
+        Log($"Client {id} disconnected");
+        NotifyClientCount();
+    }
+
+    private void NotifyClientCount()
+    {
+        int count;
+        lock (_clientsLock) count = _clients.Count;
+        ClientCountChanged?.Invoke(this, count);
+    }
+
+    public List<(string Id, string Ip)> GetConnectedClients()
+    {
+        lock (_clientsLock)
+            return _clients.Values.Select(c => (c.Id, c.RemoteIp)).ToList();
+    }
+
+    private static byte[] BuildFrame(byte[] payload)
+    {
+        var frame = new byte[4 + payload.Length];
+        frame[0] = START1;
+        frame[1] = START2;
+        frame[2] = (byte)(payload.Length >> 8);
+        frame[3] = (byte)(payload.Length & 0xFF);
+        Array.Copy(payload, 0, frame, 4, payload.Length);
+        return frame;
+    }
+
+    private void Log(string msg)
+    {
+        Logger.WriteLine($"[VirtualNode] {msg}");
+        LogMessage?.Invoke(this, msg);
+    }
+
+    public void Dispose() => Stop();
+
+    private sealed class VnClient : IDisposable
+    {
+        private readonly SemaphoreSlim _sendLock = new(1, 1);
+        private uint _lastConfigId;
+        private DateTime _lastConfigAt = DateTime.MinValue;
+
+        public string Id { get; }
+        public TcpClient TcpClient { get; }
+        public string RemoteIp { get; }
+
+        public VnClient(string id, TcpClient tcpClient)
+        {
+            Id = id;
+            TcpClient = tcpClient;
+            RemoteIp = ((IPEndPoint?)tcpClient.Client.RemoteEndPoint)?.Address.ToString() ?? "?";
+        }
+
+        public bool IsDuplicateConfigRequest(uint configId)
+        {
+            var now = DateTime.UtcNow;
+            if (configId == _lastConfigId && (now - _lastConfigAt).TotalSeconds < 5)
+                return true;
+            _lastConfigId = configId;
+            _lastConfigAt = now;
+            return false;
+        }
+
+        public async Task SendAsync(byte[] frame, CancellationToken ct)
+        {
+            if (!TcpClient.Connected) return;
+            await _sendLock.WaitAsync(ct);
+            try
+            {
+                await TcpClient.GetStream().WriteAsync(frame, ct);
+            }
+            catch { }
+            finally
+            {
+                _sendLock.Release();
+            }
+        }
+
+        public void Dispose()
+        {
+            try { TcpClient.Close(); } catch { }
+        }
+    }
+}

--- a/MeshhessenClient/TDeckExportWindow.xaml
+++ b/MeshhessenClient/TDeckExportWindow.xaml
@@ -1,0 +1,40 @@
+<Window x:Class="MeshhessenClient.TDeckExportWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="{DynamicResource StrTDeckExportTitle}"
+        Width="480" SizeToContent="Height"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="20">
+        <TextBlock Text="{DynamicResource StrTDeckExportHint}"
+                   TextWrapping="Wrap" Margin="0,0,0,14" Foreground="#444"/>
+
+        <Grid Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0" Text="{DynamicResource StrTDeckExportTypeLabel}"
+                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <ComboBox x:Name="TypeComboBox" Grid.Column="1">
+                <ComboBoxItem Tag="" IsSelected="True"
+                              Content="{DynamicResource StrTDeckExportAllTypes}"/>
+                <ComboBoxItem Tag="OSM"  Content="{DynamicResource StrTDeckMapOSM}"/>
+                <ComboBoxItem Tag="Dark" Content="{DynamicResource StrTDeckMapDark}"/>
+                <ComboBoxItem Tag="Topo" Content="{DynamicResource StrTDeckMapTopo}"/>
+            </ComboBox>
+        </Grid>
+
+        <ProgressBar x:Name="ExportProgress" Height="8" Margin="0,0,0,6" Visibility="Collapsed"/>
+        <TextBlock x:Name="StatusText" TextWrapping="Wrap" FontSize="12" Margin="0,0,0,10"/>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="ExportBtn"
+                    Content="{DynamicResource StrTDeckExportStartBtn}"
+                    Padding="14,7" Margin="0,0,8,0"
+                    Click="ExportBtn_Click"/>
+            <Button Content="{DynamicResource StrTDeckClose}"
+                    Padding="14,7" IsCancel="True"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/MeshhessenClient/TDeckExportWindow.xaml.cs
+++ b/MeshhessenClient/TDeckExportWindow.xaml.cs
@@ -1,0 +1,99 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using MeshhessenClient.Services;
+
+namespace MeshhessenClient;
+
+public partial class TDeckExportWindow : Window
+{
+    private static string Loc(string key) =>
+        Application.Current?.Resources[key] as string ?? key;
+
+    private static readonly string LocalTileDir =
+        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "maptiles");
+
+    private CancellationTokenSource? _cts;
+
+    public TDeckExportWindow() => InitializeComponent();
+
+    private async void ExportBtn_Click(object sender, RoutedEventArgs e)
+    {
+        // Determine source filter
+        MapSource? filter = null;
+        if (TypeComboBox.SelectedItem is ComboBoxItem item)
+        {
+            filter = (item.Tag as string) switch
+            {
+                "OSM"  => MapSource.OSM,
+                "Dark" => MapSource.OSMDark,
+                "Topo" => MapSource.OSMTopo,
+                _      => null
+            };
+        }
+
+        // Verify tiles exist
+        var sourceFolder = filter.HasValue
+            ? TileDownloaderService.GetSourceFolderName(filter.Value)
+            : null;
+
+        if (sourceFolder != null)
+        {
+            var dir = Path.Combine(LocalTileDir, sourceFolder);
+            if (!Directory.Exists(dir) ||
+                !Directory.EnumerateFiles(dir, "*.png", SearchOption.AllDirectories).Any())
+            {
+                StatusText.Text = Loc("StrTDeckExportNoTiles");
+                return;
+            }
+        }
+
+        // Save dialog
+        var dialog = new Microsoft.Win32.SaveFileDialog
+        {
+            Title      = Loc("StrTDeckExportTitle"),
+            Filter     = "ZIP-Dateien (*.zip)|*.zip",
+            DefaultExt = "zip",
+            FileName   = filter.HasValue
+                ? $"maptiles_{TDeckTileService.GetSDFolderName(filter.Value)}.zip"
+                : "maptiles_all.zip"
+        };
+        if (dialog.ShowDialog() != true) return;
+
+        ExportBtn.IsEnabled = false;
+        ExportProgress.Visibility = Visibility.Visible;
+        ExportProgress.IsIndeterminate = false;
+        StatusText.Text = "";
+
+        _cts = new CancellationTokenSource();
+        int totalReported = 1;
+
+        var progress = new Progress<(int done, int total, string status)>(p =>
+        {
+            totalReported = p.total;
+            ExportProgress.Maximum = p.total;
+            ExportProgress.Value   = p.done;
+            StatusText.Text        = p.status;
+        });
+
+        try
+        {
+            await TDeckTileService.ExportToZipAsync(
+                LocalTileDir, dialog.FileName, filter, progress, _cts.Token);
+
+            StatusText.Text = string.Format(Loc("StrTDeckExportDone"),
+                Path.GetFileName(dialog.FileName));
+            StatusText.Foreground = System.Windows.Media.Brushes.DarkGreen;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = string.Format(Loc("StrTDeckExportFailed"), ex.Message);
+            StatusText.Foreground = System.Windows.Media.Brushes.Red;
+        }
+        finally
+        {
+            ExportBtn.IsEnabled = true;
+            ExportProgress.Visibility = Visibility.Collapsed;
+        }
+    }
+}

--- a/MeshhessenClient/TDeckRegionMapWindow.xaml
+++ b/MeshhessenClient/TDeckRegionMapWindow.xaml
@@ -1,0 +1,71 @@
+<Window x:Class="MeshhessenClient.TDeckRegionMapWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mapsui="clr-namespace:Mapsui.UI.Wpf;assembly=Mapsui.UI.Wpf"
+        Title="{DynamicResource StrTDeckMapPickTitle}"
+        Width="900" Height="640"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Hint bar -->
+        <Border Grid.Row="0" Background="#1E90FF" Padding="10,6">
+            <TextBlock Text="{DynamicResource StrTDeckMapPickHint}"
+                       Foreground="White" FontSize="12" TextWrapping="Wrap"/>
+        </Border>
+
+        <!-- Toolbar -->
+        <Border Grid.Row="1" Background="#F5F5F5" BorderBrush="#CCCCCC" BorderThickness="0,0,0,1" Padding="6,4">
+            <StackPanel Orientation="Horizontal">
+                <ToggleButton x:Name="DrawModeBtn"
+                              Content="{DynamicResource StrTDeckMapDrawModeOff}"
+                              Padding="10,5" Margin="0,0,8,0" MinWidth="130"
+                              Checked="DrawModeBtn_Changed"
+                              Unchecked="DrawModeBtn_Changed"/>
+                <Button x:Name="ClearLastBtn"
+                        Content="{DynamicResource StrTDeckMapClearLast}"
+                        Padding="8,5" Margin="0,0,4,0"
+                        Click="ClearLastBtn_Click"/>
+                <Button x:Name="ClearAllBtn"
+                        Content="{DynamicResource StrTDeckMapClearAll}"
+                        Padding="8,5"
+                        Click="ClearAllBtn_Click"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Map -->
+        <mapsui:MapControl x:Name="MapControl" Grid.Row="2"/>
+
+        <!-- Bottom bar -->
+        <Grid Grid.Row="3" Background="{DynamicResource SystemChromeMediumLowBrush}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock x:Name="CoordText" Grid.Column="0"
+                       VerticalAlignment="Center" Margin="10,8"
+                       Text="{DynamicResource StrTDeckMapPickNoSel}"
+                       FontSize="12"/>
+
+            <Button x:Name="AcceptBtn" Grid.Column="1"
+                    Content="{DynamicResource StrTDeckMapPickAccept}"
+                    Margin="4,6" Padding="10,5"
+                    IsEnabled="False"
+                    Click="AcceptBtn_Click"/>
+
+            <Button x:Name="CancelBtn" Grid.Column="2"
+                    Content="{DynamicResource StrTDeckCancel}"
+                    Margin="4,6,10,6" Padding="10,5"
+                    Click="CancelBtn_Click"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/MeshhessenClient/TDeckRegionMapWindow.xaml.cs
+++ b/MeshhessenClient/TDeckRegionMapWindow.xaml.cs
@@ -1,0 +1,278 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using Mapsui;
+using Mapsui.Extensions;
+using Mapsui.Layers;
+using Mapsui.Projections;
+using Mapsui.Styles;
+using Mapsui.Tiling;
+using Mapsui.Tiling.Layers;
+using NetTopologySuite.Geometries;
+using MeshhessenClient.Services;
+using Mapsui.Nts;
+using BruTile;
+using BruTile.Predefined;
+
+namespace MeshhessenClient;
+
+public partial class TDeckRegionMapWindow : Window
+{
+    private static string Loc(string key) =>
+        Application.Current?.Resources[key] as string ?? key;
+
+    public double ResultNorth { get; private set; }
+    public double ResultSouth { get; private set; }
+    public double ResultEast  { get; private set; }
+    public double ResultWest  { get; private set; }
+    public bool   Accepted    { get; private set; }
+
+    private readonly WritableLayer _drawLayer = new() { Style = null };
+
+    // Completed shapes
+    private readonly List<(MPoint Start, MPoint End)> _shapes = new();
+
+    // Shape currently being drawn
+    private bool   _isDrawing;
+    private MPoint _currentStart = new();
+    private MPoint _currentEnd   = new();
+
+    // Draw mode flag – when false, Mapsui panning is active
+    private bool _drawModeActive;
+
+    private static readonly string LocalTileDir =
+        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "maptiles");
+
+    public TDeckRegionMapWindow()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        SetupMap();
+
+        // Use Preview events so we can intercept before Mapsui's own pan handler
+        MapControl.AddHandler(PreviewMouseLeftButtonDownEvent,
+            new MouseButtonEventHandler(Map_PreviewMouseDown), handledEventsToo: false);
+        MapControl.AddHandler(PreviewMouseMoveEvent,
+            new MouseEventHandler(Map_PreviewMouseMove), handledEventsToo: false);
+        MapControl.AddHandler(PreviewMouseLeftButtonUpEvent,
+            new MouseButtonEventHandler(Map_PreviewMouseUp), handledEventsToo: false);
+    }
+
+    private void SetupMap()
+    {
+        var map = new Mapsui.Map();
+
+        var localOsmDir = Path.Combine(LocalTileDir, "osm");
+        bool hasLocalTiles = Directory.Exists(localOsmDir) &&
+            Directory.EnumerateFiles(localOsmDir, "*.png", SearchOption.AllDirectories).Any();
+
+        if (hasLocalTiles)
+        {
+            var schema   = new GlobalSphericalMercator(YAxis.TMS, 0, 18, "OSM");
+            var provider = new LocalFileTileProvider(LocalTileDir, "osm");
+            var source   = new TileSource(provider, schema);
+            map.Layers.Add(new TileLayer(source) { Name = "Tiles" });
+        }
+        else
+        {
+            map.Layers.Add(OpenStreetMap.CreateTileLayer("MeshhessenClient/TDeckWizard"));
+        }
+
+        map.Layers.Add(_drawLayer);
+
+        // Use Home callback – fires after the viewport is sized, so Resolutions are populated
+        var center = SphericalMercator.FromLonLat(10.0, 51.3);
+        map.Home = n => n.CenterOnAndZoomTo(new MPoint(center.x, center.y), 611.0);
+
+        MapControl.Map = map;
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  DRAW MODE TOGGLE
+    // ──────────────────────────────────────────────────────────
+    private void DrawModeBtn_Changed(object sender, RoutedEventArgs e)
+    {
+        _drawModeActive = DrawModeBtn.IsChecked == true;
+        DrawModeBtn.Content = _drawModeActive
+            ? Loc("StrTDeckMapDrawModeOn")
+            : Loc("StrTDeckMapDrawModeOff");
+        MapControl.Cursor = _drawModeActive ? Cursors.Cross : Cursors.Arrow;
+
+        // If user switches back to nav mode mid-draw, discard the incomplete shape
+        if (!_drawModeActive && _isDrawing)
+        {
+            _isDrawing = false;
+            MapControl.ReleaseMouseCapture();
+            _currentStart = new MPoint();
+            _currentEnd   = new MPoint();
+            UpdateDrawLayer();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  MOUSE HANDLING (Preview = before Mapsui pan handler)
+    // ──────────────────────────────────────────────────────────
+    private void Map_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (!_drawModeActive) return;
+        e.Handled = true;   // blocks Mapsui panning
+        _isDrawing    = true;
+        var pos       = e.GetPosition(MapControl);
+        _currentStart = MapControl.Map.Navigator.Viewport.ScreenToWorld(pos.X, pos.Y);
+        _currentEnd   = _currentStart;
+        MapControl.CaptureMouse();
+    }
+
+    private void Map_PreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_isDrawing) return;
+        e.Handled   = true;
+        var pos     = e.GetPosition(MapControl);
+        _currentEnd = MapControl.Map.Navigator.Viewport.ScreenToWorld(pos.X, pos.Y);
+        UpdateDrawLayer();
+    }
+
+    private void Map_PreviewMouseUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_isDrawing) return;
+        e.Handled = true;
+        _isDrawing = false;
+        MapControl.ReleaseMouseCapture();
+
+        var pos     = e.GetPosition(MapControl);
+        _currentEnd = MapControl.Map.Navigator.Viewport.ScreenToWorld(pos.X, pos.Y);
+
+        // Only keep shapes with actual area
+        if (Math.Abs(_currentEnd.X - _currentStart.X) > 1 &&
+            Math.Abs(_currentEnd.Y - _currentStart.Y) > 1)
+        {
+            _shapes.Add((_currentStart, _currentEnd));
+        }
+
+        _currentStart = new MPoint();
+        _currentEnd   = new MPoint();
+        UpdateDrawLayer();
+        UpdateCoordText();
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  CLEAR BUTTONS
+    // ──────────────────────────────────────────────────────────
+    private void ClearLastBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_shapes.Count > 0) _shapes.RemoveAt(_shapes.Count - 1);
+        UpdateDrawLayer();
+        UpdateCoordText();
+    }
+
+    private void ClearAllBtn_Click(object sender, RoutedEventArgs e)
+    {
+        _shapes.Clear();
+        _isDrawing    = false;
+        _currentStart = new MPoint();
+        _currentEnd   = new MPoint();
+        MapControl.ReleaseMouseCapture();
+        UpdateDrawLayer();
+        UpdateCoordText();
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  DRAW LAYER
+    // ──────────────────────────────────────────────────────────
+    private void UpdateDrawLayer()
+    {
+        _drawLayer.Clear();
+
+        foreach (var (s, end) in _shapes)
+            AddRect(s, end, completed: true);
+
+        if (_isDrawing && (Math.Abs(_currentEnd.X - _currentStart.X) > 1 ||
+                           Math.Abs(_currentEnd.Y - _currentStart.Y) > 1))
+            AddRect(_currentStart, _currentEnd, completed: false);
+
+        _drawLayer.DataHasChanged();
+        AcceptBtn.IsEnabled = _shapes.Count > 0;
+        ClearLastBtn.IsEnabled = _shapes.Count > 0;
+        ClearAllBtn.IsEnabled  = _shapes.Count > 0;
+    }
+
+    private void AddRect(MPoint s, MPoint e, bool completed)
+    {
+        double minX = Math.Min(s.X, e.X), maxX = Math.Max(s.X, e.X);
+        double minY = Math.Min(s.Y, e.Y), maxY = Math.Max(s.Y, e.Y);
+
+        var ring = new LinearRing(new[]
+        {
+            new Coordinate(minX, minY),
+            new Coordinate(maxX, minY),
+            new Coordinate(maxX, maxY),
+            new Coordinate(minX, maxY),
+            new Coordinate(minX, minY),
+        });
+
+        var feature = new GeometryFeature
+        {
+            Geometry = new NetTopologySuite.Geometries.Polygon(ring)
+        };
+        feature.Styles.Add(new VectorStyle
+        {
+            Fill    = new Brush(completed ? new Color(30, 144, 255, 70)  : new Color(255, 165, 0, 70)),
+            Outline = new Pen(completed  ? new Color(30, 144, 255, 220) : new Color(255, 165, 0, 220), 2)
+        });
+        _drawLayer.Add(feature);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  COORD TEXT + BBOX
+    // ──────────────────────────────────────────────────────────
+    private void UpdateCoordText()
+    {
+        if (_shapes.Count == 0)
+        {
+            CoordText.Text = Loc("StrTDeckMapPickNoSel");
+            AcceptBtn.IsEnabled = false;
+            return;
+        }
+
+        var (north, south, west, east) = ComputeUnionBbox();
+        CoordText.Text = string.Format(Loc("StrTDeckMapPickSel"),
+            _shapes.Count, north, south, west, east);
+    }
+
+    private (double North, double South, double West, double East) ComputeUnionBbox()
+    {
+        double north = double.MinValue, south = double.MaxValue;
+        double west  = double.MaxValue, east  = double.MinValue;
+
+        foreach (var (s, e) in _shapes)
+        {
+            var (lon1, lat1) = SphericalMercator.ToLonLat(s.X, s.Y);
+            var (lon2, lat2) = SphericalMercator.ToLonLat(e.X, e.Y);
+            north = Math.Max(north, Math.Max(lat1, lat2));
+            south = Math.Min(south, Math.Min(lat1, lat2));
+            west  = Math.Min(west,  Math.Min(lon1, lon2));
+            east  = Math.Max(east,  Math.Max(lon1, lon2));
+        }
+        return (north, south, west, east);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  ACCEPT / CANCEL
+    // ──────────────────────────────────────────────────────────
+    private void AcceptBtn_Click(object sender, RoutedEventArgs e)
+    {
+        var (north, south, west, east) = ComputeUnionBbox();
+        ResultNorth = north;
+        ResultSouth = south;
+        ResultWest  = west;
+        ResultEast  = east;
+        Accepted    = true;
+        Close();
+    }
+
+    private void CancelBtn_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/MeshhessenClient/TDeckWizardWindow.xaml
+++ b/MeshhessenClient/TDeckWizardWindow.xaml
@@ -1,0 +1,371 @@
+<Window x:Class="MeshhessenClient.TDeckWizardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="{DynamicResource StrTDeckTitle}"
+        Width="680" Height="560"
+        MinWidth="560" MinHeight="460"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>  <!-- header -->
+            <RowDefinition Height="*"/>     <!-- page content -->
+            <RowDefinition Height="Auto"/>  <!-- footer nav -->
+        </Grid.RowDefinitions>
+
+        <!-- ── HEADER ── -->
+        <Border Grid.Row="0" Background="#1E3A5F" Padding="16,10">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="StepTitleText" Grid.Column="0"
+                           Foreground="White" FontSize="16" FontWeight="SemiBold"
+                           VerticalAlignment="Center"/>
+                <TextBlock x:Name="StepIndicatorText" Grid.Column="1"
+                           Foreground="#A0C4E8" FontSize="12"
+                           VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <!-- ── PAGE AREA ── -->
+        <Grid Grid.Row="1">
+
+            <!-- PAGE 1: Welcome -->
+            <ScrollViewer x:Name="Page1" VerticalScrollBarVisibility="Auto" Padding="20">
+                <StackPanel>
+                    <Border Background="#1E90FF" CornerRadius="4" Padding="10,6" Margin="0,0,0,14">
+                        <TextBlock Text="{DynamicResource StrTDeckGermanyOnly}"
+                                   Foreground="White" FontWeight="SemiBold"/>
+                    </Border>
+                    <TextBlock Text="{DynamicResource StrTDeckS1Desc}"
+                               TextWrapping="Wrap" LineHeight="20" FontSize="13"/>
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- PAGE 2: Drive selection -->
+            <Grid x:Name="Page2" Visibility="Collapsed" Margin="20">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0" Text="{DynamicResource StrTDeckS2Hint}"
+                           TextWrapping="Wrap" Margin="0,0,0,10" Foreground="#666"/>
+
+                <Grid Grid.Row="1" Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="{DynamicResource StrTDeckDriveLabel}"
+                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="DriveComboBox" Grid.Column="1"
+                              SelectionChanged="DriveComboBox_SelectionChanged"/>
+                    <Button Grid.Column="2" Content="{DynamicResource StrTDeckRefresh}"
+                            Margin="8,0,0,0" Padding="10,5"
+                            Click="RefreshDrives_Click"/>
+                </Grid>
+
+                <Border Grid.Row="2" BorderBrush="#DDD" BorderThickness="1" CornerRadius="4"
+                        Padding="12" Margin="0,0,0,8">
+                    <TextBlock x:Name="DriveInfoText" TextWrapping="Wrap"
+                               Text="{DynamicResource StrTDeckNoDrives}"
+                               Foreground="#555" FontSize="12"/>
+                </Border>
+
+                <TextBlock Grid.Row="3" x:Name="DriveWarningText"
+                           Foreground="OrangeRed" TextWrapping="Wrap" FontSize="12"/>
+            </Grid>
+
+            <!-- PAGE 3: Format check -->
+            <Grid x:Name="Page3" Visibility="Collapsed" Margin="20">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" CornerRadius="6" Padding="12" Margin="0,0,0,10"
+                        x:Name="FormatStatusBorder">
+                    <TextBlock x:Name="FormatStatusText" TextWrapping="Wrap" FontSize="13"/>
+                </Border>
+
+                <TextBlock Grid.Row="1"
+                           Text="{DynamicResource StrTDeckFormatHint}"
+                           TextWrapping="Wrap" Foreground="#555" FontSize="11"
+                           Margin="0,0,0,12"/>
+
+                <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,10">
+                    <Button x:Name="FormatBtn"
+                            Content="{DynamicResource StrTDeckFormatBtn}"
+                            Padding="14,7" Margin="0,0,10,0"
+                            Click="FormatBtn_Click"/>
+                    <Button x:Name="SkipFormatBtn"
+                            Content="{DynamicResource StrTDeckSkipFormat}"
+                            Padding="14,7"
+                            Click="SkipFormatBtn_Click"/>
+                </StackPanel>
+
+                <Border Grid.Row="3" x:Name="FormatProgressBorder" Visibility="Collapsed"
+                        Background="#F0F4F8" CornerRadius="4" Padding="10">
+                    <StackPanel>
+                        <TextBlock x:Name="FormatProgressText" TextWrapping="Wrap" Margin="0,0,0,6"/>
+                        <ProgressBar x:Name="FormatProgress" Height="6" IsIndeterminate="True"/>
+                    </StackPanel>
+                </Border>
+
+                <TextBlock Grid.Row="4" x:Name="FormatResultText"
+                           TextWrapping="Wrap" FontWeight="SemiBold" Margin="0,8,0,0"/>
+            </Grid>
+
+            <!-- PAGE 4: Region selection -->
+            <Grid x:Name="Page4" Visibility="Collapsed" Margin="20">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Radio buttons -->
+                <StackPanel Grid.Row="0" Margin="0,0,0,10">
+                    <RadioButton x:Name="RegionByStateRb" GroupName="Region"
+                                 Content="{DynamicResource StrTDeckRegionByState}"
+                                 IsChecked="True" Margin="0,0,0,4"
+                                 Checked="Region_Checked"/>
+                    <RadioButton x:Name="RegionGermanyRb" GroupName="Region"
+                                 Content="{DynamicResource StrTDeckRegionGermany}"
+                                 Margin="0,0,0,4"
+                                 Checked="Region_Checked"/>
+                    <RadioButton x:Name="RegionFreestyleRb" GroupName="Region"
+                                 Content="{DynamicResource StrTDeckRegionFreeStyle}"
+                                 Checked="Region_Checked"/>
+                </StackPanel>
+
+                <!-- State selection panel -->
+                <Grid x:Name="StatesPanel" Grid.Row="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
+                        <Button Content="{DynamicResource StrTDeckStateSelectAll}"
+                                Padding="10,4" Margin="0,0,6,0" Click="SelectAllStates_Click"/>
+                        <Button Content="{DynamicResource StrTDeckStateSelectNone}"
+                                Padding="10,4" Click="SelectNoneStates_Click"/>
+                    </StackPanel>
+                    <Border Grid.Row="1" BorderBrush="#CCC" BorderThickness="1" CornerRadius="4">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <WrapPanel x:Name="StatesWrapPanel" Margin="8"/>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+
+                <!-- Freestyle panel -->
+                <Grid x:Name="FreestylePanel" Grid.Row="1" Visibility="Collapsed">
+                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <Button Content="{DynamicResource StrTDeckOpenMap}"
+                                FontSize="14" Padding="20,10"
+                                Click="OpenMapDraw_Click"/>
+                        <TextBlock x:Name="FreestyleStatusText"
+                                   Text="{DynamicResource StrTDeckFreestyleNotSet}"
+                                   Margin="0,12,0,0" TextAlignment="Center"
+                                   Foreground="#666" FontSize="12" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Grid>
+
+                <!-- Germany panel (just info) -->
+                <Grid x:Name="GermanyPanel" Grid.Row="1" Visibility="Collapsed">
+                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <TextBlock Text="🇩🇪" FontSize="48" TextAlignment="Center"/>
+                        <TextBlock Text="N 55.10° | S 47.27° | W 5.87° | E 15.04°"
+                                   Margin="0,8,0,0" TextAlignment="Center"
+                                   Foreground="#444" FontSize="12"/>
+                    </StackPanel>
+                </Grid>
+
+                <!-- Bbox preview -->
+                <TextBlock x:Name="BboxPreviewText" Grid.Row="2"
+                           Foreground="#1E3A5F" FontWeight="SemiBold"
+                           Margin="0,8,0,0" TextWrapping="Wrap" FontSize="12"/>
+            </Grid>
+
+            <!-- PAGE 5: Zoom + map type -->
+            <ScrollViewer x:Name="Page5" Visibility="Collapsed"
+                          VerticalScrollBarVisibility="Auto" Padding="20">
+                <StackPanel>
+                    <!-- Zoom -->
+                    <TextBlock Text="{DynamicResource StrTDeckZoomLabel}"
+                               FontWeight="SemiBold" Margin="0,0,0,6"/>
+                    <StackPanel Margin="8,0,0,0">
+                        <RadioButton x:Name="Zoom8Rb"  GroupName="Zoom" Tag="8"
+                                     Content="{DynamicResource StrTDeckZoom8}"
+                                     Margin="0,3" Checked="Zoom_Checked"/>
+                        <RadioButton x:Name="Zoom10Rb" GroupName="Zoom" Tag="10"
+                                     Content="{DynamicResource StrTDeckZoom10}"
+                                     Margin="0,3" Checked="Zoom_Checked"/>
+                        <RadioButton x:Name="Zoom12Rb" GroupName="Zoom" Tag="12"
+                                     Content="{DynamicResource StrTDeckZoom12}"
+                                     Margin="0,3" Checked="Zoom_Checked"/>
+                        <RadioButton x:Name="Zoom14Rb" GroupName="Zoom" Tag="14"
+                                     IsChecked="True"
+                                     Content="{DynamicResource StrTDeckZoom14}"
+                                     Margin="0,3" Checked="Zoom_Checked"/>
+                        <RadioButton x:Name="Zoom16Rb" GroupName="Zoom" Tag="16"
+                                     Content="{DynamicResource StrTDeckZoom16}"
+                                     Margin="0,3" Checked="Zoom_Checked"/>
+                        <RadioButton x:Name="Zoom17Rb" GroupName="Zoom" Tag="17"
+                                     Content="{DynamicResource StrTDeckZoom17}"
+                                     Margin="0,3" Checked="Zoom_Checked"/>
+                    </StackPanel>
+
+                    <TextBlock x:Name="ZoomWarningText" Margin="0,8,0,0"
+                               TextWrapping="Wrap" FontSize="12" Visibility="Collapsed"/>
+
+                    <Separator Margin="0,14"/>
+
+                    <!-- Map type -->
+                    <TextBlock Text="{DynamicResource StrTDeckMapTypeLabel}"
+                               FontWeight="SemiBold" Margin="0,0,0,6"/>
+                    <StackPanel Margin="8,0,0,0">
+                        <RadioButton x:Name="MapOsmRb" GroupName="MapType" Tag="OSM"
+                                     Content="{DynamicResource StrTDeckMapOSM}"
+                                     IsChecked="True" Margin="0,3"
+                                     Checked="MapType_Checked"/>
+                        <RadioButton x:Name="MapDarkRb" GroupName="MapType" Tag="Dark"
+                                     Content="{DynamicResource StrTDeckMapDark}"
+                                     Margin="0,3" Checked="MapType_Checked"/>
+                        <RadioButton x:Name="MapTopoRb" GroupName="MapType" Tag="Topo"
+                                     Content="{DynamicResource StrTDeckMapTopo}"
+                                     Margin="0,3" Checked="MapType_Checked"/>
+                    </StackPanel>
+
+                    <Separator Margin="0,14"/>
+
+                    <!-- Estimate -->
+                    <TextBlock x:Name="EstimateText" FontSize="13" TextWrapping="Wrap"/>
+                    <TextBlock x:Name="SDFreeText" FontSize="12" Foreground="#555"
+                               Margin="0,4" TextWrapping="Wrap"/>
+                    <TextBlock x:Name="SDLowText" FontSize="12" Foreground="OrangeRed"
+                               Margin="0,4" TextWrapping="Wrap" Visibility="Collapsed"/>
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- PAGE 6: Download -->
+            <Grid x:Name="Page6" Visibility="Collapsed" Margin="20">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Summary -->
+                <Border Grid.Row="0" Background="#F0F4F8" CornerRadius="6"
+                        Padding="14" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock Text="{DynamicResource StrTDeckSummaryTitle}"
+                                   FontWeight="Bold" Margin="0,0,0,6"/>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource StrTDeckSumDrive}" Foreground="#555"/>
+                            <TextBlock Grid.Row="0" Grid.Column="1" x:Name="SumDriveText" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource StrTDeckSumRegion}" Foreground="#555"/>
+                            <TextBlock Grid.Row="1" Grid.Column="1" x:Name="SumRegionText" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource StrTDeckSumZoom}" Foreground="#555"/>
+                            <TextBlock Grid.Row="2" Grid.Column="1" x:Name="SumZoomText" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource StrTDeckSumType}" Foreground="#555"/>
+                            <TextBlock Grid.Row="3" Grid.Column="1" x:Name="SumTypeText" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource StrTDeckSumTiles}" Foreground="#555"/>
+                            <TextBlock Grid.Row="4" Grid.Column="1" x:Name="SumTilesText" FontWeight="SemiBold"/>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <StackPanel Grid.Row="1" Margin="0,0,0,8">
+                    <TextBlock Text="{DynamicResource StrTDeckCopyHint}"
+                               Foreground="#2E7D32" FontSize="11" Margin="0,0,0,2"/>
+                    <TextBlock Text="{DynamicResource StrTDeckAdditiveHint}"
+                               Foreground="#2E7D32" FontSize="11"/>
+                </StackPanel>
+
+                <!-- Progress area -->
+                <Grid Grid.Row="2" Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="StartBtn" Grid.Column="0"
+                            Content="{DynamicResource StrTDeckStartBtn}"
+                            FontSize="13" Padding="14,8"
+                            Click="StartDownload_Click"/>
+                    <Button x:Name="CancelDownloadBtn" Grid.Column="1"
+                            Content="{DynamicResource StrTDeckCancel}"
+                            Visibility="Collapsed" Padding="14,8" Margin="8,0,0,0"
+                            Click="CancelDownload_Click"/>
+                </Grid>
+
+                <StackPanel Grid.Row="3" Margin="0,4,0,0">
+                    <ProgressBar x:Name="DownloadProgress" Height="10" Margin="0,0,0,6"/>
+                    <TextBlock x:Name="ProgressTileText" FontSize="11" Foreground="#555" Margin="0,0,0,2"/>
+                    <TextBlock x:Name="ProgressZoomText" FontSize="11" Foreground="#777"/>
+                </StackPanel>
+
+                <TextBlock Grid.Row="4" x:Name="DownloadResultText"
+                           FontWeight="SemiBold" FontSize="13" TextWrapping="Wrap"
+                           Margin="0,10,0,0"/>
+            </Grid>
+
+        </Grid>
+
+        <!-- ── FOOTER NAV ── -->
+        <Border Grid.Row="2" BorderBrush="#DDD" BorderThickness="0,1,0,0"
+                Background="{DynamicResource SystemChromeMediumLowBrush}" Padding="16,10">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <Button x:Name="BackBtn" Grid.Column="0"
+                        Content="{DynamicResource StrTDeckBack}"
+                        Padding="14,7" IsEnabled="False"
+                        Click="BackBtn_Click"/>
+
+                <TextBlock x:Name="FooterStepText" Grid.Column="1"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Foreground="#888" FontSize="12"/>
+
+                <Button x:Name="CancelBtn" Grid.Column="2"
+                        Content="{DynamicResource StrTDeckCancel}"
+                        Padding="14,7" Margin="0,0,8,0"
+                        Click="CancelBtn_Click"/>
+
+                <Button x:Name="NextBtn" Grid.Column="3"
+                        Content="{DynamicResource StrTDeckNext}"
+                        Padding="14,7"
+                        Click="NextBtn_Click"/>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/MeshhessenClient/TDeckWizardWindow.xaml.cs
+++ b/MeshhessenClient/TDeckWizardWindow.xaml.cs
@@ -1,0 +1,701 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using MeshhessenClient.Services;
+
+namespace MeshhessenClient;
+
+public partial class TDeckWizardWindow : Window
+{
+    private static string Loc(string key) =>
+        Application.Current?.Resources[key] as string ?? key;
+
+    private static readonly string LocalTileDir =
+        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "maptiles");
+
+    // ── Wizard state ──
+    private int _currentStep = 1;
+    private const int TotalSteps = 6;
+
+    // Step 2: drive
+    private DriveInfo? _selectedDrive;
+
+    // Step 3: format
+    private bool _formatOk;
+
+    // Step 4: region
+    private double _north, _south, _east, _west;
+    private string _regionName = "";
+    private bool _regionSet;
+
+    // Step 5: zoom + type
+    private int _maxZoom = 14;
+    private MapSource _mapSource = MapSource.OSM;
+
+    // Step 6: download
+    private CancellationTokenSource? _cts;
+
+    // ── German states bounding boxes: north, south, east, west ──
+    private static readonly (string Name, double N, double S, double E, double W)[] States =
+    {
+        ("Baden-Württemberg", 49.7913, 47.5324, 10.4923, 7.5114),
+        ("Bayern",            50.5648, 47.2703, 13.8395, 8.9766),
+        ("Berlin",            52.6754, 52.3383, 13.7612, 13.0883),
+        ("Brandenburg",       53.5588, 51.3595, 14.7654, 11.2668),
+        ("Bremen",            53.2282, 53.0059,  8.9910,  8.4817),
+        ("Hamburg",           53.7444, 53.3951, 10.3257,  9.7312),
+        ("Hessen",            51.6567, 49.3951, 10.2367,  7.7731),
+        ("Mecklenburg-Vorpommern", 54.6850, 53.1148, 14.4127, 10.5930),
+        ("Niedersachsen",     53.8941, 51.2955, 11.5978,  6.6541),
+        ("Nordrhein-Westfalen", 52.5314, 50.3228, 9.4614,  5.8660),
+        ("Rheinland-Pfalz",   50.9391, 48.9667,  8.5077,  6.1131),
+        ("Saarland",          49.6399, 49.1119,  7.4036,  6.3626),
+        ("Sachsen",           51.6853, 50.1713, 15.0376, 11.8726),
+        ("Sachsen-Anhalt",    53.0410, 50.9380, 13.1877, 10.5631),
+        ("Schleswig-Holstein",55.0583, 53.3595, 11.3102,  7.8700),
+        ("Thüringen",         51.6488, 50.2004, 12.6534,  9.8774),
+    };
+
+    // Checkboxes for states
+    private readonly List<CheckBox> _stateCheckBoxes = new();
+
+    // Freestyle bbox
+    private double _freeN, _freeS, _freeE, _freeW;
+    private bool _freeStyleSet;
+
+    public TDeckWizardWindow()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        BuildStateCheckboxes();
+        RefreshDrives();
+        GoToStep(1);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  STATE CHECKBOXES
+    // ──────────────────────────────────────────────────────────
+    private void BuildStateCheckboxes()
+    {
+        StatesWrapPanel.Children.Clear();
+        _stateCheckBoxes.Clear();
+        foreach (var s in States)
+        {
+            var cb = new CheckBox
+            {
+                Content = s.Name,
+                Tag     = s,
+                Margin  = new Thickness(4, 3, 12, 3),
+                Width   = 190
+            };
+            cb.Checked   += StateCheckBox_Changed;
+            cb.Unchecked += StateCheckBox_Changed;
+            _stateCheckBoxes.Add(cb);
+            StatesWrapPanel.Children.Add(cb);
+        }
+    }
+
+    private void StateCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateBboxFromStates();
+
+    private void SelectAllStates_Click(object sender, RoutedEventArgs e)
+    {
+        foreach (var cb in _stateCheckBoxes) cb.IsChecked = true;
+    }
+
+    private void SelectNoneStates_Click(object sender, RoutedEventArgs e)
+    {
+        foreach (var cb in _stateCheckBoxes) cb.IsChecked = false;
+    }
+
+    private void UpdateBboxFromStates()
+    {
+        var selected = _stateCheckBoxes
+            .Where(cb => cb.IsChecked == true)
+            .Select(cb => ((string Name, double N, double S, double E, double W))cb.Tag!)
+            .ToList();
+
+        if (selected.Count == 0)
+        {
+            _regionSet = false;
+            BboxPreviewText.Text = "";
+            return;
+        }
+
+        _north = selected.Max(s => s.N);
+        _south = selected.Min(s => s.S);
+        _east  = selected.Max(s => s.E);
+        _west  = selected.Min(s => s.W);
+        _regionName = selected.Count == 1 ? selected[0].Name : $"{selected.Count} Bundesländer";
+        _regionSet = true;
+        BboxPreviewText.Text = string.Format(Loc("StrTDeckBboxPreview"), _north, _south, _west, _east);
+        UpdateEstimateIfOnPage5();
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  DRIVE HANDLING
+    // ──────────────────────────────────────────────────────────
+    private void RefreshDrives()
+    {
+        DriveComboBox.Items.Clear();
+        var drives = DriveService.GetRemovableDrives();
+        if (drives.Count == 0)
+        {
+            DriveInfoText.Text = Loc("StrTDeckNoDrives");
+            _selectedDrive = null;
+            return;
+        }
+
+        foreach (var d in drives)
+        {
+            DriveComboBox.Items.Add(new ComboBoxItem
+            {
+                Content = $"{d.Name} — {d.VolumeLabel}",
+                Tag = d
+            });
+        }
+        DriveComboBox.SelectedIndex = 0;
+    }
+
+    private void RefreshDrives_Click(object sender, RoutedEventArgs e) => RefreshDrives();
+
+    private void DriveComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (DriveComboBox.SelectedItem is ComboBoxItem item && item.Tag is DriveInfo d)
+        {
+            _selectedDrive = d;
+            DriveInfoText.Text = string.Format(Loc("StrTDeckDriveInfo"),
+                DriveService.FormatSizeString(d.TotalSize),
+                DriveService.FormatSizeString(d.AvailableFreeSpace),
+                d.DriveFormat ?? "?");
+        }
+        else
+        {
+            _selectedDrive = null;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  FORMAT
+    // ──────────────────────────────────────────────────────────
+    private void UpdateFormatPage()
+    {
+        if (_selectedDrive == null) return;
+        var status = DriveService.CheckFormat(_selectedDrive);
+
+        if (status.IsRecommended)
+        {
+            _formatOk = true;
+            FormatStatusBorder.Background = new SolidColorBrush(System.Windows.Media.Color.FromRgb(200, 230, 200));
+            FormatStatusText.Text = string.Format(Loc("StrTDeckFormatOk"), status.FileSystem);
+            FormatStatusText.Foreground = Brushes.DarkGreen;
+        }
+        else
+        {
+            _formatOk = false;
+            FormatStatusBorder.Background = new SolidColorBrush(System.Windows.Media.Color.FromRgb(255, 240, 200));
+            FormatStatusText.Text = string.Format(Loc("StrTDeckFormatWarn"), status.FileSystem);
+            FormatStatusText.Foreground = Brushes.DarkOrange;
+        }
+
+        FormatResultText.Text = "";
+    }
+
+    private async void FormatBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_selectedDrive == null) return;
+        char dl = _selectedDrive.Name[0];
+
+        // Ask filesystem
+        var dlg1 = new TDeckFormatChoiceDialog(_selectedDrive)
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+        if (dlg1.ShowDialog() != true) return;
+        string fsChoice = dlg1.ChosenFileSystem;
+
+        // First confirmation
+        if (MessageBox.Show(
+                string.Format(Loc("StrTDeckFmtConfirm1"), $"{dl}:\\"),
+                Loc("StrTDeckFmtConfirmTitle"),
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
+            return;
+
+        // Second confirmation
+        if (MessageBox.Show(
+                string.Format(Loc("StrTDeckFmtConfirm2"), $"{dl}:\\"),
+                Loc("StrTDeckFmtConfirmTitle"),
+                MessageBoxButton.YesNo, MessageBoxImage.Stop) != MessageBoxResult.Yes)
+            return;
+
+        FormatProgressBorder.Visibility = Visibility.Visible;
+        FormatProgressText.Text = string.Format(Loc("StrTDeckFormatting"), $"{dl}:\\");
+        FormatBtn.IsEnabled = false;
+        SkipFormatBtn.IsEnabled = false;
+
+        var progress = new Progress<string>(msg => FormatProgressText.Text = msg);
+        var result = await DriveService.FormatDriveAsync(dl, fsChoice, progress);
+
+        FormatProgressBorder.Visibility = Visibility.Collapsed;
+        FormatBtn.IsEnabled = true;
+        SkipFormatBtn.IsEnabled = true;
+
+        if (result == FormatResult.Success)
+        {
+            // Re-read drive info after format
+            var refreshed = DriveService.GetRemovableDrives()
+                .FirstOrDefault(d => d.Name[0] == dl);
+            if (refreshed != null) _selectedDrive = refreshed;
+
+            _formatOk = true;
+            FormatResultText.Foreground = Brushes.DarkGreen;
+            FormatResultText.Text = string.Format(Loc("StrTDeckFormatDone"), fsChoice);
+            UpdateFormatPage();
+        }
+        else if (result == FormatResult.Cancelled)
+        {
+            FormatResultText.Foreground = Brushes.Gray;
+            FormatResultText.Text = Loc("StrTDeckFormatFailed");
+        }
+        else
+        {
+            FormatResultText.Foreground = Brushes.Red;
+            FormatResultText.Text = Loc("StrTDeckFormatFailed");
+        }
+    }
+
+    private void SkipFormatBtn_Click(object sender, RoutedEventArgs e)
+    {
+        _formatOk = true; // user chose to skip, proceed anyway
+        GoToStep(4);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  REGION
+    // ──────────────────────────────────────────────────────────
+    private void Region_Checked(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded) return;
+        bool byState   = RegionByStateRb.IsChecked == true;
+        bool germany   = RegionGermanyRb.IsChecked == true;
+        bool freestyle = RegionFreestyleRb.IsChecked == true;
+
+        StatesPanel.Visibility    = byState   ? Visibility.Visible : Visibility.Collapsed;
+        GermanyPanel.Visibility   = germany   ? Visibility.Visible : Visibility.Collapsed;
+        FreestylePanel.Visibility = freestyle ? Visibility.Visible : Visibility.Collapsed;
+
+        if (germany)
+        {
+            _north = 55.0997; _south = 47.2701; _east = 15.0419; _west = 5.8660;
+            _regionName = "Deutschland";
+            _regionSet  = true;
+            BboxPreviewText.Text = string.Format(Loc("StrTDeckBboxPreview"), _north, _south, _west, _east);
+        }
+        else if (freestyle)
+        {
+            _regionSet = _freeStyleSet;
+            if (_freeStyleSet)
+            {
+                _north = _freeN; _south = _freeS; _east = _freeE; _west = _freeW;
+                BboxPreviewText.Text = string.Format(Loc("StrTDeckBboxPreview"), _north, _south, _west, _east);
+            }
+            else
+            {
+                BboxPreviewText.Text = "";
+            }
+        }
+        else // by state
+        {
+            UpdateBboxFromStates();
+        }
+        UpdateEstimateIfOnPage5();
+    }
+
+    private void OpenMapDraw_Click(object sender, RoutedEventArgs e)
+    {
+        var mapWin = new TDeckRegionMapWindow { Owner = this };
+        mapWin.ShowDialog();
+        if (mapWin.Accepted)
+        {
+            _freeN = mapWin.ResultNorth;
+            _freeS = mapWin.ResultSouth;
+            _freeE = mapWin.ResultEast;
+            _freeW = mapWin.ResultWest;
+            _freeStyleSet = true;
+
+            _north = _freeN; _south = _freeS; _east = _freeE; _west = _freeW;
+            _regionName = "Freestyle";
+            _regionSet  = true;
+
+            FreestyleStatusText.Text = string.Format(Loc("StrTDeckBboxPreview"),
+                _freeN, _freeS, _freeW, _freeE);
+            BboxPreviewText.Text = FreestyleStatusText.Text;
+            UpdateEstimateIfOnPage5();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  ZOOM + MAP TYPE
+    // ──────────────────────────────────────────────────────────
+    private void Zoom_Checked(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded) return;
+        var rb = (RadioButton)sender;
+        _maxZoom = int.Parse((string)rb.Tag);
+
+        ZoomWarningText.Visibility = Visibility.Collapsed;
+        if (_maxZoom >= 16)
+        {
+            ZoomWarningText.Text = Loc("StrTDeckZoomWarn16");
+            ZoomWarningText.Foreground = Brushes.Red;
+            ZoomWarningText.Visibility = Visibility.Visible;
+        }
+        else if (_maxZoom >= 14)
+        {
+            ZoomWarningText.Text = Loc("StrTDeckZoomWarn14");
+            ZoomWarningText.Foreground = Brushes.DarkOrange;
+            ZoomWarningText.Visibility = Visibility.Visible;
+        }
+
+        UpdateEstimate();
+    }
+
+    private void MapType_Checked(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded) return;
+        var rb = (RadioButton)sender;
+        _mapSource = (string)rb.Tag switch
+        {
+            "Topo" => MapSource.OSMTopo,
+            "Dark" => MapSource.OSMDark,
+            _      => MapSource.OSM
+        };
+        UpdateEstimate();
+    }
+
+    private void UpdateEstimate()
+    {
+        if (!IsLoaded || !_regionSet || EstimateText == null) return;
+
+        int count = TileDownloaderService.EstimateTileCount(_north, _south, _east, _west, 1, _maxZoom);
+        long sizeBytes = TDeckTileService.EstimateSizeBytes(count);
+        EstimateText.Text = string.Format(Loc("StrTDeckEstimate"),
+            count, TDeckTileService.FormatSize(sizeBytes));
+
+        if (_selectedDrive != null)
+        {
+            SDFreeText.Text = string.Format(Loc("StrTDeckSDFree"),
+                DriveService.FormatSizeString(_selectedDrive.AvailableFreeSpace));
+            SDLowText.Visibility = sizeBytes > _selectedDrive.AvailableFreeSpace
+                ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
+
+    private void UpdateEstimateIfOnPage5()
+    {
+        if (_currentStep == 5) UpdateEstimate();
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  DOWNLOAD
+    // ──────────────────────────────────────────────────────────
+    private void UpdateSummaryPage()
+    {
+        SumDriveText.Text  = _selectedDrive?.Name ?? "?";
+        SumRegionText.Text = _regionName;
+        SumZoomText.Text   = $"1–{_maxZoom}";
+        SumTypeText.Text   = _mapSource switch
+        {
+            MapSource.OSMTopo => Loc("StrTDeckMapTopo"),
+            MapSource.OSMDark => Loc("StrTDeckMapDark"),
+            _                 => Loc("StrTDeckMapOSM")
+        };
+
+        int count = TileDownloaderService.EstimateTileCount(_north, _south, _east, _west, 1, _maxZoom);
+        SumTilesText.Text = $"≈ {count:N0} (~{TDeckTileService.FormatSize(TDeckTileService.EstimateSizeBytes(count))})";
+
+        DownloadProgress.Value  = 0;
+        ProgressTileText.Text   = "";
+        ProgressZoomText.Text   = "";
+        DownloadResultText.Text = "";
+    }
+
+    private async void StartDownload_Click(object sender, RoutedEventArgs e)
+    {
+        if (_selectedDrive == null) return;
+
+        // SD card space check before starting
+        int estimatedTiles = TileDownloaderService.EstimateTileCount(_north, _south, _east, _west, 1, _maxZoom);
+        long estimatedBytes = TDeckTileService.EstimateSizeBytes(estimatedTiles);
+
+        // Re-read free space (might have changed since step 5)
+        try
+        {
+            var refreshed = new DriveInfo(_selectedDrive.Name);
+            if (estimatedBytes > refreshed.AvailableFreeSpace)
+            {
+                var needed = TDeckTileService.FormatSize(estimatedBytes);
+                var free   = DriveService.FormatSizeString(refreshed.AvailableFreeSpace);
+                var answer = MessageBox.Show(
+                    $"⚠️ Möglicherweise nicht genug Speicherplatz auf der SD-Karte!\n\n" +
+                    $"Geschätzt benötigt: {needed}\n" +
+                    $"Verfügbar:          {free}\n\n" +
+                    $"Trotzdem fortfahren?",
+                    Loc("StrTDeckTitle"),
+                    MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                if (answer != MessageBoxResult.Yes) return;
+            }
+        }
+        catch { /* drive may have been removed — proceed and let the copy fail gracefully */ }
+
+        StartBtn.Visibility           = Visibility.Collapsed;
+        CancelDownloadBtn.Visibility  = Visibility.Visible;
+        BackBtn.IsEnabled             = false;
+        NextBtn.IsEnabled             = false;
+
+        int total = TileDownloaderService.EstimateTileCount(_north, _south, _east, _west, 1, _maxZoom);
+        DownloadProgress.Maximum = Math.Max(total, 1);
+
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var sdRoot = _selectedDrive.Name.TrimEnd('\\', '/');
+
+        var progress = new Progress<TileProgress>(p =>
+        {
+            DownloadProgress.Value = p.Done;
+            ProgressTileText.Text  = string.Format(Loc("StrTDeckProgressTile"),
+                p.Done, p.Total, (double)p.Done / p.Total);
+            ProgressZoomText.Text  = string.Format(Loc("StrTDeckProgressZoom"),
+                p.Zoom, p.X, p.Y);
+        });
+
+        try
+        {
+            await TDeckTileService.TransferTilesAsync(
+                _mapSource, _north, _south, _east, _west, _maxZoom,
+                sdRoot, LocalTileDir, progress, _cts.Token);
+
+            var done = (int)DownloadProgress.Value;
+            DownloadResultText.Text = _cts.Token.IsCancellationRequested
+                ? Loc("StrTDeckCancelled")
+                : string.Format(Loc("StrTDeckDone"), done);
+            DownloadResultText.Foreground = _cts.Token.IsCancellationRequested
+                ? Brushes.Gray : Brushes.DarkGreen;
+        }
+        catch (OperationCanceledException)
+        {
+            DownloadResultText.Text = Loc("StrTDeckCancelled");
+            DownloadResultText.Foreground = Brushes.Gray;
+        }
+        catch (Exception ex)
+        {
+            DownloadResultText.Text = string.Format(Loc("StrTDeckError"), ex.Message);
+            DownloadResultText.Foreground = Brushes.Red;
+        }
+        finally
+        {
+            StartBtn.Visibility          = Visibility.Visible;
+            CancelDownloadBtn.Visibility = Visibility.Collapsed;
+            BackBtn.IsEnabled            = true;
+            // Show Close instead of Next on completion
+            NextBtn.Content   = Loc("StrTDeckClose");
+            NextBtn.IsEnabled = true;
+        }
+    }
+
+    private void CancelDownload_Click(object sender, RoutedEventArgs e) => _cts?.Cancel();
+
+    // ──────────────────────────────────────────────────────────
+    //  NAVIGATION
+    // ──────────────────────────────────────────────────────────
+    private void NextBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_currentStep == TotalSteps) { Close(); return; }
+
+        if (!ValidateCurrentStep()) return;
+
+        if (_currentStep == 3 && _formatOk)
+        {
+            GoToStep(4);
+        }
+        else
+        {
+            GoToStep(_currentStep + 1);
+        }
+    }
+
+    private void BackBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_currentStep > 1) GoToStep(_currentStep - 1);
+    }
+
+    private void CancelBtn_Click(object sender, RoutedEventArgs e) => Close();
+
+    private bool ValidateCurrentStep()
+    {
+        switch (_currentStep)
+        {
+            case 2:
+                if (_selectedDrive == null)
+                {
+                    MessageBox.Show(Loc("StrTDeckSelectDriveFirst"), Loc("StrTDeckTitle"),
+                        MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return false;
+                }
+                return true;
+
+            case 4:
+                if (!_regionSet)
+                {
+                    MessageBox.Show(Loc("StrTDeckNoRegion"), Loc("StrTDeckTitle"),
+                        MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return false;
+                }
+                return true;
+
+            default:
+                return true;
+        }
+    }
+
+    private void GoToStep(int step)
+    {
+        _currentStep = step;
+
+        // Show/hide pages
+        Page1.Visibility = step == 1 ? Visibility.Visible : Visibility.Collapsed;
+        Page2.Visibility = step == 2 ? Visibility.Visible : Visibility.Collapsed;
+        Page3.Visibility = step == 3 ? Visibility.Visible : Visibility.Collapsed;
+        Page4.Visibility = step == 4 ? Visibility.Visible : Visibility.Collapsed;
+        Page5.Visibility = step == 5 ? Visibility.Visible : Visibility.Collapsed;
+        Page6.Visibility = step == 6 ? Visibility.Visible : Visibility.Collapsed;
+
+        // Update header
+        StepTitleText.Text = step switch
+        {
+            1 => Loc("StrTDeckS1Title"),
+            2 => Loc("StrTDeckS2Title"),
+            3 => Loc("StrTDeckS3Title"),
+            4 => Loc("StrTDeckS4Title"),
+            5 => Loc("StrTDeckS5Title"),
+            6 => Loc("StrTDeckS6Title"),
+            _ => ""
+        };
+        StepIndicatorText.Text = string.Format(Loc("StrTDeckStep"), step, TotalSteps);
+        FooterStepText.Text    = StepIndicatorText.Text;
+
+        BackBtn.IsEnabled = step > 1;
+
+        if (step == TotalSteps)
+        {
+            NextBtn.Content   = Loc("StrTDeckClose");
+            NextBtn.IsEnabled = false; // enabled after download completes
+        }
+        else
+        {
+            NextBtn.Content   = Loc("StrTDeckNext");
+            NextBtn.IsEnabled = true;
+        }
+
+        // Page-specific setup
+        switch (step)
+        {
+            case 3:
+                UpdateFormatPage();
+                break;
+            case 4:
+                Region_Checked(this, new RoutedEventArgs());
+                break;
+            case 5:
+                UpdateEstimate();
+                break;
+            case 6:
+                UpdateSummaryPage();
+                break;
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────
+//  INLINE FORMAT CHOICE DIALOG
+// ──────────────────────────────────────────────────────────
+public class TDeckFormatChoiceDialog : Window
+{
+    private static string Loc(string key) =>
+        Application.Current?.Resources[key] as string ?? key;
+
+    public string ChosenFileSystem { get; private set; } = "exFAT";
+
+    public TDeckFormatChoiceDialog(DriveInfo drive)
+    {
+        Title  = Loc("StrTDeckFmtChoiceTitle");
+        Width  = 380;
+        SizeToContent = SizeToContent.Height;
+        ResizeMode = ResizeMode.NoResize;
+
+        var panel = new StackPanel { Margin = new Thickness(20) };
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = Loc("StrTDeckFmtChoiceHint"),
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 0, 0, 12)
+        });
+
+        bool preferFAT32 = drive.TotalSize <= 32L * 1024 * 1024 * 1024;
+
+        var rbExFAT = new RadioButton
+        {
+            Content   = Loc("StrTDeckFmtExFAT"),
+            IsChecked = true,        // always recommend exFAT for T-Deck
+            Margin    = new Thickness(0, 4, 0, 4)
+        };
+        var rbFAT32 = new RadioButton
+        {
+            Content = Loc("StrTDeckFmtFAT32"),
+            Margin  = new Thickness(0, 4, 0, 12)
+        };
+        panel.Children.Add(rbExFAT);
+        panel.Children.Add(rbFAT32);
+
+        var btnPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right
+        };
+
+        var okBtn = new Button
+        {
+            Content = "OK",
+            Width   = 80,
+            Padding = new Thickness(0, 6, 0, 6),
+            Margin  = new Thickness(0, 0, 8, 0),
+            IsDefault = true
+        };
+        var cancelBtn = new Button
+        {
+            Content   = Loc("StrTDeckCancel"),
+            Width     = 80,
+            Padding   = new Thickness(0, 6, 0, 6),
+            IsCancel  = true
+        };
+
+        okBtn.Click += (s, e) =>
+        {
+            ChosenFileSystem = rbExFAT.IsChecked == true ? "exFAT" : "FAT32";
+            DialogResult = true;
+        };
+        cancelBtn.Click += (s, e) => DialogResult = false;
+
+        btnPanel.Children.Add(okBtn);
+        btnPanel.Children.Add(cancelBtn);
+        panel.Children.Add(btnPanel);
+
+        Content = panel;
+    }
+}

--- a/MeshhessenClient/TelemetryDashboardWindow.xaml
+++ b/MeshhessenClient/TelemetryDashboardWindow.xaml
@@ -1,0 +1,186 @@
+<Window x:Class="MeshhessenClient.TelemetryDashboardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
+        ui:WindowHelper.UseModernWindowStyle="True"
+        Title="{DynamicResource StrDashboardTitle}"
+        Width="1280" Height="820"
+        MinWidth="860" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize">
+
+    <Window.Resources>
+        <Style x:Key="ToolbarBtn" TargetType="Button">
+            <Setter Property="Background"       Value="Transparent"/>
+            <Setter Property="BorderThickness"  Value="1"/>
+            <Setter Property="Padding"          Value="10,5"/>
+            <Setter Property="FontSize"         Value="12"/>
+            <Setter Property="Cursor"           Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="4"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="BorderBrush" Value="#58A6FF"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter Property="Background" Value="#1F6FEB"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="AccentBtn" TargetType="Button" BasedOn="{StaticResource ToolbarBtn}">
+            <Setter Property="Background"  Value="#1F6FEB"/>
+            <Setter Property="BorderBrush" Value="#388BFD"/>
+            <Setter Property="Foreground"  Value="#FFFFFF"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#388BFD"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="CardIconBtn" TargetType="Button">
+            <Setter Property="Background"       Value="Transparent"/>
+            <Setter Property="BorderThickness"  Value="0"/>
+            <Setter Property="Width"            Value="22"/>
+            <Setter Property="Height"           Value="22"/>
+            <Setter Property="Padding"          Value="0"/>
+            <Setter Property="FontSize"         Value="13"/>
+            <Setter Property="Cursor"           Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}"
+                                CornerRadius="4"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="#1F6FEB"/>
+                                <Setter Property="Foreground" Value="#FFFFFF"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="CardCloseBtn" TargetType="Button" BasedOn="{StaticResource CardIconBtn}">
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#DA3633"/>
+                    <Setter Property="Foreground" Value="#FFFFFF"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+
+    <DockPanel x:Name="RootPanel">
+
+        <!-- ── Toolbar ─────────────────────────────────────────────────────── -->
+        <Border x:Name="ToolbarBorder" DockPanel.Dock="Top"
+                BorderThickness="0,0,0,1"
+                Padding="12,7">
+            <DockPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" VerticalAlignment="Center">
+                    <Border Background="#1F6FEB" CornerRadius="4" Padding="8,3" Margin="0,0,12,0">
+                        <TextBlock Text="▦ MESH" Foreground="White"
+                                   FontWeight="Bold" FontSize="11" VerticalAlignment="Center"/>
+                    </Border>
+
+                    <TextBlock x:Name="DashboardLabelText"
+                               Text="{DynamicResource StrDashboardLabel}"
+                               VerticalAlignment="Center"
+                               FontSize="12" Margin="0,0,6,0"/>
+                    <ComboBox x:Name="DashboardCombo" Width="180"
+                              SelectionChanged="DashboardCombo_SelectionChanged"
+                              Margin="0,0,6,0"/>
+                    <Button Content="{DynamicResource StrDashboardNew}"
+                            Style="{StaticResource ToolbarBtn}" Margin="0,0,4,0"
+                            Click="NewDashboard_Click"/>
+                    <Button Content="{DynamicResource StrDashboardRename}"
+                            Style="{StaticResource ToolbarBtn}" Margin="0,0,4,0"
+                            Click="RenameDashboard_Click"/>
+                    <Button Content="{DynamicResource StrDashboardDelete}"
+                            Style="{StaticResource ToolbarBtn}"
+                            Click="DeleteDashboard_Click"/>
+
+                    <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}"
+                               Margin="10,0" Opacity="0.3"/>
+
+                    <Button Content="{DynamicResource StrDashboardAddWidget}"
+                            Style="{StaticResource AccentBtn}" Margin="0,0,6,0"
+                            Click="AddWidget_Click"/>
+                    <Button Content="{DynamicResource StrDashboardRefresh}"
+                            Style="{StaticResource ToolbarBtn}"
+                            Click="Refresh_Click"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right"
+                            HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <TextBlock x:Name="AutoRefreshLabel"
+                               Text="{DynamicResource StrDashboardAutoRefresh}"
+                               VerticalAlignment="Center"
+                               FontSize="12" Margin="0,0,6,0"/>
+                    <ComboBox x:Name="AutoRefreshCombo" Width="100"
+                              SelectionChanged="AutoRefreshCombo_SelectionChanged"/>
+                    <Ellipse x:Name="RefreshDot" Width="8" Height="8"
+                             Fill="#238636" Margin="8,0,0,0"
+                             VerticalAlignment="Center" Opacity="0"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <!-- ── Status bar ──────────────────────────────────────────────────── -->
+        <Border x:Name="StatusBorder" DockPanel.Dock="Bottom"
+                BorderThickness="0,1,0,0"
+                Padding="12,4">
+            <DockPanel>
+                <TextBlock x:Name="StatusText"
+                           FontSize="11" VerticalAlignment="Center"/>
+                <TextBlock x:Name="LastRefreshText"
+                           FontSize="11" VerticalAlignment="Center"
+                           HorizontalAlignment="Right" DockPanel.Dock="Right"/>
+            </DockPanel>
+        </Border>
+
+        <!-- ── Widget canvas ───────────────────────────────────────────────── -->
+        <ScrollViewer x:Name="CanvasScroller"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      Padding="4,4,4,4">
+            <Grid>
+                <Border x:Name="EmptyState" Visibility="Collapsed"
+                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                        Margin="0,60,0,0">
+                    <StackPanel HorizontalAlignment="Center">
+                        <TextBlock x:Name="EmptyStateIcon"
+                                   Text="▦" FontSize="64"
+                                   HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="EmptyStateText"
+                                   Text="{DynamicResource StrDashboardEmpty}"
+                                   FontSize="14"
+                                   HorizontalAlignment="Center" Margin="0,12,0,0"
+                                   TextWrapping="Wrap" MaxWidth="400"
+                                   TextAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+                <WrapPanel x:Name="WidgetPanel" Margin="4" Orientation="Horizontal"/>
+            </Grid>
+        </ScrollViewer>
+
+    </DockPanel>
+</Window>

--- a/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
@@ -65,6 +65,7 @@ public partial class TelemetryDashboardWindow : Window
     // ── Fields ────────────────────────────────────────────────────────────────
     private readonly TelemetryDatabaseService _db;
     private readonly Dictionary<uint, string> _nodeNames;
+    private readonly Dictionary<uint, string> _nodeShortNames;
     private DashboardStore _store = new();
     private Dashboard? _current;
     private bool _suppressComboEvent;
@@ -76,11 +77,21 @@ public partial class TelemetryDashboardWindow : Window
 
     public TelemetryDashboardWindow(
         TelemetryDatabaseService db,
-        Dictionary<uint, string> nodeNames)
+        Dictionary<uint, string> nodeNames,
+        Dictionary<uint, string>? nodeShortNames = null)
     {
         InitializeComponent();
-        _db        = db;
-        _nodeNames = nodeNames;
+        _db             = db;
+        _nodeShortNames = nodeShortNames ?? new Dictionary<uint, string>();
+
+        // Merge live node names with any nodes known from the DB (for offline use)
+        var merged = new Dictionary<uint, string>(nodeNames);
+        foreach (var id in db.GetKnownNodeIds())
+            if (!merged.ContainsKey(id))
+                merged[id] = $"!{id:x8}";
+        _nodeNames = merged;
+
+        Closing += (_, _) => SaveStore();
 
         // Detect theme
         _isDark = ThemeManager.Current.ActualApplicationTheme == ApplicationTheme.Dark;
@@ -321,7 +332,7 @@ public partial class TelemetryDashboardWindow : Window
                 MessageBoxButton.OK, MessageBoxImage.Information);
             return;
         }
-        var dlg = new AddWidgetDialog(_nodeNames) { Owner = this };
+        var dlg = new AddWidgetDialog(_nodeNames, _nodeShortNames) { Owner = this };
         if (dlg.ShowDialog() != true) return;
         var widget = dlg.Result!;
         var idx = _store.Dashboards.IndexOf(_current);
@@ -1160,7 +1171,8 @@ public partial class TelemetryDashboardWindow : Window
             {
                 Title           = NodeLabel(nodeId),
                 Color           = oxy,
-                Fill            = OxyColor.FromAColor(30, oxy),
+                Fill            = OxyColor.FromAColor(55, oxy),
+                ConstantY2      = min,
                 StrokeThickness = 1.5,
                 MarkerType      = MarkerType.None,
                 TrackerFormatString = "{0}\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
@@ -1561,7 +1573,7 @@ public partial class TelemetryDashboardWindow : Window
         if (sender is not Button btn || btn.Tag is not DashboardWidget w) return;
         if (_current == null) return;
 
-        var dlg = new AddWidgetDialog(_nodeNames, existing: w) { Owner = this };
+        var dlg = new AddWidgetDialog(_nodeNames, _nodeShortNames, existing: w) { Owner = this };
         if (dlg.ShowDialog() != true) return;
 
         // Preserve ID and size from the original
@@ -1743,7 +1755,7 @@ public partial class TelemetryDashboardWindow : Window
             Tag     = w.Id,
             VerticalAlignment = System.Windows.VerticalAlignment.Center,
             Margin  = new Thickness(3, 0, 0, 0),
-            ToolTip = Loc("StrDashboardThreshold"),
+            ToolTip = Loc("StrDashboardThresholdTip"),
         };
         threshBox.LostFocus += (_, _) =>
         {
@@ -2027,118 +2039,175 @@ public partial class TelemetryDashboardWindow : Window
 
     private FrameworkElement BuildMeshHealthContent(DashboardWidget w)
     {
-        var nodeIds     = w.NodeIds.Count > 0 ? w.NodeIds : _nodeNames.Keys.ToList();
-        int lookbackDays = w.Days > 0 ? w.Days : 1;
+        var nodeIds  = w.NodeIds.Count > 0 ? w.NodeIds : _nodeNames.Keys.ToList();
+        int days     = w.Days > 0 ? w.Days : 7;
+        int shortH   = 6;
 
-        var wrap = new WrapPanel { Margin = new Thickness(6), Orientation = Orientation.Horizontal };
+        var stack = new StackPanel { Margin = new Thickness(6) };
 
+        // ── Global mesh health score ──────────────────────────────────────────
+        var global = _db.GetMeshHealthScore(days);
+        var globalTile = new Border
+        {
+            Background      = new SolidColorBrush(_isDark ? Color.FromRgb(21, 26, 35) : Color.FromRgb(245, 247, 250)),
+            BorderBrush     = new SolidColorBrush(_borderCol),
+            BorderThickness = new Thickness(1),
+            CornerRadius    = new CornerRadius(5),
+            Margin          = new Thickness(0, 0, 0, 6),
+            Padding         = new Thickness(10, 7, 10, 7),
+            ToolTip         = global.Summary,
+        };
+        var gRow = new StackPanel { Orientation = Orientation.Horizontal };
+        gRow.Children.Add(MeshLed(global.State, 12));
+        gRow.Children.Add(new TextBlock
+        {
+            Text       = $" {Loc("StrMeshHealthScore")}: {global.Score:0}%",
+            FontSize   = 12,
+            FontWeight = System.Windows.FontWeights.SemiBold,
+            Foreground = new SolidColorBrush(_fgMain),
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+        });
+        var gDetails = new TextBlock
+        {
+            Text       = $"   Ø Pfad: {global.AvgPathCost:F2}  |  Routen: {global.RouteChangeRate:F1}/h  |  Empfang: {global.RxScore * 100:0}%  |  Kanal: {global.ChannelUtilization:F1}%",
+            FontSize   = 10,
+            Foreground = new SolidColorBrush(_fgSub),
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+        };
+        gRow.Children.Add(gDetails);
+        globalTile.Child = gRow;
+        stack.Children.Add(globalTile);
+
+        // ── Per-node tiles ────────────────────────────────────────────────────
         foreach (var id in nodeIds)
         {
-            var pts = _db.GetTimeSeries(new[] { id }, "snr", lookbackDays);
-            double lastSnr = pts.Count > 0
-                ? pts.OrderByDescending(p => p.Timestamp).First().Value
-                : double.NaN;
-            bool stale = pts.Count == 0 ||
-                         (DateTime.UtcNow - pts.Max(p => p.Timestamp)).TotalHours > 24;
+            var analysis = _db.GetSignalAnalysis(id, shortH, days, _nodeNames);
+            string name  = NodeLabel(id);
 
-            Color ledColor;
-            string status;
-            if (stale || double.IsNaN(lastSnr))
-            {
-                ledColor = Color.FromRgb(240,  76,  76);
-                status   = Loc("StrMeshHealthOffline");
-            }
-            else if (lastSnr >= -5)
-            {
-                ledColor = Color.FromRgb( 63, 185, 126);
-                status   = Loc("StrMeshHealthGood");
-            }
-            else if (lastSnr >= -15)
-            {
-                ledColor = Color.FromRgb(255, 171,  76);
-                status   = Loc("StrMeshHealthWeak");
-            }
-            else
-            {
-                ledColor = Color.FromRgb(240,  76,  76);
-                status   = Loc("StrMeshHealthPoor");
-            }
+            var overallState = new[] { analysis.WeatherLed, analysis.AntennaLed, analysis.NeighborLed, analysis.PathLed }
+                .Where(l => l != LedState.NoData)
+                .DefaultIfEmpty(LedState.NoData)
+                .Max();
 
-            string name = NodeLabel(id);
-
+            Color accent = LedColor(overallState);
             var tile = new Border
             {
-                Background      = new SolidColorBrush(Color.FromArgb(12, ledColor.R, ledColor.G, ledColor.B)),
-                BorderBrush     = new SolidColorBrush(Color.FromArgb(40, ledColor.R, ledColor.G, ledColor.B)),
+                Background      = new SolidColorBrush(Color.FromArgb(10, accent.R, accent.G, accent.B)),
+                BorderBrush     = new SolidColorBrush(Color.FromArgb(35, accent.R, accent.G, accent.B)),
                 BorderThickness = new Thickness(1),
                 CornerRadius    = new CornerRadius(5),
-                Margin          = new Thickness(3),
+                Margin          = new Thickness(0, 0, 0, 4),
                 Padding         = new Thickness(8, 6, 8, 6),
-                MinWidth        = 110,
-                ToolTip         = $"{name}  SNR: {(double.IsNaN(lastSnr) ? "–" : $"{lastSnr:F1} dB")}  {status}",
             };
 
-            var row = new StackPanel
-            {
-                Orientation       = Orientation.Horizontal,
-                VerticalAlignment = System.Windows.VerticalAlignment.Center,
-            };
+            var tileStack = new StackPanel();
 
-            var led = new System.Windows.Shapes.Ellipse
+            // Name row
+            var nameRow = new DockPanel { Margin = new Thickness(0, 0, 0, 4) };
+            nameRow.Children.Add(MeshLed(overallState, 10));
+            nameRow.Children.Add(new TextBlock
             {
-                Width  = 10,
-                Height = 10,
-                Fill   = new SolidColorBrush(ledColor),
-                Effect = new DropShadowEffect
+                Text       = " " + name,
+                FontSize   = 11,
+                FontWeight = System.Windows.FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(_fgMain),
+            });
+            tileStack.Children.Add(nameRow);
+
+            // LED bubbles row
+            var ledRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 4) };
+            ledRow.Children.Add(MeshLedCell(analysis.WeatherLed,  Loc("StrMeshHealthWeather")));
+            ledRow.Children.Add(MeshLedCell(analysis.AntennaLed,  Loc("StrMeshHealthAntenna")));
+            ledRow.Children.Add(MeshLedCell(analysis.NeighborLed, Loc("StrMeshHealthNeighbor")));
+            ledRow.Children.Add(MeshLedCell(analysis.PathLed,     Loc("StrMeshHealthPath")));
+            tileStack.Children.Add(ledRow);
+
+            // Factor row: trend + neighbor count + hop cost
+            var factors = new List<string>();
+            if (analysis.Trends.Count > 0)
+            {
+                string arrow = analysis.AvgLongSlope < -0.1f ? "▼" : analysis.AvgLongSlope > 0.1f ? "▲" : "→";
+                factors.Add($"SNR {arrow} {analysis.AvgLongSlope:+0.0;-0.0} dB/d");
+            }
+            if (analysis.TotalNeighbors > 0)
+                factors.Add($"{analysis.TotalNeighbors} {Loc("StrMeshHealthNeighborCount")}");
+            if (analysis.HopCost > 0)
+                factors.Add($"{Loc("StrMeshHealthHopCost")}: {analysis.HopCost:F2}");
+            if (!string.IsNullOrEmpty(analysis.ProblemNeighborName))
+                factors.Add($"⚠ {analysis.ProblemNeighborName}");
+
+            if (factors.Count > 0)
+                tileStack.Children.Add(new TextBlock
                 {
-                    Color       = ledColor,
-                    BlurRadius  = 6,
-                    ShadowDepth = 0,
-                    Opacity     = 0.7,
-                },
-                Margin            = new Thickness(0, 0, 7, 0),
-                VerticalAlignment = System.Windows.VerticalAlignment.Center,
-            };
-            row.Children.Add(led);
+                    Text       = string.Join("   ", factors),
+                    FontSize   = 9,
+                    Foreground = new SolidColorBrush(_fgMuted),
+                });
 
-            var info = new StackPanel { VerticalAlignment = System.Windows.VerticalAlignment.Center };
-            info.Children.Add(new TextBlock
-            {
-                Text         = name.Length > 14 ? name[..14] : name,
-                FontSize     = 11,
-                Foreground   = new SolidColorBrush(_fgMain),
-                TextTrimming = TextTrimming.CharacterEllipsis,
-            });
-            info.Children.Add(new TextBlock
-            {
-                Text       = double.IsNaN(lastSnr) ? "–" : $"{lastSnr:F1} dB",
-                FontSize   = 9,
-                Foreground = new SolidColorBrush(_fgMuted),
-            });
-            row.Children.Add(info);
-
-            tile.Child = row;
-            wrap.Children.Add(tile);
+            tile.Child = tileStack;
+            stack.Children.Add(tile);
         }
 
-        if (wrap.Children.Count == 0)
-            wrap.Children.Add(new TextBlock
+        if (nodeIds.Count == 0)
+            stack.Children.Add(new TextBlock
             {
                 Text       = Loc("StrDashboardNoData"),
                 Foreground = new SolidColorBrush(_fgMuted),
                 FontSize   = 11,
-                Margin     = new Thickness(4),
             });
 
         return new Border
         {
             Child = new ScrollViewer
             {
-                Content = wrap,
+                Content = stack,
                 VerticalScrollBarVisibility   = ScrollBarVisibility.Auto,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
             },
         };
+    }
+
+    private static Color LedColor(LedState state) => state switch
+    {
+        LedState.Good    => Color.FromRgb(76, 175, 80),
+        LedState.Warning => Color.FromRgb(255, 193, 7),
+        LedState.Alert   => Color.FromRgb(244, 67, 54),
+        _                => Color.FromRgb(189, 189, 189),
+    };
+
+    private static System.Windows.UIElement MeshLed(LedState state, int size)
+    {
+        var c = LedColor(state);
+        return new System.Windows.Shapes.Ellipse
+        {
+            Width  = size, Height = size,
+            Fill   = new SolidColorBrush(c),
+            Effect = new DropShadowEffect { Color = c, BlurRadius = 5, ShadowDepth = 0, Opacity = 0.65 },
+            Margin = new Thickness(0, 0, 5, 0),
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+        };
+    }
+
+    private FrameworkElement MeshLedCell(LedState state, string label)
+    {
+        var cell = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            Margin = new Thickness(0, 0, 10, 0),
+        };
+        var led = (System.Windows.Shapes.Ellipse)MeshLed(state, 10);
+        led.Margin = new Thickness(0);
+        led.HorizontalAlignment = System.Windows.HorizontalAlignment.Center;
+        cell.Children.Add(led);
+        cell.Children.Add(new TextBlock
+        {
+            Text       = label,
+            FontSize   = 8,
+            Foreground = new SolidColorBrush(_fgMuted),
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+        });
+        return cell;
     }
 
     // ── CSV Export ────────────────────────────────────────────────────────────

--- a/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
@@ -10,6 +11,7 @@ using MeshhessenClient.Models;
 using MeshhessenClient.Services;
 using ModernWpf;
 using OxyPlot;
+using OxyPlot.Annotations;
 using OxyPlot.Axes;
 using OxyPlot.Legends;
 using OxyPlot.Series;
@@ -188,10 +190,6 @@ public partial class TelemetryDashboardWindow : Window
             DateTime.Now.ToString("HH:mm:ss"));
     }
 
-    /// <summary>
-    /// Re-render each card's CONTENT in place without rebuilding the container.
-    /// Preserves current size (even if the user is in mid-resize) and drag state.
-    /// </summary>
     private void RefreshAllCardsInPlace()
     {
         if (_current == null) return;
@@ -200,12 +198,14 @@ public partial class TelemetryDashboardWindow : Window
             if (container.Tag is not DashboardWidget w) continue;
             if (container.Children.OfType<Border>().FirstOrDefault(b => b.Tag as string == "card") is not Border card) continue;
             if (card.Child is not DockPanel dock) continue;
-
-            // Content is the second child (after header)
-            if (dock.Children.Count < 2) continue;
+            var oldContent = dock.Children.OfType<UIElement>()
+                .FirstOrDefault(c => (c as FrameworkElement)?.Tag as string == "widgetcontent");
+            if (oldContent == null) continue;
+            int idx = dock.Children.IndexOf(oldContent);
+            dock.Children.Remove(oldContent);
             var newContent = BuildWidgetContent(w);
-            dock.Children.RemoveAt(1);
-            dock.Children.Add(newContent);
+            if (newContent is FrameworkElement fe) fe.Tag = "widgetcontent";
+            dock.Children.Insert(idx, newContent);
         }
     }
 
@@ -351,9 +351,40 @@ public partial class TelemetryDashboardWindow : Window
         EmptyState.Visibility = Visibility.Collapsed;
         foreach (var w in _current.Widgets)
             WidgetPanel.Children.Add(BuildCard(w));
+
+        // Allow dropping onto empty panel space → move to end
+        WidgetPanel.AllowDrop = true;
+        WidgetPanel.Drop -= WidgetPanel_Drop;
+        WidgetPanel.Drop += WidgetPanel_Drop;
+        WidgetPanel.DragOver -= WidgetPanel_DragOver;
+        WidgetPanel.DragOver += WidgetPanel_DragOver;
+
         UpdateStatus();
         LastRefreshText.Text = string.Format(Loc("StrDashboardLastRefreshed"),
             DateTime.Now.ToString("HH:mm:ss"));
+    }
+
+    private void WidgetPanel_DragOver(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent("widget_id")) { e.Effects = DragDropEffects.Move; e.Handled = true; }
+    }
+
+    private void WidgetPanel_Drop(object sender, DragEventArgs e)
+    {
+        if (!e.Data.GetDataPresent("widget_id") || _current == null) return;
+        string srcId = (string)e.Data.GetData("widget_id")!;
+        // Move dragged widget to the end if it was dropped on panel background
+        var srcIdx = _current.Widgets.FindIndex(x => x.Id == srcId);
+        if (srcIdx < 0 || srcIdx == _current.Widgets.Count - 1) return;
+        var newWidgets = new List<DashboardWidget>(_current.Widgets);
+        var item = newWidgets[srcIdx];
+        newWidgets.RemoveAt(srcIdx);
+        newWidgets.Add(item);
+        var dashIdx = _store.Dashboards.IndexOf(_current);
+        _current = _current with { Widgets = newWidgets };
+        _store.Dashboards[dashIdx] = _current;
+        SaveStore();
+        RenderCurrentDashboard();
     }
 
     private void UpdateStatus()
@@ -445,11 +476,22 @@ public partial class TelemetryDashboardWindow : Window
             Padding    = new Thickness(2, 0, 2, 0),
         };
         DockPanel.SetDock(dragHandle, Dock.Left);
+        // Track start point; only initiate DoDragDrop after minimum system drag distance
+        var dragStartPoint = new System.Windows.Point(-1, -1);
+        dragHandle.PreviewMouseLeftButtonDown += (_, e) =>
+            dragStartPoint = e.GetPosition(dragHandle);
+        dragHandle.PreviewMouseLeftButtonUp += (_, _) =>
+            dragStartPoint = new System.Windows.Point(-1, -1);
         dragHandle.MouseMove += (_, e) =>
         {
-            if (e.LeftButton == System.Windows.Input.MouseButtonState.Pressed)
-                DragDrop.DoDragDrop(container,
-                    new DataObject("widget_id", w.Id), DragDropEffects.Move);
+            if (e.LeftButton != System.Windows.Input.MouseButtonState.Pressed) return;
+            if (dragStartPoint.X < 0) return;
+            var pos  = e.GetPosition(dragHandle);
+            bool far = Math.Abs(pos.X - dragStartPoint.X) > SystemParameters.MinimumHorizontalDragDistance
+                    || Math.Abs(pos.Y - dragStartPoint.Y) > SystemParameters.MinimumVerticalDragDistance;
+            if (!far) return;
+            dragStartPoint = new System.Windows.Point(-1, -1);
+            DragDrop.DoDragDrop(dragHandle, new DataObject("widget_id", w.Id), DragDropEffects.Move);
         };
         header.Children.Add(dragHandle);
 
@@ -491,23 +533,52 @@ public partial class TelemetryDashboardWindow : Window
         headerBorder.Child = header;
         dock.Children.Add(headerBorder);
 
-        // Content
-        dock.Children.Add(BuildWidgetContent(w));
+        // Time-range presets bar — only for OxyPlot chart types
+        bool isChartType = w.Type is "line" or "area" or "bar" or "scatter"
+                                    or "heatmap" or "histogram" or "candlestick" or "stateline";
+        if (isChartType)
+        {
+            var presetsBar = BuildTimePresetsBar(w);
+            DockPanel.SetDock(presetsBar, Dock.Top);
+            dock.Children.Add(presetsBar);
+        }
+
+        // Content — tagged so RefreshAllCardsInPlace can find it
+        var widgetContent = BuildWidgetContent(w);
+        if (widgetContent is FrameworkElement wfe) wfe.Tag = "widgetcontent";
+        dock.Children.Add(widgetContent);
         card.Child = dock;
         container.Children.Add(card);
 
-        // Drop target for reordering
+        // Context menu: CSV export
+        var ctxMenu = new ContextMenu();
+        var exportItem = new MenuItem
+        {
+            Header = Loc("StrDashboardExportCsv"),
+            Tag    = w,
+        };
+        exportItem.Click += (_, _) => ExportWidgetCsv(w);
+        ctxMenu.Items.Add(exportItem);
+        container.ContextMenu = ctxMenu;
+
+        // Drop target for reordering — with visual highlight feedback
         container.AllowDrop = true;
         container.DragEnter += (_, e) =>
         {
-            if (e.Data.GetDataPresent("widget_id")) e.Effects = DragDropEffects.Move;
+            if (!e.Data.GetDataPresent("widget_id")) return;
+            string srcId = (string)e.Data.GetData("widget_id")!;
+            if (srcId != w.Id) card.BorderBrush = new SolidColorBrush(Color.FromRgb(31, 111, 235));
+            e.Effects = DragDropEffects.Move;
         };
+        container.DragLeave += (_, _) =>
+            card.BorderBrush = new SolidColorBrush(_borderCol);
         container.DragOver += (_, e) =>
         {
             if (e.Data.GetDataPresent("widget_id")) { e.Effects = DragDropEffects.Move; e.Handled = true; }
         };
         container.Drop += (_, e) =>
         {
+            card.BorderBrush = new SolidColorBrush(_borderCol);
             if (!e.Data.GetDataPresent("widget_id")) return;
             string srcId = (string)e.Data.GetData("widget_id")!;
             if (srcId != w.Id) ReorderWidgets(srcId, w.Id);
@@ -560,6 +631,9 @@ public partial class TelemetryDashboardWindow : Window
                 "histogram"   => BuildPlotContent(BuildHistogramModel(w)),
                 "candlestick" => BuildPlotContent(BuildCandlestickModel(w)),
                 "stateline"   => BuildPlotContent(BuildStatelineModel(w)),
+                "ranking"     => BuildRankingContent(w),
+                "multistat"   => BuildMultiStatContent(w),
+                "meshhealth"  => BuildMeshHealthContent(w),
                 _             => BuildPlotContent(BuildLineModel(w)),
             };
         }
@@ -588,6 +662,9 @@ public partial class TelemetryDashboardWindow : Window
         "histogram"   => Color.FromRgb( 63, 185, 126),
         "candlestick" => Color.FromRgb(240,  76,  76),
         "stateline"   => Color.FromRgb(  0, 205, 218),
+        "ranking"     => Color.FromRgb( 63, 185, 126),
+        "multistat"   => Color.FromRgb(  0, 205, 218),
+        "meshhealth"  => Color.FromRgb(255, 171,  76),
         _             => Color.FromRgb(139, 148, 158),
     };
 
@@ -604,6 +681,9 @@ public partial class TelemetryDashboardWindow : Window
         "histogram"   => "▦",
         "candlestick" => "🕯",
         "stateline"   => "▬",
+        "ranking"     => "⊞",
+        "multistat"   => "⊟",
+        "meshhealth"  => "⬤",
         _             => "▪",
     };
 
@@ -1026,19 +1106,38 @@ public partial class TelemetryDashboardWindow : Window
         {
             var pts = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days);
             if (pts.Count == 0) continue;
+            var oxy  = Palette[ci % Palette.Length];
             var line = new LineSeries
             {
                 Title               = NodeLabel(nodeId),
-                Color               = Palette[ci % Palette.Length],
+                Color               = oxy,
                 StrokeThickness     = 1.8,
                 MarkerType          = MarkerType.None,
                 TrackerFormatString = "{0}\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
             };
-            foreach (var p in pts.OrderBy(x => x.Timestamp))
-                line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(p.Timestamp), p.Value));
+            var sorted = pts.OrderBy(x => x.Timestamp)
+                            .Select(p => new DataPoint(DateTimeAxis.ToDouble(p.Timestamp), p.Value))
+                            .ToList();
+            foreach (var dp in sorted) line.Points.Add(dp);
             model.Series.Add(line);
+
+            if (w.ShowMovingAverage && sorted.Count > 5)
+            {
+                var maLine = new LineSeries
+                {
+                    Title           = $"MA({NodeLabel(nodeId)})",
+                    Color           = OxyColor.FromAColor(180, oxy),
+                    StrokeThickness = 1.5,
+                    LineStyle       = LineStyle.Dash,
+                    MarkerType      = MarkerType.None,
+                    TrackerFormatString = "{0} MA\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
+                };
+                foreach (var dp in MovingAverage(sorted)) maLine.Points.Add(dp);
+                model.Series.Add(maLine);
+            }
             ci++;
         }
+        AddThresholdAnnotation(model, w);
         return model;
     }
 
@@ -1066,12 +1165,58 @@ public partial class TelemetryDashboardWindow : Window
                 MarkerType      = MarkerType.None,
                 TrackerFormatString = "{0}\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
             };
-            foreach (var p in pts.OrderBy(x => x.Timestamp))
-                series.Points.Add(new DataPoint(DateTimeAxis.ToDouble(p.Timestamp), p.Value));
+            var sorted = pts.OrderBy(x => x.Timestamp)
+                            .Select(p => new DataPoint(DateTimeAxis.ToDouble(p.Timestamp), p.Value))
+                            .ToList();
+            foreach (var dp in sorted) series.Points.Add(dp);
             model.Series.Add(series);
+
+            if (w.ShowMovingAverage && sorted.Count > 5)
+            {
+                var maLine = new LineSeries
+                {
+                    Title           = $"MA({NodeLabel(nodeId)})",
+                    Color           = OxyColor.FromAColor(200, oxy),
+                    StrokeThickness = 1.5,
+                    LineStyle       = LineStyle.Dash,
+                    MarkerType      = MarkerType.None,
+                    TrackerFormatString = "{0} MA\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
+                };
+                foreach (var dp in MovingAverage(sorted)) maLine.Points.Add(dp);
+                model.Series.Add(maLine);
+            }
             ci++;
         }
+        AddThresholdAnnotation(model, w);
         return model;
+    }
+
+    private static void AddThresholdAnnotation(PlotModel model, DashboardWidget w)
+    {
+        if (double.IsNaN(w.Threshold)) return;
+        model.Annotations.Add(new LineAnnotation
+        {
+            Type            = LineAnnotationType.Horizontal,
+            Y               = w.Threshold,
+            Color           = OxyColor.FromArgb(200, 240, 76, 76),
+            StrokeThickness = 1.5,
+            LineStyle       = LineStyle.Dash,
+            Text            = $"⊥ {w.Threshold:G4}",
+            TextColor       = OxyColor.FromArgb(200, 240, 76, 76),
+            FontSize        = 9,
+        });
+    }
+
+    private static IEnumerable<DataPoint> MovingAverage(IList<DataPoint> points, int window = 12)
+    {
+        for (int i = 0; i < points.Count; i++)
+        {
+            int start = Math.Max(0, i - window + 1);
+            double sum = 0;
+            int cnt = 0;
+            for (int j = start; j <= i; j++) { sum += points[j].Y; cnt++; }
+            yield return new DataPoint(points[i].X, sum / cnt);
+        }
     }
 
     // ── Bar chart ─────────────────────────────────────────────────────────────
@@ -1519,6 +1664,523 @@ public partial class TelemetryDashboardWindow : Window
         return dlg.ShowDialog() == true && !string.IsNullOrWhiteSpace(box.Text)
             ? box.Text.Trim()
             : null;
+    }
+
+    // ── Time-presets bar ──────────────────────────────────────────────────────
+
+    private FrameworkElement BuildTimePresetsBar(DashboardWidget w)
+    {
+        var panel = new WrapPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin      = new Thickness(8, 3, 8, 3),
+        };
+
+        var presets = new (int days, string label)[]
+        {
+            (1, "1d"), (7, "7d"), (14, "14d"), (30, "30d"), (0, Loc("StrDaysAll")),
+        };
+        foreach (var (days, label) in presets)
+        {
+            bool active = w.Days == days;
+            var btn = new Button
+            {
+                Content    = label,
+                Margin     = new Thickness(0, 0, 3, 0),
+                Padding    = new Thickness(5, 1, 5, 1),
+                FontSize   = 10,
+                Tag        = (w.Id, days),
+                Foreground = new SolidColorBrush(active ? WpfPalette[0] : _fgSub),
+                FontWeight = active ? System.Windows.FontWeights.SemiBold
+                                    : System.Windows.FontWeights.Normal,
+            };
+            btn.Click += (_, _) =>
+            {
+                var (wid, d) = ((string, int))btn.Tag!;
+                UpdateWidgetDays(wid, d);
+            };
+            panel.Children.Add(btn);
+        }
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = " | ",
+            Foreground = new SolidColorBrush(_fgMuted),
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            FontSize = 10,
+        });
+
+        var maBtn = new Button
+        {
+            Content    = "⌀ MA",
+            Margin     = new Thickness(0, 0, 3, 0),
+            Padding    = new Thickness(5, 1, 5, 1),
+            FontSize   = 10,
+            ToolTip    = Loc("StrDashboardMovingAvg"),
+            Tag        = w.Id,
+            Foreground = new SolidColorBrush(w.ShowMovingAverage ? WpfPalette[0] : _fgSub),
+            FontWeight = w.ShowMovingAverage ? System.Windows.FontWeights.SemiBold
+                                             : System.Windows.FontWeights.Normal,
+        };
+        maBtn.Click += (_, _) => ToggleMovingAverage((string)maBtn.Tag!);
+        panel.Children.Add(maBtn);
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = " " + Loc("StrDashboardThreshold") + ":",
+            Foreground = new SolidColorBrush(_fgSub),
+            FontSize = 10,
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+        });
+
+        var threshBox = new TextBox
+        {
+            Width   = 52,
+            Height  = 20,
+            FontSize = 10,
+            Padding = new Thickness(3, 0, 3, 0),
+            Text    = double.IsNaN(w.Threshold) ? "" : w.Threshold.ToString("G4"),
+            Tag     = w.Id,
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            Margin  = new Thickness(3, 0, 0, 0),
+            ToolTip = Loc("StrDashboardThreshold"),
+        };
+        threshBox.LostFocus += (_, _) =>
+        {
+            string id  = (string)threshBox.Tag!;
+            double val = double.TryParse(threshBox.Text.Replace(",", "."),
+                System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out double v)
+                ? v : double.NaN;
+            UpdateWidgetThreshold(id, val);
+        };
+        panel.Children.Add(threshBox);
+
+        return new Border
+        {
+            Background      = new SolidColorBrush(_bgHeader),
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            BorderBrush     = new SolidColorBrush(_borderCol),
+            Child           = panel,
+            Tag             = "presetsbar",
+        };
+    }
+
+    private void UpdateWidgetDays(string widgetId, int newDays)
+    {
+        if (_current == null) return;
+        int dashIdx = _store.Dashboards.IndexOf(_current);
+        if (dashIdx < 0) return;
+        int wIdx = _current.Widgets.FindIndex(x => x.Id == widgetId);
+        if (wIdx < 0) return;
+        var updated = _current.Widgets[wIdx] with { Days = newDays };
+        CommitWidgetUpdate(dashIdx, wIdx, updated);
+        RefreshCardById(widgetId, updated);
+    }
+
+    private void ToggleMovingAverage(string widgetId)
+    {
+        if (_current == null) return;
+        int dashIdx = _store.Dashboards.IndexOf(_current);
+        if (dashIdx < 0) return;
+        int wIdx = _current.Widgets.FindIndex(x => x.Id == widgetId);
+        if (wIdx < 0) return;
+        var old     = _current.Widgets[wIdx];
+        var updated = old with { ShowMovingAverage = !old.ShowMovingAverage };
+        CommitWidgetUpdate(dashIdx, wIdx, updated);
+        RefreshCardById(widgetId, updated);
+    }
+
+    private void UpdateWidgetThreshold(string widgetId, double threshold)
+    {
+        if (_current == null) return;
+        int dashIdx = _store.Dashboards.IndexOf(_current);
+        if (dashIdx < 0) return;
+        int wIdx = _current.Widgets.FindIndex(x => x.Id == widgetId);
+        if (wIdx < 0) return;
+        var old = _current.Widgets[wIdx];
+        bool sameNaN = double.IsNaN(old.Threshold) && double.IsNaN(threshold);
+        if (sameNaN) return;
+        if (!double.IsNaN(old.Threshold) && !double.IsNaN(threshold) &&
+            Math.Abs(old.Threshold - threshold) < 1e-9) return;
+        var updated = old with { Threshold = threshold };
+        CommitWidgetUpdate(dashIdx, wIdx, updated);
+        RefreshCardById(widgetId, updated);
+    }
+
+    private void CommitWidgetUpdate(int dashIdx, int widgetIdx, DashboardWidget updated)
+    {
+        var newWidgets = new List<DashboardWidget>(_current!.Widgets);
+        newWidgets[widgetIdx] = updated;
+        _current = _current with { Widgets = newWidgets };
+        _store.Dashboards[dashIdx] = _current;
+        foreach (Grid g in WidgetPanel.Children.OfType<Grid>())
+            if (g.Tag is DashboardWidget tw && tw.Id == updated.Id) { g.Tag = updated; break; }
+        SaveStore();
+    }
+
+    private void RefreshCardById(string widgetId, DashboardWidget? withWidget = null)
+    {
+        for (int i = 0; i < WidgetPanel.Children.Count; i++)
+        {
+            if (WidgetPanel.Children[i] is not Grid container) continue;
+            if (container.Tag is not DashboardWidget tw || tw.Id != widgetId) continue;
+            var w       = withWidget ?? tw;
+            var newCard = BuildCard(w);
+            // Preserve the current size
+            if (newCard is Grid ng)
+            {
+                ng.Width  = container.Width;
+                ng.Height = container.Height;
+                ng.Tag    = w with { Width = container.Width, Height = container.Height };
+            }
+            WidgetPanel.Children.RemoveAt(i);
+            WidgetPanel.Children.Insert(i, newCard);
+            return;
+        }
+    }
+
+    // ── Node-Ranking widget ───────────────────────────────────────────────────
+
+    private FrameworkElement BuildRankingContent(DashboardWidget w)
+    {
+        (_, _, string unit) = MetricRange(w.Metric);
+        var nodeIds = w.NodeIds.Count > 0 ? w.NodeIds : _nodeNames.Keys.ToList();
+
+        var rows = nodeIds
+            .Select(id =>
+            {
+                var pts = _db.GetTimeSeries(new[] { id }, w.Metric, w.Days > 0 ? w.Days : 7);
+                double val = pts.Count > 0
+                    ? pts.OrderByDescending(p => p.Timestamp).First().Value
+                    : double.NaN;
+                return (id, val);
+            })
+            .Where(x => !double.IsNaN(x.val))
+            .OrderByDescending(x => x.val)
+            .ToList();
+
+        var grid = new Grid { Margin = new Thickness(8, 6, 8, 4) };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(30) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        AddRankingCell(grid, "#",                0, 0, _fgMuted, true);
+        AddRankingCell(grid, Loc("StrRankingNode"), 1, 0, _fgMuted, true);
+        AddRankingCell(grid, unit,               2, 0, _fgMuted, true);
+
+        if (rows.Count == 0)
+        {
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            var noData = new TextBlock
+            {
+                Text       = Loc("StrDashboardNoData"),
+                Foreground = new SolidColorBrush(_fgMuted),
+                FontSize   = 11,
+                Margin     = new Thickness(4, 8, 4, 4),
+            };
+            Grid.SetRow(noData, 1);
+            Grid.SetColumnSpan(noData, 3);
+            grid.Children.Add(noData);
+        }
+        else
+        {
+            for (int i = 0; i < rows.Count; i++)
+            {
+                var (id, val) = rows[i];
+                Color rowColor = i == 0 ? WpfPalette[1]
+                               : i == 1 ? WpfPalette[2]
+                               : _fgMain;
+                grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                int row = i + 1;
+                AddRankingCell(grid, $"{i + 1}",  0, row, rowColor, false);
+                AddRankingCell(grid, NodeLabel(id), 1, row, _fgMain, false);
+                AddRankingCell(grid, $"{val:F1}",  2, row, rowColor, false);
+            }
+        }
+
+        return new Border
+        {
+            Child = new ScrollViewer
+            {
+                Content = grid,
+                VerticalScrollBarVisibility   = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            },
+            Padding = new Thickness(2),
+        };
+    }
+
+    private void AddRankingCell(Grid grid, string text, int col, int row, Color color, bool header)
+    {
+        var tb = new TextBlock
+        {
+            Text         = text,
+            Foreground   = new SolidColorBrush(color),
+            FontSize     = header ? 10 : 11,
+            FontWeight   = header ? System.Windows.FontWeights.SemiBold
+                                  : System.Windows.FontWeights.Normal,
+            Padding      = new Thickness(3, 2, 3, 2),
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+        Grid.SetRow(tb,    row);
+        Grid.SetColumn(tb, col);
+        grid.Children.Add(tb);
+    }
+
+    // ── Multi-Node-Stat widget ────────────────────────────────────────────────
+
+    private FrameworkElement BuildMultiStatContent(DashboardWidget w)
+    {
+        (_, _, string unit) = MetricRange(w.Metric);
+        var nodeIds = w.NodeIds.Count > 0 ? w.NodeIds : _nodeNames.Keys.Take(8).ToList();
+
+        var wrap = new WrapPanel { Margin = new Thickness(6), Orientation = Orientation.Horizontal };
+
+        int ci = 0;
+        foreach (var id in nodeIds)
+        {
+            var values = _db.GetTimeSeries(new[] { id }, w.Metric, w.Days > 0 ? w.Days : 7)
+                            .Select(p => p.Value).ToList();
+            double last = values.Count > 0
+                ? _db.GetTimeSeries(new[] { id }, w.Metric, w.Days > 0 ? w.Days : 7)
+                      .OrderByDescending(p => p.Timestamp).First().Value
+                : double.NaN;
+            double min = values.Count > 0 ? values.Min() : double.NaN;
+            double max = values.Count > 0 ? values.Max() : double.NaN;
+            double avg = values.Count > 0 ? values.Average() : double.NaN;
+
+            Color accent = WpfPalette[ci % WpfPalette.Length];
+            string name  = NodeLabel(id);
+
+            var tile = new Border
+            {
+                Background      = new SolidColorBrush(Color.FromArgb(20, accent.R, accent.G, accent.B)),
+                BorderBrush     = new SolidColorBrush(Color.FromArgb(60, accent.R, accent.G, accent.B)),
+                BorderThickness = new Thickness(1),
+                CornerRadius    = new CornerRadius(5),
+                Margin          = new Thickness(3),
+                Padding         = new Thickness(8, 5, 8, 5),
+                MinWidth        = 110,
+            };
+
+            var tileGrid = new Grid();
+            tileGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            tileGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            tileGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var nameText = new TextBlock
+            {
+                Text         = name.Length > 14 ? name[..14] : name,
+                FontSize     = 10,
+                FontWeight   = System.Windows.FontWeights.SemiBold,
+                Foreground   = new SolidColorBrush(accent),
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            };
+            Grid.SetRow(nameText, 0);
+
+            var bigText = new TextBlock
+            {
+                Text                = double.IsNaN(last) ? "–" : $"{last:F1}",
+                FontSize            = 22,
+                FontWeight          = System.Windows.FontWeights.Light,
+                Foreground          = new SolidColorBrush(_fgMain),
+                HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            };
+            Grid.SetRow(bigText, 1);
+
+            var statsRow = new StackPanel { Orientation = Orientation.Horizontal };
+            statsRow.Children.Add(MakeMultiStatMini("↓", min, _fgMuted));
+            statsRow.Children.Add(MakeMultiStatMini(" ⌀", avg, _fgSub));
+            statsRow.Children.Add(MakeMultiStatMini(" ↑", max, _fgMuted));
+            Grid.SetRow(statsRow, 2);
+
+            tileGrid.Children.Add(nameText);
+            tileGrid.Children.Add(bigText);
+            tileGrid.Children.Add(statsRow);
+            tile.Child = tileGrid;
+            wrap.Children.Add(tile);
+            ci++;
+        }
+
+        return new Border
+        {
+            Child = new ScrollViewer
+            {
+                Content = wrap,
+                VerticalScrollBarVisibility   = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            },
+        };
+    }
+
+    private TextBlock MakeMultiStatMini(string prefix, double val, Color color) => new()
+    {
+        Text       = double.IsNaN(val) ? $"{prefix}–" : $"{prefix}{val:F1}",
+        FontSize   = 9,
+        Foreground = new SolidColorBrush(color),
+        Margin     = new Thickness(0, 0, 3, 0),
+    };
+
+    // ── Mesh-Health widget ────────────────────────────────────────────────────
+
+    private FrameworkElement BuildMeshHealthContent(DashboardWidget w)
+    {
+        var nodeIds     = w.NodeIds.Count > 0 ? w.NodeIds : _nodeNames.Keys.ToList();
+        int lookbackDays = w.Days > 0 ? w.Days : 1;
+
+        var wrap = new WrapPanel { Margin = new Thickness(6), Orientation = Orientation.Horizontal };
+
+        foreach (var id in nodeIds)
+        {
+            var pts = _db.GetTimeSeries(new[] { id }, "snr", lookbackDays);
+            double lastSnr = pts.Count > 0
+                ? pts.OrderByDescending(p => p.Timestamp).First().Value
+                : double.NaN;
+            bool stale = pts.Count == 0 ||
+                         (DateTime.UtcNow - pts.Max(p => p.Timestamp)).TotalHours > 24;
+
+            Color ledColor;
+            string status;
+            if (stale || double.IsNaN(lastSnr))
+            {
+                ledColor = Color.FromRgb(240,  76,  76);
+                status   = Loc("StrMeshHealthOffline");
+            }
+            else if (lastSnr >= -5)
+            {
+                ledColor = Color.FromRgb( 63, 185, 126);
+                status   = Loc("StrMeshHealthGood");
+            }
+            else if (lastSnr >= -15)
+            {
+                ledColor = Color.FromRgb(255, 171,  76);
+                status   = Loc("StrMeshHealthWeak");
+            }
+            else
+            {
+                ledColor = Color.FromRgb(240,  76,  76);
+                status   = Loc("StrMeshHealthPoor");
+            }
+
+            string name = NodeLabel(id);
+
+            var tile = new Border
+            {
+                Background      = new SolidColorBrush(Color.FromArgb(12, ledColor.R, ledColor.G, ledColor.B)),
+                BorderBrush     = new SolidColorBrush(Color.FromArgb(40, ledColor.R, ledColor.G, ledColor.B)),
+                BorderThickness = new Thickness(1),
+                CornerRadius    = new CornerRadius(5),
+                Margin          = new Thickness(3),
+                Padding         = new Thickness(8, 6, 8, 6),
+                MinWidth        = 110,
+                ToolTip         = $"{name}  SNR: {(double.IsNaN(lastSnr) ? "–" : $"{lastSnr:F1} dB")}  {status}",
+            };
+
+            var row = new StackPanel
+            {
+                Orientation       = Orientation.Horizontal,
+                VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            };
+
+            var led = new System.Windows.Shapes.Ellipse
+            {
+                Width  = 10,
+                Height = 10,
+                Fill   = new SolidColorBrush(ledColor),
+                Effect = new DropShadowEffect
+                {
+                    Color       = ledColor,
+                    BlurRadius  = 6,
+                    ShadowDepth = 0,
+                    Opacity     = 0.7,
+                },
+                Margin            = new Thickness(0, 0, 7, 0),
+                VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            };
+            row.Children.Add(led);
+
+            var info = new StackPanel { VerticalAlignment = System.Windows.VerticalAlignment.Center };
+            info.Children.Add(new TextBlock
+            {
+                Text         = name.Length > 14 ? name[..14] : name,
+                FontSize     = 11,
+                Foreground   = new SolidColorBrush(_fgMain),
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            });
+            info.Children.Add(new TextBlock
+            {
+                Text       = double.IsNaN(lastSnr) ? "–" : $"{lastSnr:F1} dB",
+                FontSize   = 9,
+                Foreground = new SolidColorBrush(_fgMuted),
+            });
+            row.Children.Add(info);
+
+            tile.Child = row;
+            wrap.Children.Add(tile);
+        }
+
+        if (wrap.Children.Count == 0)
+            wrap.Children.Add(new TextBlock
+            {
+                Text       = Loc("StrDashboardNoData"),
+                Foreground = new SolidColorBrush(_fgMuted),
+                FontSize   = 11,
+                Margin     = new Thickness(4),
+            });
+
+        return new Border
+        {
+            Child = new ScrollViewer
+            {
+                Content = wrap,
+                VerticalScrollBarVisibility   = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            },
+        };
+    }
+
+    // ── CSV Export ────────────────────────────────────────────────────────────
+
+    private void ExportWidgetCsv(DashboardWidget w)
+    {
+        (_, _, string unit) = MetricRange(w.Metric);
+        var dlg = new Microsoft.Win32.SaveFileDialog
+        {
+            Title    = Loc("StrDashboardExportCsv"),
+            Filter   = "CSV (*.csv)|*.csv",
+            FileName = $"{w.Title}_{w.Metric}_{DateTime.Now:yyyyMMdd_HHmm}.csv",
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        try
+        {
+            var nodeIds = w.NodeIds.Count > 0 ? w.NodeIds : _nodeNames.Keys.ToList();
+            var sb = new StringBuilder();
+            sb.AppendLine($"Timestamp,Node,{w.Metric} ({unit})");
+
+            foreach (var id in nodeIds)
+            {
+                string name = NodeLabel(id);
+                var pts = _db.GetTimeSeries(new[] { id }, w.Metric, w.Days > 0 ? w.Days : 30)
+                             .OrderBy(p => p.Timestamp);
+                foreach (var p in pts)
+                    sb.AppendLine($"{p.Timestamp:yyyy-MM-dd HH:mm:ss},{name},{p.Value:F4}");
+            }
+
+            System.IO.File.WriteAllText(dlg.FileName, sb.ToString(), Encoding.UTF8);
+            MessageBox.Show(
+                string.Format(Loc("StrDashboardExportDone"), dlg.FileName),
+                Loc("StrDashboardTitle"),
+                MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Export fehlgeschlagen: {ex.Message}",
+                Loc("StrDashboardTitle"),
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 }
 

--- a/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
@@ -1,0 +1,1538 @@
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using System.Windows.Shapes;
+using System.Windows.Threading;
+using MeshhessenClient.Models;
+using MeshhessenClient.Services;
+using ModernWpf;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Legends;
+using OxyPlot.Series;
+using OxyPlot.Wpf;
+
+namespace MeshhessenClient;
+
+public partial class TelemetryDashboardWindow : Window
+{
+    private static string Loc(string key) =>
+        Application.Current?.Resources[key] as string ?? key;
+
+    private static readonly string StoreFile =
+        System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "dashboards.json");
+
+    private static bool FileExists(string path) => System.IO.File.Exists(path);
+    private static string ReadAllText(string path) => System.IO.File.ReadAllText(path);
+    private static void WriteAllText(string path, string text) => System.IO.File.WriteAllText(path, text);
+
+    // ── Palette (same for both themes) ────────────────────────────────────────
+    private static readonly OxyColor[] Palette =
+    {
+        OxyColor.FromRgb( 31, 111, 235),
+        OxyColor.FromRgb( 63, 185, 126),
+        OxyColor.FromRgb(255, 171,  76),
+        OxyColor.FromRgb(240,  76,  76),
+        OxyColor.FromRgb(162, 116, 255),
+        OxyColor.FromRgb(  0, 205, 218),
+        OxyColor.FromRgb(255, 123,  84),
+        OxyColor.FromRgb( 82, 174, 255),
+    };
+
+    private static readonly Color[] WpfPalette =
+    {
+        Color.FromRgb( 31, 111, 235),
+        Color.FromRgb( 63, 185, 126),
+        Color.FromRgb(255, 171,  76),
+        Color.FromRgb(240,  76,  76),
+        Color.FromRgb(162, 116, 255),
+        Color.FromRgb(  0, 205, 218),
+        Color.FromRgb(255, 123,  84),
+        Color.FromRgb( 82, 174, 255),
+    };
+
+    // ── Theme colors (instance, set from theme detection) ─────────────────────
+    private readonly bool _isDark;
+    private readonly Color _bgCard, _bgPage, _bgHeader, _borderCol;
+    private readonly Color _fgMain, _fgSub, _fgMuted;
+    private readonly OxyColor _oxyText, _oxyTick, _oxyGrid, _oxyLegendBg;
+
+    // ── Fields ────────────────────────────────────────────────────────────────
+    private readonly TelemetryDatabaseService _db;
+    private readonly Dictionary<uint, string> _nodeNames;
+    private DashboardStore _store = new();
+    private Dashboard? _current;
+    private bool _suppressComboEvent;
+    private readonly DispatcherTimer _refreshTimer = new();
+    private int _refreshIntervalSeconds = 30;
+    private readonly Dictionary<string, DispatcherTimer> _clockTimers = new();
+
+    // ── Constructor ───────────────────────────────────────────────────────────
+
+    public TelemetryDashboardWindow(
+        TelemetryDatabaseService db,
+        Dictionary<uint, string> nodeNames)
+    {
+        InitializeComponent();
+        _db        = db;
+        _nodeNames = nodeNames;
+
+        // Detect theme
+        _isDark = ThemeManager.Current.ActualApplicationTheme == ApplicationTheme.Dark;
+
+        if (_isDark)
+        {
+            _bgCard    = Color.FromRgb( 22,  27,  34);
+            _bgPage    = Color.FromRgb( 13,  17,  23);
+            _bgHeader  = Color.FromRgb( 21,  26,  35);
+            _borderCol = Color.FromRgb( 48,  57,  74);
+            _fgMain    = Color.FromRgb(201, 209, 217);
+            _fgSub     = Color.FromRgb(139, 148, 158);
+            _fgMuted   = Color.FromRgb( 72,  79,  88);
+        }
+        else
+        {
+            _bgCard    = Color.FromRgb(254, 254, 254);
+            _bgPage    = Color.FromRgb(244, 246, 248);
+            _bgHeader  = Color.FromRgb(248, 249, 252);
+            _borderCol = Color.FromRgb(216, 220, 226);
+            _fgMain    = Color.FromRgb( 30,  34,  40);
+            _fgSub     = Color.FromRgb( 90,  99, 110);
+            _fgMuted   = Color.FromRgb(160, 166, 174);
+        }
+
+        _oxyText     = OxyColor.FromRgb(_fgSub.R, _fgSub.G, _fgSub.B);
+        _oxyTick     = OxyColor.FromRgb(_borderCol.R, _borderCol.G, _borderCol.B);
+        _oxyGrid     = OxyColor.FromArgb(60, _borderCol.R, _borderCol.G, _borderCol.B);
+        _oxyLegendBg = _isDark
+            ? OxyColor.FromArgb(180,  13, 17, 23)
+            : OxyColor.FromArgb(220, 255, 255, 255);
+
+        ApplyThemeToWindow();
+
+        PopulateAutoRefreshCombo();
+        LoadStore();
+        RebuildCombo();
+
+        _refreshTimer.Tick += (_, _) => OnAutoRefreshTick();
+
+        Loaded += (_, _) =>
+        {
+            RenderCurrentDashboard();
+            StartAutoRefreshIfEnabled();
+        };
+    }
+
+    private void ApplyThemeToWindow()
+    {
+        Background               = new SolidColorBrush(_bgPage);
+        RootPanel.Background     = new SolidColorBrush(_bgPage);
+        ToolbarBorder.Background = new SolidColorBrush(_bgCard);
+        ToolbarBorder.BorderBrush = new SolidColorBrush(_borderCol);
+        StatusBorder.Background  = new SolidColorBrush(_bgCard);
+        StatusBorder.BorderBrush = new SolidColorBrush(_borderCol);
+        CanvasScroller.Background = new SolidColorBrush(_bgPage);
+
+        var subBrush = new SolidColorBrush(_fgSub);
+        DashboardLabelText.Foreground = subBrush;
+        AutoRefreshLabel.Foreground   = subBrush;
+        StatusText.Foreground         = subBrush;
+        LastRefreshText.Foreground    = new SolidColorBrush(_fgMuted);
+        EmptyStateIcon.Foreground     = new SolidColorBrush(_fgMuted);
+        EmptyStateText.Foreground     = new SolidColorBrush(_fgMuted);
+    }
+
+    // ── Auto-refresh ─────────────────────────────────────────────────────────
+
+    private void PopulateAutoRefreshCombo()
+    {
+        var items = new[]
+        {
+            (0,    Loc("StrDashboardRefreshOff")),
+            (10,   "10s"),
+            (30,   "30s"),
+            (60,   "60s"),
+            (300,  "5 min"),
+        };
+        foreach (var (seconds, label) in items)
+            AutoRefreshCombo.Items.Add(new ComboBoxItem { Tag = seconds, Content = label });
+        AutoRefreshCombo.SelectedIndex = 2;
+    }
+
+    private void AutoRefreshCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (AutoRefreshCombo.SelectedItem is not ComboBoxItem item) return;
+        _refreshIntervalSeconds = item.Tag is int s ? s : 0;
+        StartAutoRefreshIfEnabled();
+    }
+
+    private void StartAutoRefreshIfEnabled()
+    {
+        _refreshTimer.Stop();
+        if (_refreshIntervalSeconds <= 0) return;
+        _refreshTimer.Interval = TimeSpan.FromSeconds(_refreshIntervalSeconds);
+        _refreshTimer.Start();
+    }
+
+    private async void OnAutoRefreshTick()
+    {
+        RefreshDot.Opacity = 1.0;
+        await Task.Delay(600);
+        RefreshDot.Opacity = 0.0;
+
+        RefreshAllCardsInPlace();
+        LastRefreshText.Text = string.Format(Loc("StrDashboardLastRefreshed"),
+            DateTime.Now.ToString("HH:mm:ss"));
+    }
+
+    /// <summary>
+    /// Re-render each card's CONTENT in place without rebuilding the container.
+    /// Preserves current size (even if the user is in mid-resize) and drag state.
+    /// </summary>
+    private void RefreshAllCardsInPlace()
+    {
+        if (_current == null) return;
+        foreach (Grid container in WidgetPanel.Children.OfType<Grid>())
+        {
+            if (container.Tag is not DashboardWidget w) continue;
+            if (container.Children.OfType<Border>().FirstOrDefault(b => b.Tag as string == "card") is not Border card) continue;
+            if (card.Child is not DockPanel dock) continue;
+
+            // Content is the second child (after header)
+            if (dock.Children.Count < 2) continue;
+            var newContent = BuildWidgetContent(w);
+            dock.Children.RemoveAt(1);
+            dock.Children.Add(newContent);
+        }
+    }
+
+    // ── Persistence ───────────────────────────────────────────────────────────
+
+    private void LoadStore()
+    {
+        try
+        {
+            if (FileExists(StoreFile))
+                _store = JsonSerializer.Deserialize<DashboardStore>(
+                    ReadAllText(StoreFile)) ?? new();
+        }
+        catch { _store = new(); }
+    }
+
+    private void SaveStore()
+    {
+        try
+        {
+            WriteAllText(StoreFile,
+                JsonSerializer.Serialize(_store,
+                    new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch { }
+    }
+
+    // ── Combo management ─────────────────────────────────────────────────────
+
+    private void RebuildCombo()
+    {
+        _suppressComboEvent = true;
+        DashboardCombo.Items.Clear();
+        foreach (var d in _store.Dashboards)
+            DashboardCombo.Items.Add(new ComboBoxItem { Content = d.Name, Tag = d });
+        if (_current != null)
+        {
+            foreach (ComboBoxItem item in DashboardCombo.Items)
+                if (item.Tag is Dashboard td && td == _current) { DashboardCombo.SelectedItem = item; break; }
+        }
+        if (DashboardCombo.SelectedItem == null && DashboardCombo.Items.Count > 0)
+        {
+            DashboardCombo.SelectedIndex = 0;
+            _current = _store.Dashboards.Count > 0 ? _store.Dashboards[0] : null;
+        }
+        _suppressComboEvent = false;
+    }
+
+    private void DashboardCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressComboEvent) return;
+        if (DashboardCombo.SelectedItem is ComboBoxItem { Tag: Dashboard d })
+        {
+            _current = d;
+            RenderCurrentDashboard();
+        }
+    }
+
+    // ── Toolbar actions ──────────────────────────────────────────────────────
+
+    private void NewDashboard_Click(object sender, RoutedEventArgs e)
+    {
+        var name = PromptString(
+            Loc("StrDashboardNewTitle"),
+            Loc("StrDashboardNewPrompt"),
+            $"{Loc("StrDashboardDefaultName")} {_store.Dashboards.Count + 1}");
+        if (name == null) return;
+        var d = new Dashboard(name, new List<DashboardWidget>());
+        _store.Dashboards.Add(d);
+        _current = d;
+        SaveStore();
+        RebuildCombo();
+        RenderCurrentDashboard();
+    }
+
+    private void RenameDashboard_Click(object sender, RoutedEventArgs e)
+    {
+        if (_current == null) return;
+        var name = PromptString(
+            Loc("StrDashboardRenameTitle"),
+            Loc("StrDashboardNewPrompt"),
+            _current.Name);
+        if (name == null) return;
+        var idx = _store.Dashboards.IndexOf(_current);
+        if (idx < 0) return;
+        _current = _current with { Name = name };
+        _store.Dashboards[idx] = _current;
+        SaveStore();
+        RebuildCombo();
+    }
+
+    private void DeleteDashboard_Click(object sender, RoutedEventArgs e)
+    {
+        if (_current == null) return;
+        if (MessageBox.Show(
+                string.Format(Loc("StrDashboardDeleteConfirm"), _current.Name),
+                Loc("StrDashboardTitle"),
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question) != MessageBoxResult.Yes) return;
+        _store.Dashboards.Remove(_current);
+        _current = _store.Dashboards.FirstOrDefault();
+        SaveStore();
+        RebuildCombo();
+        RenderCurrentDashboard();
+    }
+
+    private void AddWidget_Click(object sender, RoutedEventArgs e)
+    {
+        if (_current == null)
+        {
+            MessageBox.Show(Loc("StrDashboardNoDashboard"),
+                Loc("StrDashboardTitle"),
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+        var dlg = new AddWidgetDialog(_nodeNames) { Owner = this };
+        if (dlg.ShowDialog() != true) return;
+        var widget = dlg.Result!;
+        var idx = _store.Dashboards.IndexOf(_current);
+        var newWidgets = new List<DashboardWidget>(_current.Widgets) { widget };
+        _current = _current with { Widgets = newWidgets };
+        _store.Dashboards[idx] = _current;
+        SaveStore();
+        RenderCurrentDashboard();
+    }
+
+    private void Refresh_Click(object sender, RoutedEventArgs e) => RenderCurrentDashboard();
+
+    // ── Rendering ────────────────────────────────────────────────────────────
+
+    private void RenderCurrentDashboard()
+    {
+        foreach (var t in _clockTimers.Values) t.Stop();
+        _clockTimers.Clear();
+
+        WidgetPanel.Children.Clear();
+        if (_current == null || _current.Widgets.Count == 0)
+        {
+            EmptyState.Visibility = Visibility.Visible;
+            StatusText.Text = Loc("StrDashboardEmpty");
+            return;
+        }
+        EmptyState.Visibility = Visibility.Collapsed;
+        foreach (var w in _current.Widgets)
+            WidgetPanel.Children.Add(BuildCard(w));
+        UpdateStatus();
+        LastRefreshText.Text = string.Format(Loc("StrDashboardLastRefreshed"),
+            DateTime.Now.ToString("HH:mm:ss"));
+    }
+
+    private void UpdateStatus()
+    {
+        var count = _current?.Widgets.Count ?? 0;
+        StatusText.Text = $"{_current?.Name ?? "–"}  ·  {count} {Loc("StrDashboardWidgetCount")}";
+    }
+
+    // ── Card builder ─────────────────────────────────────────────────────────
+
+    private FrameworkElement BuildCard(DashboardWidget w)
+    {
+        var container = new Grid
+        {
+            Width  = Math.Max(280, w.Width),
+            Height = Math.Max(200, w.Height),
+            Margin = new Thickness(6),
+            Tag    = w,
+        };
+
+        var card = new Border
+        {
+            Background      = new SolidColorBrush(_bgCard),
+            BorderBrush     = new SolidColorBrush(_borderCol),
+            BorderThickness = new Thickness(1),
+            CornerRadius    = new CornerRadius(8),
+            ClipToBounds    = true,
+            Tag             = "card",
+            Effect = new DropShadowEffect
+            {
+                Color      = _isDark ? Color.FromRgb(0, 0, 0) : Color.FromRgb(120, 128, 138),
+                BlurRadius = 16,
+                ShadowDepth = 3,
+                Opacity    = _isDark ? 0.55 : 0.15,
+            },
+        };
+
+        var dock = new DockPanel { LastChildFill = true };
+
+        // Header
+        var headerBorder = new Border
+        {
+            Background      = new SolidColorBrush(_bgHeader),
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            BorderBrush     = new SolidColorBrush(_borderCol),
+            Padding         = new Thickness(8, 6, 6, 6),
+        };
+        DockPanel.SetDock(headerBorder, Dock.Top);
+
+        var header = new DockPanel();
+
+        // Right side: edit + close buttons
+        var rightButtons = new StackPanel { Orientation = Orientation.Horizontal };
+        DockPanel.SetDock(rightButtons, Dock.Right);
+
+        var editBtn = new Button
+        {
+            Content = "✎",
+            Tag     = w,
+            ToolTip = Loc("StrDashboardEditWidget"),
+            Style   = TryFindResource("CardIconBtn") as Style,
+            Foreground = new SolidColorBrush(_fgSub),
+        };
+        editBtn.Click += EditWidget_Click;
+        rightButtons.Children.Add(editBtn);
+
+        var closeBtn = new Button
+        {
+            Content = "×",
+            Tag     = w,
+            ToolTip = Loc("StrDashboardRemoveWidget"),
+            Style   = TryFindResource("CardCloseBtn") as Style,
+            Foreground = new SolidColorBrush(_fgSub),
+            FontSize   = 14,
+        };
+        closeBtn.Click += RemoveWidget_Click;
+        rightButtons.Children.Add(closeBtn);
+        header.Children.Add(rightButtons);
+
+        // Drag handle (left)
+        var dragHandle = new TextBlock
+        {
+            Text       = "⠿",
+            FontSize   = 13,
+            Foreground = new SolidColorBrush(_fgMuted),
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            Cursor     = System.Windows.Input.Cursors.SizeAll,
+            Margin     = new Thickness(0, 0, 6, 0),
+            Padding    = new Thickness(2, 0, 2, 0),
+        };
+        DockPanel.SetDock(dragHandle, Dock.Left);
+        dragHandle.MouseMove += (_, e) =>
+        {
+            if (e.LeftButton == System.Windows.Input.MouseButtonState.Pressed)
+                DragDrop.DoDragDrop(container,
+                    new DataObject("widget_id", w.Id), DragDropEffects.Move);
+        };
+        header.Children.Add(dragHandle);
+
+        // Type color badge
+        Color typeColor = TypeColor(w.Type);
+        string typeIcon = TypeIcon(w.Type);
+
+        var badge = new Border
+        {
+            Background      = new SolidColorBrush(Color.FromArgb(40, typeColor.R, typeColor.G, typeColor.B)),
+            BorderBrush     = new SolidColorBrush(Color.FromArgb(80, typeColor.R, typeColor.G, typeColor.B)),
+            BorderThickness = new Thickness(1),
+            CornerRadius    = new CornerRadius(3),
+            Padding         = new Thickness(5, 1, 5, 1),
+            Margin          = new Thickness(0, 0, 7, 0),
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            Child = new TextBlock
+            {
+                Text       = typeIcon,
+                Foreground = new SolidColorBrush(typeColor),
+                FontSize   = 10,
+            },
+        };
+        DockPanel.SetDock(badge, Dock.Left);
+        header.Children.Add(badge);
+
+        var titleText = new TextBlock
+        {
+            Text      = w.Title,
+            Foreground = new SolidColorBrush(_fgMain),
+            FontWeight = System.Windows.FontWeights.SemiBold,
+            FontSize   = 12,
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+        };
+        DockPanel.SetDock(titleText, Dock.Left);
+        header.Children.Add(titleText);
+
+        headerBorder.Child = header;
+        dock.Children.Add(headerBorder);
+
+        // Content
+        dock.Children.Add(BuildWidgetContent(w));
+        card.Child = dock;
+        container.Children.Add(card);
+
+        // Drop target for reordering
+        container.AllowDrop = true;
+        container.DragEnter += (_, e) =>
+        {
+            if (e.Data.GetDataPresent("widget_id")) e.Effects = DragDropEffects.Move;
+        };
+        container.DragOver += (_, e) =>
+        {
+            if (e.Data.GetDataPresent("widget_id")) { e.Effects = DragDropEffects.Move; e.Handled = true; }
+        };
+        container.Drop += (_, e) =>
+        {
+            if (!e.Data.GetDataPresent("widget_id")) return;
+            string srcId = (string)e.Data.GetData("widget_id")!;
+            if (srcId != w.Id) ReorderWidgets(srcId, w.Id);
+        };
+
+        // Resize grip — 30x30 hit area with visual in bottom-right
+        var grip = new Thumb
+        {
+            Width  = 30,
+            Height = 30,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Right,
+            VerticalAlignment   = System.Windows.VerticalAlignment.Bottom,
+            Cursor   = System.Windows.Input.Cursors.SizeNWSE,
+            Opacity  = 0.8,
+            Template = BuildResizeGripTemplate(_fgSub),
+        };
+        string widgetId = w.Id;
+        grip.DragDelta += (_, delta) =>
+        {
+            double newW = Math.Max(280, container.Width  + delta.HorizontalChange);
+            double newH = Math.Max(200, container.Height + delta.VerticalChange);
+            container.Width  = newW;
+            container.Height = newH;
+            SaveWidgetSizeById(widgetId, newW, newH);
+        };
+        container.Children.Add(grip);
+
+        // Tooltip
+        container.ToolTip = w.Type == "clock"
+            ? Loc("StrWidgetTypeClock")
+            : $"{w.Metric}  |  {(w.Days > 0 ? $"{w.Days}d" : Loc("StrDaysAll"))}  |  " +
+              $"{string.Join(", ", w.NodeIds.Select(id => _nodeNames.TryGetValue(id, out var n) ? n : $"!{id:x8}"))}";
+
+        return container;
+    }
+
+    private UIElement BuildWidgetContent(DashboardWidget w)
+    {
+        try
+        {
+            return w.Type switch
+            {
+                "gauge"       => BuildGaugeContent(w),
+                "stat"        => BuildStatContent(w),
+                "clock"       => BuildClockContent(w),
+                "heatmap"     => BuildPlotContent(BuildHeatmapModel(w)),
+                "bar"         => BuildPlotContent(BuildBarModel(w)),
+                "area"        => BuildPlotContent(BuildAreaModel(w)),
+                "scatter"     => BuildPlotContent(BuildScatterModel(w)),
+                "histogram"   => BuildPlotContent(BuildHistogramModel(w)),
+                "candlestick" => BuildPlotContent(BuildCandlestickModel(w)),
+                "stateline"   => BuildPlotContent(BuildStatelineModel(w)),
+                _             => BuildPlotContent(BuildLineModel(w)),
+            };
+        }
+        catch (Exception ex)
+        {
+            return new TextBlock
+            {
+                Text         = $"Error: {ex.Message}",
+                Foreground   = new SolidColorBrush(Color.FromRgb(240, 76, 76)),
+                Margin       = new Thickness(12),
+                TextWrapping = TextWrapping.Wrap,
+            };
+        }
+    }
+
+    private static Color TypeColor(string type) => type switch
+    {
+        "line"        => Color.FromRgb( 31, 111, 235),
+        "area"        => Color.FromRgb( 63, 185, 126),
+        "bar"         => Color.FromRgb(255, 171,  76),
+        "gauge"       => Color.FromRgb(162, 116, 255),
+        "stat"        => Color.FromRgb(  0, 205, 218),
+        "heatmap"     => Color.FromRgb(255, 123,  84),
+        "scatter"     => Color.FromRgb( 82, 174, 255),
+        "clock"       => Color.FromRgb(255, 171,  76),
+        "histogram"   => Color.FromRgb( 63, 185, 126),
+        "candlestick" => Color.FromRgb(240,  76,  76),
+        "stateline"   => Color.FromRgb(  0, 205, 218),
+        _             => Color.FromRgb(139, 148, 158),
+    };
+
+    private static string TypeIcon(string type) => type switch
+    {
+        "line"        => "〜",
+        "area"        => "▲",
+        "bar"         => "▮",
+        "gauge"       => "◎",
+        "stat"        => "⬢",
+        "heatmap"     => "⣿",
+        "scatter"     => "⁘",
+        "clock"       => "⏱",
+        "histogram"   => "▦",
+        "candlestick" => "🕯",
+        "stateline"   => "▬",
+        _             => "▪",
+    };
+
+    private static ControlTemplate BuildResizeGripTemplate(Color dotColor)
+    {
+        var factory = new FrameworkElementFactory(typeof(Canvas));
+        factory.SetValue(FrameworkElement.WidthProperty, 30.0);
+        factory.SetValue(FrameworkElement.HeightProperty, 30.0);
+        factory.SetValue(Panel.BackgroundProperty, Brushes.Transparent); // hit-testable
+
+        // Visual dots concentrated in bottom-right 16x16 area
+        foreach (var (x, y) in new[] { (22.0, 12.0), (18.0, 16.0), (22.0, 16.0), (14.0, 20.0), (18.0, 20.0), (22.0, 20.0) })
+        {
+            var dot = new FrameworkElementFactory(typeof(Ellipse));
+            dot.SetValue(FrameworkElement.WidthProperty, 2.8);
+            dot.SetValue(FrameworkElement.HeightProperty, 2.8);
+            dot.SetValue(Shape.FillProperty, new SolidColorBrush(dotColor));
+            dot.SetValue(Canvas.LeftProperty, x);
+            dot.SetValue(Canvas.TopProperty, y);
+            factory.AppendChild(dot);
+        }
+
+        return new ControlTemplate(typeof(Thumb)) { VisualTree = factory };
+    }
+
+    /// <summary>Save by widget ID, not by reference — avoids stale-instance bug.</summary>
+    private void SaveWidgetSizeById(string widgetId, double width, double height)
+    {
+        if (_current == null) return;
+        var idx = _store.Dashboards.IndexOf(_current);
+        if (idx < 0) return;
+        var widgetIdx = _current.Widgets.FindIndex(x => x.Id == widgetId);
+        if (widgetIdx < 0) return;
+        var updated = _current.Widgets[widgetIdx] with { Width = width, Height = height };
+        var newWidgets = new List<DashboardWidget>(_current.Widgets);
+        newWidgets[widgetIdx] = updated;
+        _current = _current with { Widgets = newWidgets };
+        _store.Dashboards[idx] = _current;
+
+        // Also update the container's Tag so refresh-in-place sees current size
+        foreach (Grid g in WidgetPanel.Children.OfType<Grid>())
+            if (g.Tag is DashboardWidget tw && tw.Id == widgetId)
+            {
+                g.Tag = updated;
+                break;
+            }
+
+        SaveStore();
+    }
+
+    private void ReorderWidgets(string sourceId, string targetId)
+    {
+        if (_current == null) return;
+        var srcIdx = _current.Widgets.FindIndex(x => x.Id == sourceId);
+        var tgtIdx = _current.Widgets.FindIndex(x => x.Id == targetId);
+        if (srcIdx < 0 || tgtIdx < 0 || srcIdx == tgtIdx) return;
+
+        var newWidgets = new List<DashboardWidget>(_current.Widgets);
+        var item = newWidgets[srcIdx];
+        newWidgets.RemoveAt(srcIdx);
+        newWidgets.Insert(tgtIdx, item);
+
+        var dashIdx = _store.Dashboards.IndexOf(_current);
+        _current = _current with { Widgets = newWidgets };
+        _store.Dashboards[dashIdx] = _current;
+        SaveStore();
+        RenderCurrentDashboard();
+    }
+
+    // ── Plot content wrapper ─────────────────────────────────────────────────
+
+    private FrameworkElement BuildPlotContent(PlotModel model) => new PlotView
+    {
+        Model      = model,
+        Background = Brushes.Transparent,
+        Margin     = new Thickness(2, 0, 2, 4),
+    };
+
+    // ── Clock widget ──────────────────────────────────────────────────────────
+
+    private FrameworkElement BuildClockContent(DashboardWidget w)
+    {
+        var panel = new StackPanel
+        {
+            VerticalAlignment   = System.Windows.VerticalAlignment.Center,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            Margin = new Thickness(16),
+        };
+
+        var localTime = new TextBlock
+        {
+            FontSize   = 52,
+            FontWeight = System.Windows.FontWeights.Light,
+            Foreground = new SolidColorBrush(_fgMain),
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            FontFamily = new FontFamily("Consolas"),
+        };
+        var utcTime = new TextBlock
+        {
+            FontSize   = 22,
+            Foreground = new SolidColorBrush(_fgSub),
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            FontFamily = new FontFamily("Consolas"),
+            Margin     = new Thickness(0, 6, 0, 0),
+        };
+        var date = new TextBlock
+        {
+            FontSize   = 12,
+            Foreground = new SolidColorBrush(_fgMuted),
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            Margin     = new Thickness(0, 8, 0, 0),
+        };
+
+        void Update()
+        {
+            var now    = DateTime.Now;
+            var utcNow = DateTime.UtcNow;
+            localTime.Text = now.ToString("HH:mm:ss");
+            utcTime.Text   = $"UTC  {utcNow:HH:mm:ss}";
+            date.Text      = now.ToString("dddd, dd. MMMM yyyy");
+        }
+        Update();
+
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        timer.Tick += (_, _) => Update();
+        timer.Start();
+        _clockTimers[w.Id] = timer;
+
+        panel.Children.Add(localTime);
+        panel.Children.Add(utcTime);
+        panel.Children.Add(date);
+
+        return new Border { Child = panel };
+    }
+
+    // ── Gauge ────────────────────────────────────────────────────────────────
+
+    private FrameworkElement BuildGaugeContent(DashboardWidget w)
+    {
+        var nodeId = w.NodeIds.FirstOrDefault();
+        var series = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days > 0 ? w.Days : 7);
+        var last   = series.OrderByDescending(p => p.Timestamp).FirstOrDefault();
+        double val = last?.Value ?? double.NaN;
+
+        (double min, double max, string unit) = MetricRange(w.Metric);
+        double pct = double.IsNaN(val)
+            ? 0
+            : Math.Clamp((val - min) / (max - min), 0, 1);
+
+        // Color ramp: red (low) → amber → green (high)
+        Color arcColor = pct < 0.5
+            ? InterpolateColor(Color.FromRgb(240,  76,  76), Color.FromRgb(255, 171,  76), pct * 2)
+            : InterpolateColor(Color.FromRgb(255, 171,  76), Color.FromRgb( 63, 185, 126), (pct - 0.5) * 2);
+
+        string nodeName = nodeId != 0 && _nodeNames.TryGetValue(nodeId, out var nn) ? nn : "–";
+
+        var grid = new Grid { Margin = new Thickness(8, 4, 8, 6) };
+        grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+        // Canvas sized so the full arc fits
+        var canvas = new Canvas
+        {
+            Width  = 200,
+            Height = 140,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            VerticalAlignment   = System.Windows.VerticalAlignment.Center,
+        };
+        Grid.SetRow(canvas, 0);
+
+        // Visual-degrees system: 0° = top, 90° = right, 180° = bottom, 270° = left
+        // Gauge opens at bottom: start at 225° (lower-left), sweep 270° clockwise → end at 135° (lower-right)
+        double cx = 100, cy = 70, r = 56, strokeW = 11;
+        double startVisual = 225, sweep = 270;
+
+        // Track arc (background)
+        canvas.Children.Add(BuildArcPath(cx, cy, r, startVisual, sweep,
+            _isDark ? Color.FromRgb(33, 38, 45) : Color.FromRgb(226, 229, 234),
+            strokeW));
+
+        // Value arc
+        if (pct > 0.002)
+            canvas.Children.Add(BuildArcPath(cx, cy, r, startVisual, sweep * pct,
+                arcColor, strokeW));
+
+        // Center value
+        var valText = new TextBlock
+        {
+            Text       = double.IsNaN(val) ? "–" : $"{val:F1}",
+            FontSize   = 30,
+            FontWeight = System.Windows.FontWeights.Light,
+            Foreground = new SolidColorBrush(_fgMain),
+            Width          = 100,
+            TextAlignment  = TextAlignment.Center,
+        };
+        Canvas.SetLeft(valText, cx - 50);
+        Canvas.SetTop(valText,  cy - 26);
+        canvas.Children.Add(valText);
+
+        var unitText = new TextBlock
+        {
+            Text       = unit,
+            FontSize   = 11,
+            Foreground = new SolidColorBrush(_fgSub),
+            Width          = 60,
+            TextAlignment  = TextAlignment.Center,
+        };
+        Canvas.SetLeft(unitText, cx - 30);
+        Canvas.SetTop(unitText,  cy + 10);
+        canvas.Children.Add(unitText);
+
+        // Min / max labels at arc endpoints
+        var (sx, sy) = VisualPoint(cx, cy, r, startVisual);
+        var (ex, ey) = VisualPoint(cx, cy, r, startVisual + sweep);
+        AddCanvasLabel(canvas, $"{min:G4}", sx - 20, sy + 6,  9, _fgMuted);
+        AddCanvasLabel(canvas, $"{max:G4}", ex - 10, ey + 6,  9, _fgMuted);
+
+        var subPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            Margin = new Thickness(0, 2, 0, 0),
+        };
+        Grid.SetRow(subPanel, 1);
+
+        string ts = last != null ? last.Timestamp.ToLocalTime().ToString("dd.MM HH:mm") : "–";
+
+        subPanel.Children.Add(new TextBlock
+        {
+            Text       = nodeName,
+            FontSize   = 10,
+            Foreground = new SolidColorBrush(arcColor),
+            Margin     = new Thickness(0, 0, 6, 0),
+        });
+        subPanel.Children.Add(new TextBlock
+        {
+            Text       = ts,
+            FontSize   = 10,
+            Foreground = new SolidColorBrush(_fgMuted),
+        });
+
+        grid.Children.Add(canvas);
+        grid.Children.Add(subPanel);
+
+        return new Border { Child = grid, Padding = new Thickness(4, 4, 4, 2) };
+    }
+
+    private static void AddCanvasLabel(Canvas c, string text, double left, double top,
+        double fontSize, Color color)
+    {
+        var tb = new TextBlock
+        {
+            Text       = text,
+            FontSize   = fontSize,
+            Foreground = new SolidColorBrush(color),
+        };
+        Canvas.SetLeft(tb, left);
+        Canvas.SetTop(tb,  top);
+        c.Children.Add(tb);
+    }
+
+    /// <summary>
+    /// Convert visual degrees (0 = top, 90 = right, 180 = bottom, 270 = left) to screen point.
+    /// Accounts for WPF's Y-down coordinate system.
+    /// </summary>
+    private static (double x, double y) VisualPoint(double cx, double cy, double r, double visualDeg)
+    {
+        double mathRad = (90 - visualDeg) * Math.PI / 180.0;
+        return (cx + r * Math.Cos(mathRad), cy - r * Math.Sin(mathRad));
+    }
+
+    private static System.Windows.Shapes.Path BuildArcPath(double cx, double cy, double r,
+        double visualStartDeg, double sweepDeg, Color color, double thickness)
+    {
+        var (x1, y1) = VisualPoint(cx, cy, r, visualStartDeg);
+        var (x2, y2) = VisualPoint(cx, cy, r, visualStartDeg + sweepDeg);
+
+        var geo = new PathGeometry();
+        var figure = new PathFigure { StartPoint = new System.Windows.Point(x1, y1) };
+        figure.Segments.Add(new ArcSegment
+        {
+            Point          = new System.Windows.Point(x2, y2),
+            Size           = new System.Windows.Size(r, r),
+            SweepDirection = SweepDirection.Clockwise,
+            IsLargeArc     = sweepDeg > 180,
+        });
+        geo.Figures.Add(figure);
+
+        return new System.Windows.Shapes.Path
+        {
+            Data               = geo,
+            Stroke             = new SolidColorBrush(color),
+            StrokeThickness    = thickness,
+            StrokeStartLineCap = PenLineCap.Round,
+            StrokeEndLineCap   = PenLineCap.Round,
+        };
+    }
+
+    private static Color InterpolateColor(Color a, Color b, double t)
+    {
+        t = Math.Clamp(t, 0, 1);
+        return Color.FromRgb(
+            (byte)(a.R + (b.R - a.R) * t),
+            (byte)(a.G + (b.G - a.G) * t),
+            (byte)(a.B + (b.B - a.B) * t));
+    }
+
+    // ── Stat card ─────────────────────────────────────────────────────────────
+
+    private FrameworkElement BuildStatContent(DashboardWidget w)
+    {
+        var nodeId = w.NodeIds.FirstOrDefault();
+        (double min, double max, string unit) = MetricRange(w.Metric);
+
+        var pts = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days > 0 ? w.Days : 7)
+                     .OrderByDescending(p => p.Timestamp).ToList();
+
+        double current  = pts.Count > 0 ? pts[0].Value : double.NaN;
+        double previous = pts.Count > 1 ? pts[1].Value : double.NaN;
+        double delta    = !double.IsNaN(current) && !double.IsNaN(previous)
+            ? current - previous : double.NaN;
+
+        string nodeName   = nodeId != 0 && _nodeNames.TryGetValue(nodeId, out var nn) ? nn : "–";
+        Color accentColor = WpfPalette[0];
+
+        var grid = new Grid { Margin = new Thickness(12, 10, 12, 10) };
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+        var chip = new Border
+        {
+            Background      = new SolidColorBrush(Color.FromArgb(40, accentColor.R, accentColor.G, accentColor.B)),
+            BorderBrush     = new SolidColorBrush(Color.FromArgb(80, accentColor.R, accentColor.G, accentColor.B)),
+            BorderThickness = new Thickness(1),
+            CornerRadius    = new CornerRadius(3),
+            Padding         = new Thickness(6, 2, 6, 2),
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Left,
+        };
+        chip.Child = new TextBlock
+        {
+            Text       = w.Metric.ToUpperInvariant(),
+            FontSize   = 9,
+            Foreground = new SolidColorBrush(accentColor),
+            FontWeight = System.Windows.FontWeights.SemiBold,
+        };
+        Grid.SetRow(chip, 0);
+
+        var bigVal = new TextBlock
+        {
+            Text = double.IsNaN(current) ? "–" : $"{current:F1}",
+            FontSize   = 48,
+            FontWeight = System.Windows.FontWeights.Light,
+            Foreground = new SolidColorBrush(_fgMain),
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            VerticalAlignment   = System.Windows.VerticalAlignment.Center,
+        };
+        Grid.SetRow(bigVal, 1);
+
+        var unitText = new TextBlock
+        {
+            Text       = unit,
+            FontSize   = 14,
+            Foreground = new SolidColorBrush(_fgSub),
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+            Margin     = new Thickness(0, 0, 0, 4),
+        };
+        Grid.SetRow(unitText, 2);
+
+        var footer = new DockPanel { Margin = new Thickness(0, 4, 0, 0) };
+        Grid.SetRow(footer, 3);
+
+        var nodeLabel = new TextBlock
+        {
+            Text       = nodeName,
+            FontSize   = 10,
+            Foreground = new SolidColorBrush(_fgMuted),
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+        };
+        DockPanel.SetDock(nodeLabel, Dock.Left);
+
+        if (!double.IsNaN(delta))
+        {
+            bool up = delta >= 0;
+            var deltaText = new TextBlock
+            {
+                Text       = $"{(up ? "↑" : "↓")} {Math.Abs(delta):F2}",
+                FontSize   = 11,
+                Foreground = new SolidColorBrush(up
+                    ? Color.FromRgb(63, 185, 126)
+                    : Color.FromRgb(240,  76,  76)),
+                VerticalAlignment   = System.Windows.VerticalAlignment.Center,
+                HorizontalAlignment = System.Windows.HorizontalAlignment.Right,
+            };
+            DockPanel.SetDock(deltaText, Dock.Right);
+            footer.Children.Add(deltaText);
+        }
+        footer.Children.Add(nodeLabel);
+
+        grid.Children.Add(chip);
+        grid.Children.Add(bigVal);
+        grid.Children.Add(unitText);
+        grid.Children.Add(footer);
+
+        return new Border { Child = grid };
+    }
+
+    // ── Line chart ───────────────────────────────────────────────────────────
+
+    private PlotModel BuildLineModel(DashboardWidget w)
+    {
+        (double min, double max, string unit) = MetricRange(w.Metric);
+        var model = MakeBaseModel();
+        AddTimeAxis(model);
+        AddLinearAxis(model, min, max, unit);
+
+        int ci = 0;
+        foreach (var nodeId in w.NodeIds)
+        {
+            var pts = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days);
+            if (pts.Count == 0) continue;
+            var line = new LineSeries
+            {
+                Title               = NodeLabel(nodeId),
+                Color               = Palette[ci % Palette.Length],
+                StrokeThickness     = 1.8,
+                MarkerType          = MarkerType.None,
+                TrackerFormatString = "{0}\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
+            };
+            foreach (var p in pts.OrderBy(x => x.Timestamp))
+                line.Points.Add(new DataPoint(DateTimeAxis.ToDouble(p.Timestamp), p.Value));
+            model.Series.Add(line);
+            ci++;
+        }
+        return model;
+    }
+
+    // ── Area chart ────────────────────────────────────────────────────────────
+
+    private PlotModel BuildAreaModel(DashboardWidget w)
+    {
+        (double min, double max, string unit) = MetricRange(w.Metric);
+        var model = MakeBaseModel();
+        AddTimeAxis(model);
+        AddLinearAxis(model, min, max, unit);
+
+        int ci = 0;
+        foreach (var nodeId in w.NodeIds)
+        {
+            var pts = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days);
+            if (pts.Count == 0) continue;
+            var oxy    = Palette[ci % Palette.Length];
+            var series = new AreaSeries
+            {
+                Title           = NodeLabel(nodeId),
+                Color           = oxy,
+                Fill            = OxyColor.FromAColor(30, oxy),
+                StrokeThickness = 1.5,
+                MarkerType      = MarkerType.None,
+                TrackerFormatString = "{0}\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
+            };
+            foreach (var p in pts.OrderBy(x => x.Timestamp))
+                series.Points.Add(new DataPoint(DateTimeAxis.ToDouble(p.Timestamp), p.Value));
+            model.Series.Add(series);
+            ci++;
+        }
+        return model;
+    }
+
+    // ── Bar chart ─────────────────────────────────────────────────────────────
+
+    private PlotModel BuildBarModel(DashboardWidget w)
+    {
+        (double min, double max, string unit) = MetricRange(w.Metric);
+        var model = MakeBaseModel();
+
+        var categoryAxis = new CategoryAxis
+        {
+            Position           = AxisPosition.Left,
+            TextColor          = _oxyText,
+            TicklineColor      = _oxyTick,
+            MajorGridlineStyle = LineStyle.None,
+            Minimum            = -0.5,
+        };
+        model.Axes.Add(categoryAxis);
+
+        double baseVal = Math.Min(0, min);
+        model.Axes.Add(new LinearAxis
+        {
+            Position           = AxisPosition.Bottom,
+            Minimum            = baseVal, Maximum = max,
+            Title              = unit,
+            MajorGridlineStyle = LineStyle.Dot,
+            MajorGridlineColor = _oxyGrid,
+            TextColor          = _oxyText,
+            TicklineColor      = _oxyTick,
+            TitleColor         = _oxyText,
+        });
+
+        int ci = 0;
+        foreach (var nodeId in w.NodeIds)
+        {
+            var pts = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days);
+            double val  = pts.Count > 0
+                ? pts.OrderByDescending(p => p.Timestamp).First().Value
+                : double.NaN;
+            string name = NodeLabel(nodeId);
+            categoryAxis.Labels.Add(name.Length > 14 ? name[..14] : name);
+
+            var barSeries = new BarSeries
+            {
+                FillColor           = Palette[ci % Palette.Length],
+                StrokeColor         = OxyColors.Transparent,
+                StrokeThickness     = 0,
+                BaseValue           = baseVal,
+                TrackerFormatString = name + ": {2:F2} " + unit,
+                BarWidth            = 0.6,
+            };
+            barSeries.Items.Add(new BarItem(double.IsNaN(val) ? baseVal : val, ci));
+            model.Series.Add(barSeries);
+            ci++;
+        }
+
+        categoryAxis.Maximum = Math.Max(0.5, ci - 0.5);
+        return model;
+    }
+
+    // ── Heatmap ────────────────────────────────────────────────────────────────
+
+    private PlotModel BuildHeatmapModel(DashboardWidget w)
+    {
+        var nodeId = w.NodeIds.FirstOrDefault();
+        int days   = w.Days > 0 ? w.Days : 14;
+        var data   = _db.GetHeatmapData(nodeId, w.Metric, days);
+
+        (double min, double max, string unit) = MetricRange(w.Metric);
+
+        // For packet_count we want 0-based scale, not min-1 fill
+        bool isCount = w.Metric == "packet_count";
+        var clean = new double[days, 24];
+        for (int d = 0; d < days; d++)
+            for (int h = 0; h < 24; h++)
+                clean[d, h] = isCount
+                    ? data[d, h]
+                    : (double.IsNaN(data[d, h]) ? min - 1 : data[d, h]);
+
+        // Auto-scale packet_count based on actual max
+        double colorMin = isCount ? 0 : min;
+        double colorMax = isCount
+            ? Math.Max(1, Enumerable.Range(0, days)
+                .SelectMany(d => Enumerable.Range(0, 24).Select(h => data[d, h]))
+                .DefaultIfEmpty(1).Max())
+            : max;
+
+        var model = MakeBaseModel();
+        model.Legends.Clear();
+
+        model.Axes.Add(new LinearAxis
+        {
+            Position  = AxisPosition.Left,
+            Title     = Loc("StrDashboardHourOfDay"),
+            Minimum   = -0.5, Maximum = 23.5,
+            MajorStep = 6,
+            TextColor = _oxyText, TitleColor = _oxyText,
+        });
+        model.Axes.Add(new LinearAxis
+        {
+            Position   = AxisPosition.Bottom,
+            Title      = Loc("StrDashboardDayIndex"),
+            TextColor  = _oxyText, TitleColor = _oxyText,
+        });
+        model.Axes.Add(new LinearColorAxis
+        {
+            Position   = AxisPosition.Right,
+            Minimum    = colorMin, Maximum = colorMax,
+            Palette    = OxyPalettes.Viridis(64),
+            Title      = unit,
+            TextColor  = _oxyText, TitleColor = _oxyText,
+        });
+
+        model.Series.Add(new HeatMapSeries
+        {
+            Data = clean, X0 = 0, X1 = days - 1, Y0 = 0, Y1 = 23, Interpolate = false,
+        });
+        return model;
+    }
+
+    // ── Scatter chart ─────────────────────────────────────────────────────────
+
+    private PlotModel BuildScatterModel(DashboardWidget w)
+    {
+        (double min, double max, string unit) = MetricRange(w.Metric);
+        var model = MakeBaseModel();
+        AddTimeAxis(model);
+        AddLinearAxis(model, min, max, unit);
+
+        int ci = 0;
+        foreach (var nodeId in w.NodeIds)
+        {
+            var pts = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days);
+            if (pts.Count == 0) continue;
+            var oxy    = Palette[ci % Palette.Length];
+            var series = new ScatterSeries
+            {
+                Title                  = NodeLabel(nodeId),
+                MarkerType             = MarkerType.Circle,
+                MarkerSize             = 3,
+                MarkerFill             = oxy,
+                MarkerStroke           = OxyColor.FromAColor(100, oxy),
+                MarkerStrokeThickness  = 0.5,
+                TrackerFormatString    = "{0}\n{2:dd.MM HH:mm}\n{4:F2} " + unit,
+            };
+            foreach (var p in pts.OrderBy(x => x.Timestamp))
+                series.Points.Add(new ScatterPoint(DateTimeAxis.ToDouble(p.Timestamp), p.Value));
+            model.Series.Add(series);
+            ci++;
+        }
+        return model;
+    }
+
+    // ── Histogram ─────────────────────────────────────────────────────────────
+
+    private PlotModel BuildHistogramModel(DashboardWidget w)
+    {
+        (double min, double max, string unit) = MetricRange(w.Metric);
+        var nodeId = w.NodeIds.FirstOrDefault();
+        var pts    = _db.GetTimeSeries(new[] { nodeId }, w.Metric, w.Days);
+
+        const int buckets = 20;
+        double range = Math.Max(max - min, 1e-6);
+        double bw    = range / buckets;
+        int[] counts = new int[buckets];
+
+        foreach (var p in pts)
+        {
+            int b = (int)Math.Floor((Math.Clamp(p.Value, min, max - 1e-9) - min) / bw);
+            b = Math.Clamp(b, 0, buckets - 1);
+            counts[b]++;
+        }
+
+        var model = MakeBaseModel();
+        model.Legends.Clear();
+
+        model.Axes.Add(new LinearAxis
+        {
+            Position           = AxisPosition.Bottom,
+            Title              = unit,
+            Minimum            = min, Maximum = max,
+            TextColor          = _oxyText,
+            TicklineColor      = _oxyTick,
+            TitleColor         = _oxyText,
+            MajorGridlineStyle = LineStyle.Dot,
+            MajorGridlineColor = _oxyGrid,
+        });
+        model.Axes.Add(new LinearAxis
+        {
+            Position           = AxisPosition.Left,
+            Title              = Loc("StrDashboardCount"),
+            Minimum            = 0,
+            TextColor          = _oxyText,
+            TicklineColor      = _oxyTick,
+            TitleColor         = _oxyText,
+            MajorGridlineStyle = LineStyle.Dot,
+            MajorGridlineColor = _oxyGrid,
+        });
+
+        var series = new RectangleBarSeries
+        {
+            FillColor       = OxyColor.FromAColor(200, Palette[0]),
+            StrokeColor     = OxyColor.FromAColor(230, Palette[0]),
+            StrokeThickness = 1,
+        };
+        for (int i = 0; i < buckets; i++)
+        {
+            double x0 = min + i * bw;
+            double x1 = min + (i + 1) * bw;
+            series.Items.Add(new RectangleBarItem(x0, 0, x1, counts[i]));
+        }
+        model.Series.Add(series);
+        return model;
+    }
+
+    // ── Candlestick (daily OHLC) ──────────────────────────────────────────────
+
+    private PlotModel BuildCandlestickModel(DashboardWidget w)
+    {
+        (double min, double max, string unit) = MetricRange(w.Metric);
+        var nodeId  = w.NodeIds.FirstOrDefault();
+        var candles = _db.GetCandlestickData(nodeId, w.Metric, w.Days);
+
+        var model = MakeBaseModel();
+        model.Legends.Clear();
+        AddTimeAxis(model);
+        AddLinearAxis(model, min, max, unit);
+
+        if (candles.Count == 0) return model;
+
+        var series = new CandleStickSeries
+        {
+            IncreasingColor = OxyColor.FromRgb( 63, 185, 126),
+            DecreasingColor = OxyColor.FromRgb(240,  76,  76),
+            CandleWidth     = 0.6,
+            StrokeThickness = 1.5,
+        };
+        foreach (var c in candles)
+            series.Items.Add(new HighLowItem(
+                DateTimeAxis.ToDouble(c.Time), c.High, c.Low, c.Open, c.Close));
+
+        model.Series.Add(series);
+        return model;
+    }
+
+    // ── State timeline (node activity per hour) ───────────────────────────────
+
+    private PlotModel BuildStatelineModel(DashboardWidget w)
+    {
+        var nodeId = w.NodeIds.FirstOrDefault();
+        int days   = w.Days > 0 ? w.Days : 14;
+        var data   = _db.GetNodeActivityGrid(nodeId, days);
+
+        var model = MakeBaseModel();
+        model.Legends.Clear();
+
+        model.Axes.Add(new LinearAxis
+        {
+            Position   = AxisPosition.Left,
+            Title      = Loc("StrDashboardHourOfDay"),
+            Minimum    = -0.5, Maximum = 23.5,
+            MajorStep  = 6,
+            TextColor  = _oxyText, TitleColor = _oxyText,
+        });
+        model.Axes.Add(new LinearAxis
+        {
+            Position   = AxisPosition.Bottom,
+            Title      = Loc("StrDashboardDayIndex"),
+            TextColor  = _oxyText, TitleColor = _oxyText,
+        });
+        model.Axes.Add(new LinearColorAxis
+        {
+            Position = AxisPosition.None,
+            Minimum  = 0, Maximum = 1,
+            Palette  = OxyPalette.Interpolate(2,
+                _isDark ? OxyColor.FromRgb(33, 38, 45) : OxyColor.FromRgb(230, 232, 236),
+                OxyColor.FromRgb(63, 185, 126)),
+        });
+
+        model.Series.Add(new HeatMapSeries
+        {
+            Data = data, X0 = 0, X1 = days - 1, Y0 = 0, Y1 = 23, Interpolate = false,
+        });
+        return model;
+    }
+
+    // ── OxyPlot helpers ───────────────────────────────────────────────────────
+
+    private PlotModel MakeBaseModel()
+    {
+        var model = new PlotModel
+        {
+            Background              = OxyColor.FromArgb(0, 0, 0, 0),
+            PlotAreaBorderColor     = _oxyTick,
+            PlotAreaBorderThickness = new OxyThickness(1),
+            TextColor               = _oxyText,
+        };
+        model.Legends.Add(new Legend
+        {
+            LegendPosition        = LegendPosition.TopLeft,
+            LegendBackground      = _oxyLegendBg,
+            LegendBorder          = OxyColor.FromAColor(80, _oxyTick),
+            LegendBorderThickness = 1,
+            LegendTextColor       = OxyColor.FromRgb(_fgMain.R, _fgMain.G, _fgMain.B),
+            LegendFontSize        = 10,
+        });
+        return model;
+    }
+
+    private void AddTimeAxis(PlotModel model)
+    {
+        model.Axes.Add(new DateTimeAxis
+        {
+            Position           = AxisPosition.Bottom,
+            StringFormat       = "dd.MM HH:mm",
+            MajorGridlineStyle = LineStyle.Dot,
+            MajorGridlineColor = _oxyGrid,
+            TextColor          = _oxyText,
+            TicklineColor      = _oxyTick,
+        });
+    }
+
+    private void AddLinearAxis(PlotModel model, double min, double max, string unit)
+    {
+        model.Axes.Add(new LinearAxis
+        {
+            Position           = AxisPosition.Left,
+            Minimum            = min, Maximum = max,
+            Title              = unit,
+            MajorGridlineStyle = LineStyle.Dot,
+            MajorGridlineColor = _oxyGrid,
+            TextColor          = _oxyText,
+            TicklineColor      = _oxyTick,
+            TitleColor         = _oxyText,
+        });
+    }
+
+    // ── Edit / Remove widget ──────────────────────────────────────────────────
+
+    private void EditWidget_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn || btn.Tag is not DashboardWidget w) return;
+        if (_current == null) return;
+
+        var dlg = new AddWidgetDialog(_nodeNames, existing: w) { Owner = this };
+        if (dlg.ShowDialog() != true) return;
+
+        // Preserve ID and size from the original
+        var updated = dlg.Result! with { Id = w.Id, Width = w.Width, Height = w.Height };
+
+        var idx = _store.Dashboards.IndexOf(_current);
+        var widgetIdx = _current.Widgets.FindIndex(x => x.Id == w.Id);
+        if (widgetIdx < 0 || idx < 0) return;
+
+        var newWidgets = new List<DashboardWidget>(_current.Widgets);
+        newWidgets[widgetIdx] = updated;
+        _current = _current with { Widgets = newWidgets };
+        _store.Dashboards[idx] = _current;
+        SaveStore();
+        RenderCurrentDashboard();
+    }
+
+    private void RemoveWidget_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn || btn.Tag is not DashboardWidget w) return;
+        if (_current == null) return;
+        var idx = _store.Dashboards.IndexOf(_current);
+        if (idx < 0) return;
+
+        if (_clockTimers.TryGetValue(w.Id, out var ct)) { ct.Stop(); _clockTimers.Remove(w.Id); }
+
+        var newWidgets = new List<DashboardWidget>(_current.Widgets);
+        newWidgets.RemoveAll(x => x.Id == w.Id);
+        _current = _current with { Widgets = newWidgets };
+        _store.Dashboards[idx] = _current;
+        SaveStore();
+
+        var toRemove = WidgetPanel.Children.OfType<Grid>()
+            .FirstOrDefault(g => g.Tag is DashboardWidget tw && tw.Id == w.Id);
+        if (toRemove != null) WidgetPanel.Children.Remove(toRemove);
+        UpdateStatus();
+
+        if (_current.Widgets.Count == 0)
+            EmptyState.Visibility = Visibility.Visible;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private string NodeLabel(uint nodeId) =>
+        _nodeNames.TryGetValue(nodeId, out var n) ? n : $"!{nodeId:x8}";
+
+    private static (double min, double max, string unit) MetricRange(string metric) =>
+        metric switch
+        {
+            "snr"          => (-20.0,   20.0,  "dB"),
+            "rssi"         => (-130.0, -20.0,  "dBm"),
+            "battery"      => (0.0,    100.0,  "%"),
+            "voltage"      => (2.5,      5.0,  "V"),
+            "channel_util" => (0.0,    100.0,  "%"),
+            "air_tx_util"  => (0.0,    100.0,  "%"),
+            "temperature"  => (-20.0,   60.0,  "°C"),
+            "humidity"     => (0.0,    100.0,  "%"),
+            "pressure"     => (950.0, 1050.0,  "hPa"),
+            "packet_count" => (0.0,   100.0,   "Pakete/h"),
+            _              => (0.0,    100.0,  ""),
+        };
+
+    private string? PromptString(string title, string prompt, string defaultValue = "")
+    {
+        var dlg = new Window
+        {
+            Title  = title,
+            Width  = 380, Height = 165,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            ResizeMode = ResizeMode.NoResize,
+            Background = new SolidColorBrush(_bgCard),
+        };
+        if (Application.Current.MainWindow is Window mw) dlg.Owner = mw;
+
+        var stack = new StackPanel { Margin = new Thickness(16) };
+        stack.Children.Add(new TextBlock
+        {
+            Text = prompt,
+            Foreground = new SolidColorBrush(_fgSub),
+            Margin = new Thickness(0, 0, 0, 8),
+        });
+        var box = new TextBox { Text = defaultValue };
+        stack.Children.Add(box);
+        var btnRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Right,
+            Margin = new Thickness(0, 12, 0, 0),
+        };
+        var ok     = new Button { Content = "OK", Width = 70, IsDefault = true, Margin = new Thickness(0, 0, 8, 0) };
+        var cancel = new Button { Content = Loc("StrCancel"), Width = 90, IsCancel = true };
+        ok.Click += (_, _) => { dlg.DialogResult = true; dlg.Close(); };
+        btnRow.Children.Add(ok);
+        btnRow.Children.Add(cancel);
+        stack.Children.Add(btnRow);
+        dlg.Content = stack;
+        box.Focus();
+        box.SelectAll();
+
+        return dlg.ShowDialog() == true && !string.IsNullOrWhiteSpace(box.Text)
+            ? box.Text.Trim()
+            : null;
+    }
+}
+
+internal static class VisualTreeHelperExt
+{
+    public static T? FindVisualChild<T>(this DependencyObject parent) where T : DependencyObject
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T t) return t;
+            var result = FindVisualChild<T>(child);
+            if (result != null) return result;
+        }
+        return null;
+    }
+}

--- a/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
@@ -61,6 +61,7 @@ public partial class TelemetryDashboardWindow : Window
     private readonly Color _bgCard, _bgPage, _bgHeader, _borderCol;
     private readonly Color _fgMain, _fgSub, _fgMuted;
     private readonly OxyColor _oxyText, _oxyTick, _oxyGrid, _oxyLegendBg;
+    private readonly Color[] _uiPalette;  // theme-adjusted accent colors for text/UI (not charts)
 
     // ── Fields ────────────────────────────────────────────────────────────────
     private readonly TelemetryDatabaseService _db;
@@ -116,6 +117,19 @@ public partial class TelemetryDashboardWindow : Window
             _fgSub     = Color.FromRgb( 90,  99, 110);
             _fgMuted   = Color.FromRgb(160, 166, 174);
         }
+
+        // Lighter accent colors for dark mode so text is readable on dark backgrounds
+        _uiPalette = _isDark ? new[]
+        {
+            Color.FromRgb( 88, 166, 255),   // blue  (#58A6FF)
+            Color.FromRgb( 87, 201, 150),   // green
+            Color.FromRgb(255, 199, 103),   // amber
+            Color.FromRgb(248, 107, 107),   // red
+            Color.FromRgb(183, 148, 255),   // purple
+            Color.FromRgb( 51, 225, 235),   // cyan
+            Color.FromRgb(255, 157, 120),   // orange
+            Color.FromRgb(128, 196, 255),   // light blue
+        } : WpfPalette;
 
         _oxyText     = OxyColor.FromRgb(_fgSub.R, _fgSub.G, _fgSub.B);
         _oxyTick     = OxyColor.FromRgb(_borderCol.R, _borderCol.G, _borderCol.B);
@@ -579,27 +593,34 @@ public partial class TelemetryDashboardWindow : Window
         ctxMenu.Items.Add(exportItem);
         container.ContextMenu = ctxMenu;
 
-        // Drop target for reordering — with visual highlight feedback
-        container.AllowDrop = true;
-        container.DragEnter += (_, e) =>
+        // Drop target for reordering — on card so drag events fire over all card content
+        card.AllowDrop = true;
+        card.DragEnter += (_, e) =>
         {
             if (!e.Data.GetDataPresent("widget_id")) return;
             string srcId = (string)e.Data.GetData("widget_id")!;
-            if (srcId != w.Id) card.BorderBrush = new SolidColorBrush(Color.FromRgb(31, 111, 235));
+            if (srcId != w.Id) card.BorderBrush = new SolidColorBrush(_uiPalette[0]);
             e.Effects = DragDropEffects.Move;
+            e.Handled = true;
         };
-        container.DragLeave += (_, _) =>
-            card.BorderBrush = new SolidColorBrush(_borderCol);
-        container.DragOver += (_, e) =>
+        card.DragLeave += (_, e) =>
+        {
+            // Only reset when cursor truly leaves the card bounds (not just crossing child boundaries)
+            var pos = e.GetPosition(card);
+            if (pos.X < 0 || pos.Y < 0 || pos.X > card.ActualWidth || pos.Y > card.ActualHeight)
+                card.BorderBrush = new SolidColorBrush(_borderCol);
+        };
+        card.DragOver += (_, e) =>
         {
             if (e.Data.GetDataPresent("widget_id")) { e.Effects = DragDropEffects.Move; e.Handled = true; }
         };
-        container.Drop += (_, e) =>
+        card.Drop += (_, e) =>
         {
             card.BorderBrush = new SolidColorBrush(_borderCol);
             if (!e.Data.GetDataPresent("widget_id")) return;
             string srcId = (string)e.Data.GetData("widget_id")!;
             if (srcId != w.Id) ReorderWidgets(srcId, w.Id);
+            e.Handled = true;
         };
 
         // Resize grip — 30x30 hit area with visual in bottom-right
@@ -1025,7 +1046,7 @@ public partial class TelemetryDashboardWindow : Window
             ? current - previous : double.NaN;
 
         string nodeName   = nodeId != 0 && _nodeNames.TryGetValue(nodeId, out var nn) ? nn : "–";
-        Color accentColor = WpfPalette[0];
+        Color accentColor = _uiPalette[0];
 
         var grid = new Grid { Margin = new Thickness(12, 10, 12, 10) };
         grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
@@ -1709,7 +1730,7 @@ public partial class TelemetryDashboardWindow : Window
                 Padding    = new Thickness(5, 1, 5, 1),
                 FontSize   = 10,
                 Tag        = (w.Id, days),
-                Foreground = new SolidColorBrush(active ? WpfPalette[0] : _fgSub),
+                Foreground = new SolidColorBrush(active ? _uiPalette[0] : _fgSub),
                 FontWeight = active ? System.Windows.FontWeights.SemiBold
                                     : System.Windows.FontWeights.Normal,
             };
@@ -1737,7 +1758,7 @@ public partial class TelemetryDashboardWindow : Window
             FontSize   = 10,
             ToolTip    = Loc("StrDashboardMovingAvg"),
             Tag        = w.Id,
-            Foreground = new SolidColorBrush(w.ShowMovingAverage ? WpfPalette[0] : _fgSub),
+            Foreground = new SolidColorBrush(w.ShowMovingAverage ? _uiPalette[0] : _fgSub),
             FontWeight = w.ShowMovingAverage ? System.Windows.FontWeights.SemiBold
                                              : System.Windows.FontWeights.Normal,
         };
@@ -1908,8 +1929,8 @@ public partial class TelemetryDashboardWindow : Window
             for (int i = 0; i < rows.Count; i++)
             {
                 var (id, val) = rows[i];
-                Color rowColor = i == 0 ? WpfPalette[1]
-                               : i == 1 ? WpfPalette[2]
+                Color rowColor = i == 0 ? _uiPalette[1]
+                               : i == 1 ? _uiPalette[2]
                                : _fgMain;
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
                 int row = i + 1;
@@ -1970,7 +1991,7 @@ public partial class TelemetryDashboardWindow : Window
             double max = values.Count > 0 ? values.Max() : double.NaN;
             double avg = values.Count > 0 ? values.Average() : double.NaN;
 
-            Color accent = WpfPalette[ci % WpfPalette.Length];
+            Color accent = _uiPalette[ci % _uiPalette.Length];
             string name  = NodeLabel(id);
 
             var tile = new Border

--- a/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryDashboardWindow.xaml.cs
@@ -228,20 +228,27 @@ public partial class TelemetryDashboardWindow : Window
         {
             if (FileExists(StoreFile))
                 _store = JsonSerializer.Deserialize<DashboardStore>(
-                    ReadAllText(StoreFile)) ?? new();
+                    ReadAllText(StoreFile), _jsonOptions) ?? new();
         }
         catch { _store = new(); }
     }
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented    = true,
+        NumberHandling   = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals,
+    };
 
     private void SaveStore()
     {
         try
         {
-            WriteAllText(StoreFile,
-                JsonSerializer.Serialize(_store,
-                    new JsonSerializerOptions { WriteIndented = true }));
+            WriteAllText(StoreFile, JsonSerializer.Serialize(_store, _jsonOptions));
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Services.Logger.WriteLine($"[Dashboard] SaveStore failed: {ex.Message}");
+        }
     }
 
     // ── Combo management ─────────────────────────────────────────────────────

--- a/MeshhessenClient/TelemetryWindow.xaml
+++ b/MeshhessenClient/TelemetryWindow.xaml
@@ -378,8 +378,12 @@
             </Grid.ColumnDefinitions>
             <TextBlock x:Name="FooterInfoText" Grid.Column="0"
                        VerticalAlignment="Center" FontSize="11" Opacity="0.5"/>
-            <Button Grid.Column="1" Content="{DynamicResource StrTelOpenPlot}"
-                    Padding="12,6" Click="OpenPlotWindow_Click"/>
+            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <Button Content="{DynamicResource StrTelOpenDashboard}"
+                        Padding="12,6" Margin="0,0,8,0" Click="OpenDashboard_Click"/>
+                <Button Content="{DynamicResource StrTelOpenPlot}"
+                        Padding="12,6" Click="OpenPlotWindow_Click"/>
+            </StackPanel>
         </Grid>
     </Grid>
 </Window>

--- a/MeshhessenClient/TelemetryWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryWindow.xaml.cs
@@ -222,7 +222,7 @@ public partial class TelemetryWindow : Window
 
     private void OpenDashboard_Click(object sender, RoutedEventArgs e)
     {
-        var win = new TelemetryDashboardWindow(_db, _nodeNames) { Owner = this };
+        var win = new TelemetryDashboardWindow(_db, _nodeNames);
         win.Show();
     }
 

--- a/MeshhessenClient/TelemetryWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryWindow.xaml.cs
@@ -213,17 +213,16 @@ public partial class TelemetryWindow : Window
 
     private void OpenPlotWindow_Click(object sender, RoutedEventArgs e)
     {
-        var win = new PlotWindow(_db, _nodeNames, preselectedNodeId: _node.NodeId)
-        {
-            Owner = this
-        };
+        var win = new PlotWindow(_db, _nodeNames, preselectedNodeId: _node.NodeId) { Owner = this };
         win.Show();
+        win.Activate();
     }
 
     private void OpenDashboard_Click(object sender, RoutedEventArgs e)
     {
         var win = new TelemetryDashboardWindow(_db, _nodeNames);
         win.Show();
+        win.Activate();
     }
 
     private static void SetLed(Ellipse led, LedState state, string tooltip)

--- a/MeshhessenClient/TelemetryWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryWindow.xaml.cs
@@ -220,6 +220,12 @@ public partial class TelemetryWindow : Window
         win.Show();
     }
 
+    private void OpenDashboard_Click(object sender, RoutedEventArgs e)
+    {
+        var win = new TelemetryDashboardWindow(_db, _nodeNames) { Owner = this };
+        win.Show();
+    }
+
     private static void SetLed(Ellipse led, LedState state, string tooltip)
     {
         led.Fill = state switch

--- a/MeshhessenClient/TelemetryWindow.xaml.cs
+++ b/MeshhessenClient/TelemetryWindow.xaml.cs
@@ -194,9 +194,10 @@ public partial class TelemetryWindow : Window
             // ── Routing: Pfad-Analyse ──
             var (hopCost, hopSamples) = _db.GetHopCost(_node.NodeId, _days > 0 ? _days : _longDays);
             float routeChangeRate     = _db.GetRouteChangeRate(_node.NodeId, _days > 0 ? _days : _longDays);
+            int tracerouteRows        = _db.CountTracerouteRows(_node.NodeId, _days > 0 ? _days : _longDays);
             HopCostText.Text          = hopSamples > 0 ? $"{hopCost:0.00}" : "–";
             RouteChangeRateText.Text  = hopSamples > 0 ? $"{routeChangeRate:0.00}/h" : "–";
-            TracerouteCountText.Text  = hopSamples > 0 ? hopSamples.ToString() : "–";
+            TracerouteCountText.Text  = tracerouteRows > 0 ? tracerouteRows.ToString() : "–";
 
             // ── Neighbors ──
             var trends = _db.GetNeighborSnrTrends(_node.NodeId, _shortHours, _longDays, _nodeNames)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 
 ![Windows](https://img.shields.io/badge/Windows-10%2F11-blue)
 ![.NET](https://img.shields.io/badge/.NET-8.0-purple)
-![Status](https://img.shields.io/badge/Status-v1.5.9-yellow)
+![Status](https://img.shields.io/badge/Status-v1.5.10-yellow)
 ![License](https://img.shields.io/github/license/SMLunchen/mh_windowsclient)
 ![Stars](https://img.shields.io/github/stars/SMLunchen/mh_windowsclient)
 
-> **English summary:** Free Windows app for Meshtastic devices – offline map (OSM/OpenTopo), telemetry, traceroute, PKI decryption, full device configuration, USB/Serial/TCP/BLE support. No installation, no cloud. By the Meshhessen community (Hesse, Germany). [→ English version below](#meshhessen-client--windows-client-for-meshtastic-devices-wpf--net-8)
+> **English summary:** Free Windows app for Meshtastic devices – offline map (OSM/OpenTopo), telemetry, traceroute, PKI decryption, full device configuration, USB/Serial/TCP/BLE support, remote admin, favorites & telemetry dashboard. No installation, no cloud. By the Meshhessen community (Hesse, Germany). [→ English version below](#meshhessen-client--windows-client-for-meshtastic-devices-wpf--net-8)
 
 
 ## 🚀 Schnellstart
@@ -57,6 +57,10 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 ### 📊 Telemetrie & Statistik
 
 * **Persistente Telemetrie-Datenbank** – empfangene Paket- und Gerätedaten werden lokal in einer SQLite-Datenbank gespeichert
+* **Telemetrie-Dashboard** – frei konfigurierbares Widget-Dashboard mit benannten Dashboards:
+  * Vier Widget-Typen: Zeitverlauf (Linienchart), Balkendiagramm (aktueller Vergleich), Gauge (Einzelwert), Heatmap (Stunde × Tag)
+  * Multi-Node-Support, alle Metriken: SNR, RSSI, Batterie, Spannung, Kanal-/TX-Auslastung, Temperatur, Luftfeuchtigkeit, Luftdruck
+  * Persistenz in `dashboards.json`, dunkles OxyPlot-Theme
 * **Node-Statistik-Fenster** – detaillierte Auswertung pro Node:
   * Tag/Nacht-Auswertung der Empfangsqualität
   * Zeitreihen-Graphen für SNR, RSSI, Paketrate und Gerätedaten (Batterie, Spannung)
@@ -107,6 +111,8 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 * **Node-Farben** – Nodes individuell einfärben (Karte + Listen)
 * **Node-Notizen** – Freitext-Notizen pro Node
 * **Nodes anpinnen** – Nodes in der Liste oben fixieren (unabhängig von Sortierung)
+* **Favoriten** – Nodes als Favoriten markieren (★-Symbol, Rechtsklick-Menü); wird mit dem Gerät synchronisiert (`add_favorite_node` / `remove_favorite_node`); Favoriten erscheinen oben in der Liste
+* **Fernverwaltung** – vollständige Remote-Admin-Oberfläche für Favoriten-Nodes: alle Konfigurations-Reiter (Besitzer, Gerät, Position, LoRa, Bluetooth, Netzwerk, Anzeige, Kanäle, Steuerung), Session-Schlüssel-Handshake, konfigurierbarer Timeout
 * **Node-Konfiguration** – vollständige Gerätekonfiguration direkt aus dem Client, alle Module auf einer Seite:
   * **Gerät & LoRa:** Region, Modem-Preset, TX-Power, Hop-Limit, Geräterolle, Rebroadcast-Modus
   * **Position:** GPS-Modus, Smart-Broadcast, feste Position mit Koordinaten-Eingabe; „Von Karte wählen" öffnet ein eigenes Kartenfenster (honoriert Offline-/Online-Einstellungen); „Eigener Kartenpin" übernimmt die per Rechtsklick gesetzte Position
@@ -338,7 +344,7 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 
  ![Windows](https://img.shields.io/badge/Windows-10%2F11-blue)
  ![.NET](https://img.shields.io/badge/.NET-8.0-purple)
- ![Status](https://img.shields.io/badge/Status-v1.5.9-yellow)
+ ![Status](https://img.shields.io/badge/Status-v1.5.10-yellow)
  ![License](https://img.shields.io/github/license/SMLunchen/mh_windowsclient)
  ![Stars](https://img.shields.io/github/stars/SMLunchen/mh_windowsclient)
 
@@ -389,6 +395,10 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 ### 📊 Telemetry & Statistics
 
 * **Persistent telemetry database** – received packet and device data is stored locally in a SQLite database
+* **Telemetry Dashboard** – freely configurable widget dashboard with named dashboards:
+  * Four widget types: line chart (time series), bar chart (current comparison), gauge (single value), heatmap (hour × day)
+  * Multi-node support, all metrics: SNR, RSSI, battery, voltage, channel/TX utilization, temperature, humidity, pressure
+  * Persisted in `dashboards.json`, dark OxyPlot theme
 * **Node statistics window** – detailed analysis per node:
   * Day/night breakdown of reception quality
   * Time-series graphs for SNR, RSSI, packet rate and device data (battery, voltage)
@@ -439,6 +449,8 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 * **Node colors** – color-code nodes individually (map + lists)
 * **Node notes** – free-text annotations per node
 * **Pin nodes** – pin nodes to the top of the list (independent of sorting)
+* **Favorites** – mark nodes as favorites (★ icon, right-click menu); synced with the device (`add_favorite_node` / `remove_favorite_node`); favorites shown at the top of the list
+* **Remote Administration** – full remote admin UI for favorite nodes: all configuration tabs (Owner, Device, Position, LoRa, Bluetooth, Network, Display, Channels, Control), session-key handshake, configurable timeout
 * **Node configuration** – full device configuration directly from the client, all modules in one window:
   * **Device & LoRa:** region, modem preset, TX power, hop limit, device role, rebroadcast mode
   * **Position:** GPS mode, smart broadcast, fixed position with coordinate input; "Pick from Map" opens a dedicated map picker window (respects offline/online settings); "Own Map Pin" copies the position set via right-click

--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 ### 📊 Telemetrie & Statistik
 
 * **Persistente Telemetrie-Datenbank** – empfangene Paket- und Gerätedaten werden lokal in einer SQLite-Datenbank gespeichert
-* **Telemetrie-Dashboard** – frei konfigurierbares Widget-Dashboard mit benannten Dashboards:
-  * Vier Widget-Typen: Zeitverlauf (Linienchart), Balkendiagramm (aktueller Vergleich), Gauge (Einzelwert), Heatmap (Stunde × Tag)
-  * Multi-Node-Support, alle Metriken: SNR, RSSI, Batterie, Spannung, Kanal-/TX-Auslastung, Temperatur, Luftfeuchtigkeit, Luftdruck
-  * Persistenz in `dashboards.json`, dunkles OxyPlot-Theme
+* **Telemetrie-Dashboard** – frei konfigurierbares Widget-Dashboard mit benannten Dashboards (📊-Button in der Toolbar):
+  * **11 Widget-Typen:** Linie, Fläche, Balken, Scatter, Gauge, Stat-Wert, Heatmap, Histogramm, Candlestick, State-Timeline, Uhrzeit
+  * Multi-Node-Support, alle Metriken: SNR, RSSI, Batterie, Spannung, Kanal-/TX-Auslastung, Temperatur, Luftfeuchtigkeit, Luftdruck, Pakete/h
+  * Widgets per Drag-and-Drop anordnen, frei skalierbar (Resize-Griff), editierbar, Auto-Refresh
+  * Dark & Light Mode, Theme-adaptiv (OxyPlot + WPF)
+  * Persistenz in `dashboards.json`
+  * **Unabhängiges Fenster** – kann auf einem zweiten Monitor platziert werden
 * **Node-Statistik-Fenster** – detaillierte Auswertung pro Node:
   * Tag/Nacht-Auswertung der Empfangsqualität
   * Zeitreihen-Graphen für SNR, RSSI, Paketrate und Gerätedaten (Batterie, Spannung)
@@ -112,7 +115,11 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 * **Node-Notizen** – Freitext-Notizen pro Node
 * **Nodes anpinnen** – Nodes in der Liste oben fixieren (unabhängig von Sortierung)
 * **Favoriten** – Nodes als Favoriten markieren (★-Symbol, Rechtsklick-Menü); wird mit dem Gerät synchronisiert (`add_favorite_node` / `remove_favorite_node`); Favoriten erscheinen oben in der Liste
-* **Fernverwaltung** – vollständige Remote-Admin-Oberfläche für Favoriten-Nodes: alle Konfigurations-Reiter (Besitzer, Gerät, Position, LoRa, Bluetooth, Netzwerk, Anzeige, Kanäle, Steuerung), Session-Schlüssel-Handshake, konfigurierbarer Timeout
+* **Fernverwaltung** – vollständige Remote-Admin-Oberfläche für Favoriten-Nodes:
+  * Alle Konfigurations-Reiter: Besitzer, Gerät, Position, LoRa, Bluetooth, Netzwerk, Anzeige, Kanäle, **Sicherheit**, Steuerung
+  * **Sicherheits-Reiter:** Public Key (read-only), Admin-Schlüssel 1–3 (Base64), Flags (Admin Channel, Managed Mode, Serial, Debug Log)
+  * **Favoriten remote verwalten:** Knoten auf dem Remote-Gerät als Favorit setzen oder entfernen
+  * Session-Schlüssel-Handshake, konfigurierbarer Timeout, per-Channel Retry + Neu-laden
 * **Node-Konfiguration** – vollständige Gerätekonfiguration direkt aus dem Client, alle Module auf einer Seite:
   * **Gerät & LoRa:** Region, Modem-Preset, TX-Power, Hop-Limit, Geräterolle, Rebroadcast-Modus
   * **Position:** GPS-Modus, Smart-Broadcast, feste Position mit Koordinaten-Eingabe; „Von Karte wählen" öffnet ein eigenes Kartenfenster (honoriert Offline-/Online-Einstellungen); „Eigener Kartenpin" übernimmt die per Rechtsklick gesetzte Position

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 
 ![Windows](https://img.shields.io/badge/Windows-10%2F11-blue)
 ![.NET](https://img.shields.io/badge/.NET-8.0-purple)
-![Status](https://img.shields.io/badge/Status-v1.5.10-yellow)
+![Status](https://img.shields.io/badge/Status-v1.5.11-yellow)
 ![License](https://img.shields.io/github/license/SMLunchen/mh_windowsclient)
 ![Stars](https://img.shields.io/github/stars/SMLunchen/mh_windowsclient)
 
@@ -138,12 +138,13 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 * **Node-Farben** – Nodes individuell einfärben (Karte + Listen)
 * **Node-Notizen** – Freitext-Notizen pro Node
 * **Nodes anpinnen** – Nodes in der Liste oben fixieren (unabhängig von Sortierung)
-* **Favoriten** – Nodes als Favoriten markieren (★-Symbol, Rechtsklick-Menü); wird mit dem Gerät synchronisiert (`add_favorite_node` / `remove_favorite_node`); Favoriten erscheinen oben in der Liste
+* **Favoriten** – Nodes als Favoriten markieren (★-Symbol, Rechtsklick-Menü); wird mit dem Gerät synchronisiert (`set_favorite_node` / `remove_favorite_node`); Favoriten erscheinen oben in der Liste
 * **Fernverwaltung** – vollständige Remote-Admin-Oberfläche für Favoriten-Nodes:
   * Alle Konfigurations-Reiter: Besitzer, Gerät, Position, LoRa, Bluetooth, Netzwerk, Anzeige, Kanäle, **Sicherheit**, Steuerung
-  * **Sicherheits-Reiter:** Public Key (read-only), Admin-Schlüssel 1–3 (Base64), Flags (Admin Channel, Managed Mode, Serial, Debug Log)
+  * **Sicherheits-Reiter:** Public Key (read-only, Base64), Admin-Schlüssel 1–3 (Base64), Flags (Admin Channel, Managed Mode, Serial, Debug Log)
   * **Favoriten remote verwalten:** Knoten auf dem Remote-Gerät als Favorit setzen oder entfernen
   * Session-Schlüssel-Handshake, konfigurierbarer Timeout, per-Channel Retry + Neu-laden
+  * **Lazy Loading:** Beim Öffnen wählen ob alles sofort oder seitenweise geladen wird; „↻ Tab neu laden"-Button für gezielten Reload einzelner Reiter
 * **Node-Konfiguration** – vollständige Gerätekonfiguration direkt aus dem Client, alle Module auf einer Seite:
   * **Gerät & LoRa:** Region, Modem-Preset, TX-Power, Hop-Limit, Geräterolle, Rebroadcast-Modus
   * **Position:** GPS-Modus, Smart-Broadcast, feste Position mit Koordinaten-Eingabe; „Von Karte wählen" öffnet ein eigenes Kartenfenster (honoriert Offline-/Online-Einstellungen); „Eigener Kartenpin" übernimmt die per Rechtsklick gesetzte Position
@@ -241,6 +242,7 @@ Routing-Statistik (Hop-Anzahl, Pfad-Stabilität, Pfadwechsel-Rate):
 * ~~Keine persistente Message-History~~ → jetzt optional via Nachrichten-Datenbank (aktivierbar in Einstellungen)
 * Getestet mit Firmware 2.x
 * T-Deck: Channels werden nicht immer in der Config-Sequenz mitgesendet (Retry-Workaround aktiv) – Das T-Deck ist fast schon mit sich selbst überfordert, daher dauert dort alles etwas länger…
+* ~~Heltec-Boards brechen lokale Konfiguration nach 4–5/17 Configs ab~~ → behoben durch sequentielles Laden (senden → warten → nächste)
 
 
 ## 🗺️ Karte einrichten
@@ -375,7 +377,7 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 
  ![Windows](https://img.shields.io/badge/Windows-10%2F11-blue)
  ![.NET](https://img.shields.io/badge/.NET-8.0-purple)
- ![Status](https://img.shields.io/badge/Status-v1.5.10-yellow)
+ ![Status](https://img.shields.io/badge/Status-v1.5.11-yellow)
  ![License](https://img.shields.io/github/license/SMLunchen/mh_windowsclient)
  ![Stars](https://img.shields.io/github/stars/SMLunchen/mh_windowsclient)
 
@@ -489,8 +491,8 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 * **Node colors** – color-code nodes individually (map + lists)
 * **Node notes** – free-text annotations per node
 * **Pin nodes** – pin nodes to the top of the list (independent of sorting)
-* **Favorites** – mark nodes as favorites (★ icon, right-click menu); synced with the device (`add_favorite_node` / `remove_favorite_node`); favorites shown at the top of the list
-* **Remote Administration** – full remote admin UI for favorite nodes: all configuration tabs (Owner, Device, Position, LoRa, Bluetooth, Network, Display, Channels, Control), session-key handshake, configurable timeout
+* **Favorites** – mark nodes as favorites (★ icon, right-click menu); synced with the device (`set_favorite_node` / `remove_favorite_node`); favorites shown at the top of the list
+* **Remote Administration** – full remote admin UI for favorite nodes: all configuration tabs (Owner, Device, Position, LoRa, Bluetooth, Network, Display, Channels, Security, Control), session-key handshake, configurable timeout, lazy loading (load-on-demand per tab) and "↻ Reload Tab" button
 * **Node configuration** – full device configuration directly from the client, all modules in one window:
   * **Device & LoRa:** region, modem preset, TX power, hop limit, device role, rebroadcast mode
   * **Position:** GPS mode, smart broadcast, fixed position with coordinate input; "Pick from Map" opens a dedicated map picker window (respects offline/online settings); "Own Map Pin" copies the position set via right-click
@@ -531,6 +533,7 @@ The Meshhessen Client is a community project of the Meshtastic community in Hess
 * ~~No persistent message history~~ → now available as optional message database (enable in settings)
 * Tested with firmware 2.x
 * T-Deck: channels are not always included in the config sequence (retry workaround active) – The T-Deck is barely keeping up with itself, so everything takes a bit longer there…
+* ~~Heltec boards abort local configuration after 4–5/17 configs~~ → fixed by sequential loading (send → wait for response → send next)
 
 
 ## 🗺️ Setting Up the Offline Map

--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 * **Deduplizierung** – nur neueste Traceroute pro Node-Paar anzeigen (optional)
 * **Karten-Legende** – zeigt alle aktiven Traces mit Farbe und ✕-Button zum Entfernen
 
+### 🔧 T-Deck Karten-Assistent (Tools-Tab)
+
+* **SD-Karte vorbereiten** – geführter 6-Schritt-Assistent zum Bespielen einer SD-Karte mit Offline-Karten für das Meshtastic T-Deck
+* **Schritt 1 – Willkommen:** Erklärt den Workflow; Hinweis: nur Deutschland verfügbar
+* **Schritt 2 – Laufwerk:** Zeigt alle Wechseldatenträger mit Größe, freiem Speicher und Dateisystem
+* **Schritt 3 – Formatierung:**
+  * Empfiehlt **exFAT mit 4096-Byte-Zuordnungseinheiten** (T-Deck-optimal; kleine Tiles ≈100 Bytes → kleine AU spart erheblich Speicher)
+  * Formatierung per UAC-elevated PowerShell direkt aus dem Client; zwei Bestätigungsdialoge
+* **Schritt 4 – Bereich:** Nach Bundesland (Checkboxen), ganz Deutschland, oder **Freestyle** (eigenes Rechteck auf interaktiver Mapsui-Karte zeichnen)
+* **Schritt 5 – Zoom & Kartentyp:** Zoom 8–17, Warnhinweise bei hohen Stufen; OSM / OSM Dark / OpenTopoMap
+* **Schritt 6 – Transfer:** Additiv – SD-Tile vorhanden → skip; lokal vorhanden → kopieren; sonst → vom Tile-Server laden + lokal cachen
+* **SD-Verzeichnisstruktur:** `{Laufwerk}:\maps\OSM\{z}\{x}\{y}.png` (T-Deck-kompatibel, Langklick auf Faltkartenicon schaltet zwischen Kartendiensten um)
+* **ZIP-Export** – lokale Tiles als ZIP exportieren (nach Kartentyp filterbar)
+* Vollständig mehrsprachig (Deutsch/Englisch)
+
 ### 🔧 Node-Verwaltung
 
 * **Knoten-Übersicht** – alle Nodes im Mesh mit SNR, Batterie, Entfernung, Hop-Anzahl

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 ![License](https://img.shields.io/github/license/SMLunchen/mh_windowsclient)
 ![Stars](https://img.shields.io/github/stars/SMLunchen/mh_windowsclient)
 
-> **English summary:** Free Windows app for Meshtastic devices – offline map (OSM/OpenTopo), telemetry, traceroute, PKI decryption, full device configuration, USB/Serial/TCP/BLE support, remote admin, favorites & telemetry dashboard. No installation, no cloud. By the Meshhessen community (Hesse, Germany). [→ English version below](#meshhessen-client--windows-client-for-meshtastic-devices-wpf--net-8)
+> **English summary:** Free Windows app for Meshtastic devices – offline map (OSM/OpenTopo), telemetry, traceroute, PKI decryption, full device configuration, USB/Serial/TCP/BLE support, remote admin, favorites, telemetry dashboard & **Virtual Node TCP proxy**. No installation, no cloud. By the Meshhessen community (Hesse, Germany). [→ English version below](#meshhessen-client--windows-client-for-meshtastic-devices-wpf--net-8)
 
 
 ## 🚀 Schnellstart
@@ -105,6 +105,15 @@ Der **Meshhessen Client** ist ein **kostenloser, nativer Windows-Client für Mes
 * **Zeitreihenfilter** – Traceroutes nach Zeitraum filtern (3d / 7d / 14d / 30d / 90d / Alle)
 * **Deduplizierung** – nur neueste Traceroute pro Node-Paar anzeigen (optional)
 * **Karten-Legende** – zeigt alle aktiven Traces mit Farbe und ✕-Button zum Entfernen
+
+### 🖧 Virtual Node (Tools-Tab)
+
+* **TCP-Proxy-Server** – verbinde Meshtastic-Apps (Android/iOS) direkt mit dem Meshhessen Client, als wäre er ein echtes Meshtastic-Gerät
+* **Konfigurierbar im Tools-Tab:** Port (Standard: 4404), ein-/ausschalten, Admin-Befehle blockieren
+* **Automatischer Start** sobald eine Verbindung mit dem physischen Node besteht (wenn aktiviert)
+* **Config-Replay:** verbindende Apps erhalten sofort alle Kanäle, Node-Liste und Gerätekonfig
+* **Bidirektionale Sichtbarkeit:** Nachrichten aus der App erscheinen in verbundenen Apps – und umgekehrt
+* **Multi-Client:** mehrere Apps gleichzeitig verbindbar; Status und verbundene IPs werden im Tools-Tab angezeigt
 
 ### 🔧 T-Deck Karten-Assistent (Tools-Tab)
 
@@ -462,6 +471,15 @@ Meshhessen Client · Windows-Client für Meshtastic-Geräte · Meshtastic Window
 * **Time range filter** – filter traceroutes by period (3d / 7d / 14d / 30d / 90d / All)
 * **Deduplication** – show only the latest traceroute per node pair (optional)
 * **Map legend** – shows all active traces with color and individual ✕ remove button
+
+### 🖧 Virtual Node (Tools Tab)
+
+* **TCP proxy server** – connect Meshtastic apps (Android/iOS) to the Meshhessen Client as if it were a real Meshtastic device
+* **Configurable in the Tools tab:** port (default: 4404), enable/disable, optionally block admin commands
+* **Auto-start** as soon as a connection to the physical node is established (when enabled)
+* **Config replay:** connecting apps receive all channels, node list and device config immediately
+* **Bidirectional visibility:** messages sent in the app appear in connected apps – and vice versa
+* **Multi-client:** multiple apps can connect simultaneously; status and connected IPs are shown in the Tools tab
 
 ### 🔧 Node Management
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -172,10 +172,59 @@
 <div class="section active" id="de">
 <main>
 
-  <!-- ── v1.5.9 ── -->
+  <!-- ── v1.5.10 ── -->
   <div class="version-entry current">
     <div class="version-header">
-      <span class="version-tag tag-latest">v1.5.9</span>
+      <span class="version-tag tag-latest">v1.5.10</span>
+      <span class="version-date">2026-04-23</span>
+      Favoriten, Fernverwaltung &amp; Telemetrie-Dashboard
+    </div>
+    <p class="version-desc">Nodes als Favoriten markieren (sync mit Gerät), vollständige Remote-Admin-Oberfläche für entfernte Knoten, konfigurierbarer Timeout, neues Dashboard für Telemetriedaten mit vier Widget-Typen.</p>
+
+    <div class="cl-section added">
+      <h3>✨ Hinzugefügt</h3>
+
+      <div class="cl-group">
+        <div class="cl-group-title">Favoriten</div>
+        <ul class="cl-list">
+          <li><strong>Stern-Symbol</strong> in der Node-Liste; per Rechtsklick als Favorit markieren/entfernen</li>
+          <li>Sync mit dem Gerät via <code>add_favorite_node</code> / <code>remove_favorite_node</code> Admin-Nachrichten</li>
+          <li>Favoriten werden in der Liste oben angezeigt (vor gepinnten Nodes)</li>
+          <li>Persistenz in <code>meshhessen-client.ini</code></li>
+        </ul>
+      </div>
+
+      <div class="cl-group">
+        <div class="cl-group-title">Fernverwaltung (Remote Admin)</div>
+        <ul class="cl-list">
+          <li>Schaltfläche „Fernverwaltung" im Node-Konfigurations-Bereich (nur sichtbar bei verbundenem Gerät)</li>
+          <li>Node-Auswahl aus der Favoritenliste; Session-Schlüssel-Handshake vor dem Laden</li>
+          <li>Vollständiges Admin-Fenster: Reiter Besitzer, Gerät, Position, LoRa, Bluetooth, Netzwerk, Anzeige, Kanäle, Steuerung</li>
+          <li>Feste GPS-Koordinaten via separatem <code>set_position</code>-Befehl</li>
+          <li>Ferngesteuerter Neustart, Herunterfahren, Node-DB-Reset</li>
+          <li>Favoriten-Status direkt im Remote-Admin-Fenster umschalten</li>
+          <li>Konfigurierbarer Anfrage-Timeout (Standard 30 s, einstellbar in Einstellungen)</li>
+        </ul>
+      </div>
+
+      <div class="cl-group">
+        <div class="cl-group-title">Telemetrie-Dashboard</div>
+        <ul class="cl-list">
+          <li>Neuer „Dashboard öffnen"-Button im Telemetrie-Fenster</li>
+          <li>Benannte Dashboards erstellen, umbenennen und löschen; Persistenz in <code>dashboards.json</code></li>
+          <li>Vier Widget-Typen: <strong>Zeitverlauf</strong> (OxyPlot-Linienchart, Mehrfach-Node), <strong>Balkendiagramm</strong> (aktueller Vergleich), <strong>Gauge</strong> (Einzelwert + Fortschrittsbalken), <strong>Heatmap</strong> (Stunde × Tag)</li>
+          <li>Neue Metriken: Temperatur, Luftfeuchtigkeit, Luftdruck aus Umgebungs-Telemetrie</li>
+          <li>Voreingestellte Achsen-Bereiche: SNR −20…+20 dB, RSSI −130…−20 dBm, Batterie 0…100 %, Temperatur −20…60 °C</li>
+          <li>Dunkles OxyPlot-Theme passend zum App-Design</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── v1.5.9 ── -->
+  <div class="version-entry old">
+    <div class="version-header">
+      <span class="version-tag">v1.5.9</span>
       <span class="version-date">2026-04-21</span>
       Vollständige Node-Konfiguration, Kartenauswahl &amp; Map-Report
     </div>
@@ -601,10 +650,59 @@
 <div class="section" id="en">
 <main>
 
-  <!-- ── v1.5.9 ── -->
+  <!-- ── v1.5.10 ── -->
   <div class="version-entry current">
     <div class="version-header">
-      <span class="version-tag tag-latest">v1.5.9</span>
+      <span class="version-tag tag-latest">v1.5.10</span>
+      <span class="version-date">2026-04-23</span>
+      Favorites, Remote Admin &amp; Telemetry Dashboard
+    </div>
+    <p class="version-desc">Mark nodes as favorites (synced with device), full remote admin UI for remote nodes, configurable timeout, new telemetry dashboard with four widget types.</p>
+
+    <div class="cl-section added">
+      <h3>✨ Added</h3>
+
+      <div class="cl-group">
+        <div class="cl-group-title">Favorites</div>
+        <ul class="cl-list">
+          <li><strong>Star icon</strong> in the node list; right-click to mark/unmark as favorite</li>
+          <li>Synced with device via <code>add_favorite_node</code> / <code>remove_favorite_node</code> admin messages</li>
+          <li>Favorites shown at the top of the node list (above pinned nodes)</li>
+          <li>Persisted in <code>meshhessen-client.ini</code></li>
+        </ul>
+      </div>
+
+      <div class="cl-group">
+        <div class="cl-group-title">Remote Administration</div>
+        <ul class="cl-list">
+          <li>"Remote Admin" button in the node configuration section (enabled when connected)</li>
+          <li>Node selector from favorites list; session-key handshake before loading</li>
+          <li>Full admin window: tabs for Owner, Device, Position, LoRa, Bluetooth, Network, Display, Channels, Control</li>
+          <li>Fixed GPS coordinates sent via separate <code>set_position</code> command</li>
+          <li>Remote reboot, shutdown, node DB reset</li>
+          <li>Toggle favorite status directly from the remote admin window</li>
+          <li>Configurable request timeout (default 30 s, adjustable in settings)</li>
+        </ul>
+      </div>
+
+      <div class="cl-group">
+        <div class="cl-group-title">Telemetry Dashboard</div>
+        <ul class="cl-list">
+          <li>New "Open Dashboard" button in the Telemetry window</li>
+          <li>Create, rename and delete named dashboards; persisted in <code>dashboards.json</code></li>
+          <li>Four widget types: <strong>Line chart</strong> (OxyPlot, multi-node), <strong>Bar chart</strong> (current comparison), <strong>Gauge</strong> (single value + progress bar), <strong>Heatmap</strong> (hour × day)</li>
+          <li>New metrics: temperature, humidity, pressure from environment telemetry</li>
+          <li>Pre-configured axis ranges: SNR −20…+20 dB, RSSI −130…−20 dBm, Battery 0…100 %, Temperature −20…60 °C</li>
+          <li>Dark OxyPlot theme matching the app design</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── v1.5.9 ── -->
+  <div class="version-entry old">
+    <div class="version-header">
+      <span class="version-tag">v1.5.9</span>
       <span class="version-date">2026-04-21</span>
       Full Node Configuration, Map Picker &amp; Map Report
     </div>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -172,6 +172,35 @@
 <div class="section active" id="de">
 <main>
 
+  <!-- ── upcoming ── -->
+  <div class="version-entry upcoming">
+    <div class="version-header">
+      <span class="version-tag tag-upcoming">Upcoming</span>
+      <span class="version-date">2026-05-10</span>
+      T-Deck Karten-Assistent &amp; Tools-Tab
+    </div>
+    <p class="version-desc">Neuer Tools-Reiter mit geführtem 6-Schritt-Assistenten zum Bespielen einer SD-Karte mit Offline-Karten für das Meshtastic T-Deck. Formatierung (exFAT/FAT32 mit UAC), Bereichsauswahl, Download und ZIP-Export.</p>
+
+    <div class="cl-section added">
+      <h3>✨ Hinzugefügt</h3>
+
+      <div class="cl-group">
+        <div class="cl-group-title">🔧 T-Deck Karten-Assistent (neuer Tools-Tab)</div>
+        <ul class="cl-list">
+          <li><strong>Schritt 1 – Willkommen:</strong> Erklärung des Workflows; Hinweis: nur Deutschland verfügbar</li>
+          <li><strong>Schritt 2 – SD-Karte:</strong> Listet Wechseldatenträger mit Größe, freiem Speicher und Dateisystem</li>
+          <li><strong>Schritt 3 – Formatierung:</strong> Empfiehlt exFAT mit 4096-Byte-Zuordnungseinheiten (Tiles ≈ 100 Bytes → kleine AU spart Speicher); UAC-elevated <code>Format-Volume</code>; zwei Bestätigungsdialoge</li>
+          <li><strong>Schritt 4 – Bereich:</strong> Nach Bundesland (16 Checkboxen), ganz Deutschland, oder Freestyle (Rechteck auf Mapsui-Karte zeichnen)</li>
+          <li><strong>Schritt 5 – Zoom &amp; Kartentyp:</strong> Stufen 8/10/12/14/16/17 mit Laufzeitwarnungen; OSM / OSM Dark / OpenTopoMap</li>
+          <li><strong>Schritt 6 – Transfer (additiv):</strong> SD-Tile vorhanden → skip; lokal vorhanden → kopieren; sonst → vom Tile-Server laden + lokal cachen; Fortschrittsbalken</li>
+          <li><strong>SD-Struktur:</strong> <code>{Laufwerk}:\maps\OSM\{z}\{x}\{y}.png</code> (OpenTopo, OSMDark analog) – T-Deck-kompatibel</li>
+          <li><strong>ZIP-Export:</strong> Lokale Tiles (alle oder gefiltert nach Kartentyp) als ZIP exportieren</li>
+          <li>Vollständig mehrsprachig (Deutsch/Englisch)</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
   <!-- ── v1.5.10 ── -->
   <div class="version-entry current">
     <div class="version-header">
@@ -649,6 +678,35 @@
 <!-- ════════════════════ ENGLISH ════════════════════ -->
 <div class="section" id="en">
 <main>
+
+  <!-- ── upcoming ── -->
+  <div class="version-entry upcoming">
+    <div class="version-header">
+      <span class="version-tag tag-upcoming">Upcoming</span>
+      <span class="version-date">2026-05-10</span>
+      T-Deck Map Assistant &amp; Tools Tab
+    </div>
+    <p class="version-desc">New Tools tab with a guided 6-step wizard for preparing an SD card with offline maps for the Meshtastic T-Deck. Formatting (exFAT/FAT32 with UAC), region selection, download, and ZIP export.</p>
+
+    <div class="cl-section added">
+      <h3>✨ Added</h3>
+
+      <div class="cl-group">
+        <div class="cl-group-title">🔧 T-Deck Map Assistant (new Tools tab)</div>
+        <ul class="cl-list">
+          <li><strong>Step 1 – Welcome:</strong> Workflow explanation; note: Germany only</li>
+          <li><strong>Step 2 – SD card:</strong> Lists removable drives with size, free space and filesystem</li>
+          <li><strong>Step 3 – Formatting:</strong> Recommends exFAT with 4096-byte allocation units (tiles ≈ 100 bytes → small AU saves significant space); UAC-elevated <code>Format-Volume</code>; two confirmation dialogs</li>
+          <li><strong>Step 4 – Region:</strong> By federal state (16 checkboxes), all of Germany, or Freestyle (draw rectangle on Mapsui map)</li>
+          <li><strong>Step 5 – Zoom &amp; map type:</strong> Levels 8/10/12/14/16/17 with runtime warnings; OSM / OSM Dark / OpenTopoMap</li>
+          <li><strong>Step 6 – Transfer (additive):</strong> SD tile present → skip; local tile present → copy; otherwise → download from tile server + cache locally; progress bar</li>
+          <li><strong>SD structure:</strong> <code>{Drive}:\maps\OSM\{z}\{x}\{y}.png</code> (OpenTopo, OSMDark analogously) – T-Deck compatible</li>
+          <li><strong>ZIP export:</strong> Export local tiles (all or filtered by map type) as ZIP</li>
+          <li>Fully multilingual (German/English)</li>
+        </ul>
+      </div>
+    </div>
+  </div>
 
   <!-- ── v1.5.10 ── -->
   <div class="version-entry current">

--- a/docs/index.html
+++ b/docs/index.html
@@ -312,8 +312,8 @@
 <main>
 
   <div class="whats-new">
-    <span class="vbadge">v1.5.9</span>
-    <span class="summary">Feste Position via Karte, Kanal-Uplink/Downlink, Kanalverwaltung-Fix und mehr.</span>
+    <span class="vbadge">NEU</span>
+    <span class="summary">🔧 T-Deck Karten-Assistent – SD-Karte mit Offline-Karten vorbereiten: Formatierung (exFAT, 4096 Bytes), Bereichsauswahl (Bundesland / DE / Freestyle), Zoom bis 17, additiver Download.</span>
     <a href="changelog.html">Changelog ansehen →</a>
   </div>
 
@@ -340,6 +340,19 @@
         <li><strong>Online OSM</strong> (weltweit, Policy-konform)</li>
         <li>Node-Pins, GPS-Tracks, Wegpunkte</li>
         <li>HTTP/3, ETag-Cache, tile.meshhessenclient.de</li>
+      </ul>
+    </div>
+    <div class="card" style="--card-accent:#e3b341">
+      <span class="badge-new">NEU</span>
+      <h3>🔧 T-Deck Karten-Assistent</h3>
+      <ul>
+        <li><strong>Geführter Wizard</strong> zum Bespielen einer SD-Karte</li>
+        <li>Formatierung: <strong>exFAT 4096 Bytes</strong> (empfohlen, spart Platz)</li>
+        <li>Bereich: Bundesland, ganz Deutschland, Freestyle-Zeichnen</li>
+        <li>Zoom bis 17, Kartentyp OSM/Dark/Topo</li>
+        <li>Additiv: vorhandene Tiles kopieren, fehlende laden</li>
+        <li>SD-Struktur: <code>maps/OSM/{z}/{x}/{y}.png</code></li>
+        <li>ZIP-Export lokaler Tiles</li>
       </ul>
     </div>
     <div class="card" style="--card-accent:#bc8cff">


### PR DESCRIPTION
# New Features:
## Virtual Node	TCP proxy server (Tools-Tab) 
- turns the client into a Meshtastic-compatible TCP server for Android/iOS/other clients; bidirectional message relay, Config-Replay, multi-client, message queue

## T-Deck Wizard
- 6-step SD-card preparation wizard (Tools-Tab): 
 - drive selection, exFAT format (UAC-elevated), region/Bundesland/freestyle area picker, zoom+tiletype, additive download+copy

## Dashboard
- Independent window (survives TelemetryWindow close); 11 widget types; 📊 toolbar button for direct access

## Remote Admin	
- Full remote config window: Owner, Device, Position, LoRa, Bluetooth, Network, Display, Channels, Security (Public Key + Admin Keys in Base64, flags), Control + Favorites management

## Local Admin 
– Sequential Loading fixes Heltec/slow-board abort at 4–5/17

## Channel Filter Sync
- Selecting a channel in "Kanal filtern" automatically switches the send-channel dropdown to the same channel ("Alle" leaves send channel unchanged)


# Bugfixes:
- Emoji node names on map Segoe UI Emoji font for all four LabelStyle instances → no more □ glyphs
- Key display now in Base64